### PR TITLE
pass rm opt to compose_exec for test runs

### DIFF
--- a/dev_util/compose.py
+++ b/dev_util/compose.py
@@ -50,7 +50,6 @@ def compose_run(
             *args: list[Any],
             **kwargs: dict[Any, Any],
         ) -> list[str]:
-            profile = kwargs.pop("profile")
             cmd_string = f(ctx, *args, **kwargs)
             return compose_starter(profile) + cmd_string + ctx.args  # type: ignore
 
@@ -65,6 +64,7 @@ def compose_exec(
     service: str | None = None,
     directory: str | None = None,
     cmd: str = "exec",
+    opts: list[str] | None = None,
     **kwargs: Any,
 ) -> Callable[[Callable[..., list[str]]], click.Command]:
     def decorator(f: Callable[..., list[str]]) -> click.Command:
@@ -89,9 +89,12 @@ def compose_exec(
             *args: Any,
             **kwargs: Any,
         ) -> list[str]:
+            nonlocal opts
+            if opts is None:
+                opts = []
             cmd_string = f(ctx, *args, **kwargs)
             working_dir = f"/src/{directory}" if directory else "/src"
-            return [cmd, "-w", working_dir] + [service] + cmd_string
+            return [cmd, "-w", working_dir] + opts + [service] + cmd_string
 
         return inner
 

--- a/dev_util/compose.py
+++ b/dev_util/compose.py
@@ -50,6 +50,7 @@ def compose_run(
             *args: list[Any],
             **kwargs: dict[Any, Any],
         ) -> list[str]:
+            profile = kwargs.pop("profile")
             cmd_string = f(ctx, *args, **kwargs)
             return compose_starter(profile) + cmd_string + ctx.args  # type: ignore
 

--- a/dev_util/test.py
+++ b/dev_util/test.py
@@ -36,7 +36,14 @@ def image(
     ]
 
 
-@compose_exec("run", test, service="test-runner", profile="test", cmd="run")
+@compose_exec(
+    "run",
+    test,
+    service="test-runner",
+    profile="test",
+    cmd="run",
+    opts=["--rm"],
+)
 def run(
     ctx: click.Context,
     *args: list[Any],
@@ -49,7 +56,14 @@ def run(
     ]
 
 
-@compose_exec("server", test, service="test-runner", profile="test", cmd="run")
+@compose_exec(
+    "server",
+    test,
+    service="test-runner",
+    profile="test",
+    cmd="run",
+    opts=["--rm"],
+)
 def server(
     ctx: click.Context,
     *args: list[Any],


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"dev","parentHead":"","trunk":"dev"}
```
-->
