### PR TITLE
fix circular dependency

### DIFF
--- a/ring/letters/models/default_question_model.py
+++ b/ring/letters/models/default_question_model.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 
 from sqlalchemy import ForeignKey, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ring.api_identifier.api_identified_model import APIIdentified
 from ring.created_at import CreatedAtMixin
-from ring.parties.models.group_model import Group
 from ring.sqlalchemy_base import Base
+
+if TYPE_CHECKING:
+    from ring.parties.models.group_model import Group
 
 
 class DefaultQuestion(Base, APIIdentified, CreatedAtMixin):

--- a/ring/parties/models/group_model.py
+++ b/ring/parties/models/group_model.py
@@ -15,9 +15,9 @@ from ring.ring_pydantic.linked_schemas import GroupLinked
 from ring.ring_pydantic.pydantic_model import PydanticModel
 from ring.sqlalchemy_base import Base
 from ring.tasks.models.schedule_model import Schedule
+from ring.letters.models.default_question_model import DefaultQuestion
 
 if TYPE_CHECKING:
-    from ring.letters.models.default_question_model import DefaultQuestion
     from ring.parties.models.user_model import User
 
 


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"dev","parentHead":"","trunk":"dev"}
```
-->
