### PR TITLE
use dependencies for scripts instead of decorator injection

### DIFF
--- a/ring/scripts/dependencies.py
+++ b/ring/scripts/dependencies.py
@@ -1,0 +1,55 @@
+"""Script dependency injection utilities for Ring.
+
+This module provides dependency injection utilities for Ring scripts, similar to
+FastAPI's dependency injection system but designed for standalone script execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, TypeVar
+
+from ring.sqlalchemy_base import Session, get_db
+
+T = TypeVar("T")
+
+
+@dataclass
+class ScriptDependencies:
+    """Base class for script dependencies.
+
+    This class provides the basic dependencies needed for any script,
+    such as database sessions.
+
+    Attributes:
+        db (Session): SQLAlchemy database session
+    """
+
+    db: Session
+
+
+def get_script_dependencies() -> ScriptDependencies:
+    """Get dependencies for script execution.
+
+    This function provides a database session for script execution.
+
+    Returns:
+        ScriptDependencies: Basic script dependencies
+    """
+    db = next(get_db())
+    return ScriptDependencies(db=db)
+
+
+def script_depends(dependency: Callable[..., Any]) -> Any:
+    """Create a dependency for script functions.
+
+    This decorator works similarly to FastAPI's Depends but for standalone scripts.
+    It ensures proper setup and cleanup of resources.
+
+    Args:
+        dependency (Callable[..., Any]): The dependency function to call
+
+    Returns:
+        Any: The result of calling the dependency function
+    """
+    return dependency()

--- a/ring/scripts/list_users.py
+++ b/ring/scripts/list_users.py
@@ -9,19 +9,27 @@ from sqlalchemy import select
 
 from ring.lib.logger import logger
 from ring.parties.models.user_model import User
-from ring.scripts.script_base import script_di
-from ring.sqlalchemy_base import Session
+from ring.scripts.dependencies import (
+    ScriptDependencies,
+    get_script_dependencies,
+    script_depends,
+)
 
 
-@script_di()
-def run_script(db: Session) -> None:
+def run_script(
+    deps: ScriptDependencies = script_depends(get_script_dependencies),
+) -> list[User]:
     """List all users in the database.
 
     Executes a simple query to retrieve all users and prints them to stdout.
     Uses SQLAlchemy's select statement for efficient querying.
 
     Args:
-        db (Session): Database session provided by script_di
+        deps (ScriptDependencies): Script dependencies provided by script_depends
+
+    Returns:
+        list[User]: List of all users in the database
     """
-    users = db.scalars(select(User)).all()
+    users = deps.db.scalars(select(User)).all()
     logger.info(users)
+    return users

--- a/ring/scripts/migration/create_users.py
+++ b/ring/scripts/migration/create_users.py
@@ -1,3 +1,5 @@
+"""Script to create users and groups from a JSON configuration file."""
+
 from __future__ import annotations
 
 import json
@@ -8,12 +10,24 @@ from typing import Any
 from ring.parties.crud import group as group_crud
 from ring.parties.crud import user as user_crud
 from ring.parties.models.group_model import Group
-from ring.scripts.script_base import script_di
-from ring.sqlalchemy_base import Session
+from ring.scripts.dependencies import (
+    ScriptDependencies,
+    get_script_dependencies,
+    script_depends,
+)
 
 
-@script_di()
-def run_script(db: Session, dry_run: bool = True) -> None:
+def run_script(
+    dry_run: bool = True,
+    deps: ScriptDependencies = script_depends(get_script_dependencies),
+) -> None:
+    """Create users and groups from a JSON configuration file.
+
+    Args:
+        dry_run (bool): Whether to commit changes
+        deps (ScriptDependencies): Script dependencies provided by script_depends
+    """
+    db = deps.db
     with open(os.path.join(os.path.dirname(__file__), "users.json")) as f:
         groups_dict: list[dict[str, Any]] = json.load(f)["groups"]
     groups: list[Group] = []

--- a/ring/scripts/migration/migrate_html_letterloop.py
+++ b/ring/scripts/migration/migrate_html_letterloop.py
@@ -24,19 +24,21 @@ from ring.letters.constants import LetterStatus
 from ring.letters.models.question_model import Question
 from ring.letters.models.response_model import Response
 from ring.parties.models.user_model import User
-from ring.sqlalchemy_base import Session
-from ring.scripts.script_base import script_di
+from ring.scripts.dependencies import (
+    ScriptDependencies,
+    get_script_dependencies,
+    script_depends,
+)
 from bs4 import BeautifulSoup, PageElement, Tag
 from ring.lib.logger import logger
 
 
-@script_di()
 def run_script(
-    db: Session,
     group_name: str,
     issue_numbers: list[int],
     user_admin_email: str,
     dry_run: bool = True,
+    deps: ScriptDependencies = script_depends(get_script_dependencies),
 ) -> None:
     """Import legacy Letterloop HTML files into the Ring database.
 
@@ -45,16 +47,17 @@ def run_script(
     images, and user information from the HTML files.
 
     Args:
-        db (Session): SQLAlchemy database session
         group_name (str): Name of the group the letters belong to
         issue_numbers (list[int]): List of issue numbers to import
         user_admin_email (str): Email of the admin user for the group
         dry_run (bool, optional): If True, rolls back all changes. Defaults to True.
+        deps (ScriptDependencies): Script dependencies provided by script_depends
 
     Raises:
         ValueError: If any specified HTML file is not found
         AssertionError: If the specified admin user is not found
     """
+    db = deps.db
     for issue_number in issue_numbers:
         issue_file_path = Path(
             f"/src/ring/scripts/migration/{group_name}/{issue_number}.html"
@@ -249,82 +252,57 @@ def _parse_question(
                     break
                 curr_str = (
                     first_content.contents[idx].string
-                    or first_content.contents[idx].contents[0].string
+                    if first_content.contents[idx].string
+                    else first_content.contents[idx].contents[0].string
                 )
-                if curr_str and response_text:
-                    response_text += f"\n{curr_str}"
-                elif curr_str:
-                    response_text += curr_str
+                response_text += curr_str
                 idx += 1
-            # second content is the image
-            if stack.contents[1].name == "img":
-                url = stack.contents[1].get("src")
+            if idx < len(first_content.contents):
+                url = first_content.contents[idx].get("src")
         else:
-            first_content = stack.contents[0]
-            author = first_content.contents[0].string
-            response_text = ""
-            idx = 2
-            while first_content.contents[idx].name != "button":
-                if (
-                    not first_content.contents[idx].string
-                    and not first_content.contents[idx].contents
-                ):
-                    break
-                curr_str = (
-                    first_content.contents[idx].string
-                    or first_content.contents[idx].contents[0].string
-                )
-                if curr_str and response_text:
-                    response_text += f"\n{curr_str}"
-                elif curr_str:
-                    response_text += curr_str
-                idx += 1
-        logger.info([author])
-        [current_user] = [
-            m for m in letter.group.members if m.name == author.strip()
-        ]
+            continue
+
+        [current_user] = [m for m in group.members if m.name == author]
         response = question_crud.add_response(
             db, current_question, current_user, response_text
         )
         db.add(response)
         if url:
-            with tempfile.SpooledTemporaryFile() as f:
-                f.write(requests.get(url).content)
-                f.seek(0)
-                # upload_result = upload_image(db, response, [f])
-
+            upload(db, response, url)
+        pp(str(response))
     return current_question
 
 
 def _parse_asked_question_text(
     question: PageElement,
 ) -> tuple[str | None, str]:
-    """Parse the question text and author from a question element.
+    """Parse the text of a question that was asked by a specific user.
 
     Args:
-        question (PageElement): BeautifulSoup PageElement containing the question
+        question (PageElement): BeautifulSoup PageElement containing the question text
 
     Returns:
-        tuple[str | None, str]: A tuple containing the author name (or None) and
-            the question text
+        tuple[str | None, str]: Tuple of (author name, question text)
     """
     author_name = None
-    parts = question.contents[0].contents
-    if len(parts) > 1:
-        if not parts[0].string:
-            author_name = question.contents[0].text.split(" asked:")[0]
+    question_text = ""
+    for content in question.contents:
+        if content.name == "span":
+            author_name = content.string
         else:
-            author_name = parts[0].string.split(" asked:")[0]
-    return author_name, parts[-1].string
+            question_text += content.string
+    return author_name, question_text
 
 
 async def upload(db: Session, response: Response, url: str):
-    """Upload an image from a URL and associate it with a response.
+    """Upload an image for a response.
 
     Args:
         db (Session): SQLAlchemy database session
-        response (Response): Response to associate the image with
+        response (Response): Response to attach the image to
         url (str): URL of the image to upload
     """
-    upload_result = await upload_image(db, response, url)
-    logger.info(upload_result)
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(requests.get(url).content)
+        f.flush()
+        upload_image(db, response, f.name)

--- a/ring/scripts/migration/migrate_letterloop.py
+++ b/ring/scripts/migration/migrate_letterloop.py
@@ -20,17 +20,19 @@ from ring.letters.models.letter_model import Letter
 from ring.lib.logger import logger
 from ring.parties.models.group_model import Group
 from ring.parties.models.user_model import User
-from ring.scripts.script_base import script_di
-from ring.sqlalchemy_base import Session
+from ring.scripts.dependencies import (
+    ScriptDependencies,
+    get_script_dependencies,
+    script_depends,
+)
 
 
-@script_di()
 def run_script(
-    db: Session,
     group_name: str,
     issue_number: int,
     user_admin_email: str,
     dry_run: bool = True,
+    deps: ScriptDependencies = script_depends(get_script_dependencies),
 ) -> None:
     """Import a legacy Letterloop text file into the Ring database.
 
@@ -39,16 +41,17 @@ def run_script(
     from the text file and creates the corresponding database records.
 
     Args:
-        db (Session): SQLAlchemy database session
         group_name (str): Name of the group the letter belongs to
         issue_number (int): Issue number of the letter to import
         user_admin_email (str): Email of the admin user for the group
         dry_run (bool, optional): If True, rolls back all changes. Defaults to True.
+        deps (ScriptDependencies): Script dependencies provided by script_depends
 
     Raises:
         ValueError: If the specified text file is not found
         AssertionError: If the specified admin user is not found
     """
+    db = deps.db
     issue_file_path = Path(
         f"/src/ring/scripts/migration/{group_name}/{issue_number}.txt"
     )

--- a/ring/scripts/migration/upsert_users.py
+++ b/ring/scripts/migration/upsert_users.py
@@ -19,12 +19,17 @@ from ring.parties.crud import group as group_crud
 from ring.parties.crud import user as user_crud
 from ring.parties.models.group_model import Group
 from ring.parties.models.user_model import User
-from ring.scripts.script_base import script_di
-from ring.sqlalchemy_base import Session
+from ring.scripts.dependencies import (
+    ScriptDependencies,
+    get_script_dependencies,
+    script_depends,
+)
 
 
-@script_di()
-def run_script(db: Session, dry_run: bool = True) -> None:
+def run_script(
+    dry_run: bool = True,
+    deps: ScriptDependencies = script_depends(get_script_dependencies),
+) -> None:
     """Upsert users and groups from a JSON configuration file.
 
     This function reads a users.json file from the same directory as this script,
@@ -35,12 +40,13 @@ def run_script(db: Session, dry_run: bool = True) -> None:
     4. Adds the new users to the group
 
     Args:
-        db (Session): SQLAlchemy database session
         dry_run (bool, optional): If True, rolls back all changes. Defaults to True.
+        deps (ScriptDependencies): Script dependencies provided by script_depends
 
     Raises:
         AssertionError: If an admin user specified in the JSON file is not found
     """
+    db = deps.db
     with open(os.path.join(os.path.dirname(__file__), "users.json")) as f:
         groups_dict: list[dict[str, Any]] = json.load(f)["groups"]
     groups: Sequence[Group] = db.scalars(

--- a/ring/scripts/parties/backfill_user_admins.py
+++ b/ring/scripts/parties/backfill_user_admins.py
@@ -1,27 +1,42 @@
-from __future__ import annotations
+"""Script to backfill admin status for specified users."""
 
-from sqlalchemy.orm import Session
+from __future__ import annotations
 
 from ring.lib.logger import logger
 from ring.parties.crud import user as user_crud
-from ring.scripts.script_base import script_di
+from ring.scripts.dependencies import (
+    ScriptDependencies,
+    get_script_dependencies,
+    script_depends,
+)
 
 
-@script_di()
 def run_script(
-    db: Session, dry_run: bool = True, user_emails: list[str] | None = None
+    user_emails: list[str] | None = None,
+    dry_run: bool = True,
+    deps: ScriptDependencies = script_depends(get_script_dependencies),
 ) -> None:
+    """Set admin status for specified users.
+
+    Args:
+        user_emails (list[str] | None): List of user emails to make admin
+        dry_run (bool): Whether to commit changes
+        deps (ScriptDependencies): Script dependencies provided by script_depends
+
+    Raises:
+        ValueError: If user_emails is not provided
+    """
     if user_emails is None:
         raise ValueError("user_emails is required")
     logger.info(f"Setting admin=True for {len(user_emails)} users")
     for user_email in user_emails:
-        user = user_crud.get_user_by_email(db, user_email)
+        user = user_crud.get_user_by_email(deps.db, user_email)
         if user is None:
             logger.error(f"User {user_email} not found")
             continue
-        user_crud.make_user_admin(db, user)
+        user_crud.make_user_admin(deps.db, user)
     if dry_run:
         logger.info("Dry run, rolling back")
-        db.rollback()
+        deps.db.rollback()
     else:
-        db.commit()
+        deps.db.commit()

--- a/ring/scripts/run_sql.py
+++ b/ring/scripts/run_sql.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 from sqlalchemy import text
 
 from ring.lib.logger import logger
-from ring.scripts.script_base import script_di
-from ring.sqlalchemy_base import Session
+from ring.scripts.dependencies import (
+    ScriptDependencies,
+    get_script_dependencies,
+    script_depends,
+)
 
 
-@script_di()
-def run_script(db: Session, query: str) -> None:
+def run_script(
+    query: str,
+    deps: ScriptDependencies = script_depends(get_script_dependencies),
+) -> None:
     """Execute a raw SQL query and display the results.
 
     This function executes the provided SQL query using SQLAlchemy's text()
@@ -22,8 +27,8 @@ def run_script(db: Session, query: str) -> None:
     names and formatted output.
 
     Args:
-        db (Session): Database session provided by script_di
         query (str): Raw SQL query to execute
+        deps (ScriptDependencies): Script dependencies provided by script_depends
 
     Note:
         The query is executed using SQLAlchemy's text() construct which provides
@@ -31,6 +36,6 @@ def run_script(db: Session, query: str) -> None:
         queries being executed.
     """
     logger.info("Running query: {}".format(query))
-    results = db.execute(text(query))
+    results = deps.db.execute(text(query))
     logger.info(results.keys())
     logger.info(results.fetchall())

--- a/ring/scripts/script_runner.py
+++ b/ring/scripts/script_runner.py
@@ -9,13 +9,33 @@ from __future__ import annotations
 import importlib.util
 import json
 import pathlib
+from contextlib import contextmanager
 
 import click
 
 from ring.fastapp.init_app_modules import init_app_modules
 from ring.lib.logger import logger
+from ring.scripts.dependencies import (
+    ScriptDependencies,
+    get_script_dependencies,
+)
 
 # import asyncio
+
+
+@contextmanager
+def script_context():
+    """Context manager for script execution.
+
+    This context manager ensures proper initialization and cleanup of script resources.
+    """
+    init_app_modules()
+    logger.level("DEBUG")
+    logger.debug("Debug logging enabled")
+    try:
+        yield
+    finally:
+        pass
 
 
 @click.group()
@@ -42,23 +62,20 @@ def run_script(script: pathlib.Path, json_args: str):
     Raises:
         click.ClickException: If the script file is invalid or cannot be loaded
     """
-    init_app_modules()
+    with script_context():
+        file_name = script.name
+        spec = importlib.util.spec_from_file_location(file_name, script)
+        if spec is None:
+            raise click.ClickException("Invalid script")
+        module = importlib.util.module_from_spec(spec)
+        loader = spec.loader
+        if loader is None:
+            raise click.ClickException("Invalid script")
 
-    logger.level("DEBUG")
-    logger.debug("Debug logging enabled")
-    file_name = script.name
-    spec = importlib.util.spec_from_file_location(file_name, script)
-    if spec is None:
-        raise click.ClickException("Invalid script")
-    module = importlib.util.module_from_spec(spec)
-    loader = spec.loader
-    if loader is None:
-        raise click.ClickException("Invalid script")
-
-    script_args = json.loads(json_args)
-    loader.exec_module(module)
-    click.echo(f"Running script: {module}")
-    module.run_script(**script_args)
+        script_args = json.loads(json_args)
+        loader.exec_module(module)
+        click.echo(f"Running script: {module}")
+        module.run_script(**script_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
switch to fastapi style dependencies instead of a decorator for db injection on run scripts

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"neil/search-tests","parentHead":"7a02b028999551c38d3c02acc6f497dabd025bcc","parentPull":178,"trunk":"dev"}
```
-->
