### PR TITLE
add tests for scripts

### DIFF
--- a/ring/scripts/search/backfill.py
+++ b/ring/scripts/search/backfill.py
@@ -12,7 +12,6 @@ from ring.parties.crud import group as group_crud
 from ring.parties.crud import user as user_crud
 from ring.scripts.script_base import script_di
 from ring.search.crud.hybrid_search import (
-    type_to_model_class,
     type_to_search_registration,
 )
 from ring.search.models.hybrid_search import (
@@ -40,7 +39,7 @@ def run_script(
             SearchableType.RESPONSE,
         ]
     for searchable_type in searchable_types:
-        model_class = type_to_model_class(searchable_type)
+        model_class = type_to_search_registration(searchable_type).model_class
         models = db.scalars(select(model_class)).all()
         # partition models into those that have search documents and those that don't
 

--- a/ring/tests/unit/scripts/conftest.py
+++ b/ring/tests/unit/scripts/conftest.py
@@ -1,0 +1,57 @@
+"""Test configuration and fixtures for Ring scripts.
+
+This module provides test-specific fixtures for script testing, including
+database sessions and script dependencies. It ensures proper setup and cleanup
+of resources for script tests.
+"""
+
+from __future__ import annotations
+
+from typing import Generator
+
+import pytest
+from sqlalchemy.orm import Session
+
+from ring.scripts.dependencies import ScriptDependencies
+from ring.tests.conftest import db_session
+
+
+@pytest.fixture(scope="function")
+def script_deps(
+    db_session: Session,
+) -> Generator[ScriptDependencies, None, None]:
+    """Create script dependencies for testing.
+
+    This fixture provides a ScriptDependencies instance configured with a test
+    database session. It ensures proper cleanup of resources after each test.
+
+    Args:
+        db_session (Session): Test database session
+
+    Yields:
+        ScriptDependencies: Dependencies configured for script testing
+    """
+    deps = ScriptDependencies(db=db_session)
+    yield deps
+    # Cleanup if needed
+    db_session.rollback()
+
+
+@pytest.fixture(scope="function")
+def script_deps_with_rollback(
+    script_deps: ScriptDependencies,
+) -> Generator[ScriptDependencies, None, None]:
+    """Create script dependencies that automatically rollback changes.
+
+    This fixture provides script dependencies that will automatically rollback
+    any database changes made during the test. This is useful for tests that
+    modify the database but should not persist those changes.
+
+    Args:
+        script_deps (ScriptDependencies): Base script dependencies
+
+    Yields:
+        ScriptDependencies: Dependencies configured for testing with rollback
+    """
+    yield script_deps
+    script_deps.db.rollback()

--- a/ring/tests/unit/scripts/list_users_test.py
+++ b/ring/tests/unit/scripts/list_users_test.py
@@ -1,0 +1,37 @@
+"""Tests for the list_users script.
+
+This module provides tests for the list_users script, ensuring it correctly
+retrieves and displays users from the database.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from ring.scripts.dependencies import ScriptDependencies
+from ring.scripts.list_users import run_script
+from ring.tests.factories.parties.user_factory import UserFactory
+from ring.tests.unit.scripts.script_tester import ScriptTestBase
+
+
+class TestListUsers(ScriptTestBase):
+    """Test cases for the list_users script."""
+
+    def test_list_users(self, script_deps: ScriptDependencies):
+        """Test that the script correctly lists all users.
+
+        Args:
+            script_deps (ScriptDependencies): Script dependencies with test database session
+        """
+        # Create test users
+        users = [UserFactory.create() for _ in range(1)]
+        script_deps.db.add_all(users)
+        script_deps.db.commit()
+
+        # Run the script with test dependencies
+        rv = self.run(run_script, deps=script_deps)
+
+        # Verify results
+        assert [
+            user.to_pydantic().model_dump(mode="json") for user in users
+        ] == [user.to_pydantic().model_dump(mode="json") for user in rv]

--- a/ring/tests/unit/scripts/parties/backfill_user_admins_test.py
+++ b/ring/tests/unit/scripts/parties/backfill_user_admins_test.py
@@ -1,0 +1,96 @@
+"""Tests for the backfill_user_admins script.
+
+This module provides tests for the backfill_user_admins script, ensuring it correctly
+sets admin status for specified users.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from ring.parties.models.user_model import User
+from ring.scripts.dependencies import ScriptDependencies
+from ring.scripts.parties.backfill_user_admins import run_script
+from ring.tests.factories.parties.user_factory import UserFactory
+from ring.tests.unit.scripts.script_tester import ScriptTestBase
+
+
+class TestBackfillUserAdmins(ScriptTestBase):
+    """Test cases for the backfill_user_admins script."""
+
+    def test_make_users_admin(self, script_deps: ScriptDependencies):
+        """Test that the script correctly sets admin status for users.
+
+        Args:
+            script_deps (ScriptDependencies): Script dependencies with test database session
+        """
+        # Create test users
+        users = [
+            UserFactory.create(email=f"user{i}@test.com") for i in range(3)
+        ]
+        script_deps.db.add_all(users)
+        script_deps.db.commit()
+
+        # Run the script with dry_run=True
+        self.run(
+            run_script,
+            user_emails=[user.email for user in users],
+            dry_run=True,
+            deps=script_deps,
+        )
+
+        # Get fresh copies of users from database after rollback
+        users = script_deps.db.scalars(
+            select(User).where(
+                User.email.in_([f"user{i}@test.com" for i in range(3)])
+            )
+        ).all()
+
+        # Verify no changes were made (due to dry run)
+        for user in users:
+            assert not user.admin
+
+        # Run the script with dry_run=False
+        self.run(
+            run_script,
+            user_emails=[user.email for user in users],
+            dry_run=False,
+            deps=script_deps,
+        )
+
+        # Verify users were made admin
+        for user in users:
+            assert user.admin
+
+    def test_missing_user(self, script_deps: ScriptDependencies):
+        """Test that the script handles missing users gracefully.
+
+        Args:
+            script_deps (ScriptDependencies): Script dependencies with test database session
+        """
+        # Create one test user
+        user = UserFactory.create(email="user@test.com")
+        script_deps.db.add(user)
+        script_deps.db.commit()
+
+        # Run the script with one existing and one missing user
+        self.run(
+            run_script,
+            user_emails=["user@test.com", "nonexistent@test.com"],
+            dry_run=False,
+            deps=script_deps,
+        )
+
+        # Verify only existing user was made admin
+        assert user.admin
+
+    def test_missing_user_emails(self, script_deps: ScriptDependencies):
+        """Test that the script raises an error when user_emails is not provided.
+
+        Args:
+            script_deps (ScriptDependencies): Script dependencies with test database session
+        """
+        # Run the script without user_emails
+        with pytest.raises(ValueError, match="user_emails is required"):
+            self.run(run_script, dry_run=False, deps=script_deps)

--- a/ring/tests/unit/scripts/run_sql_test.py
+++ b/ring/tests/unit/scripts/run_sql_test.py
@@ -1,0 +1,48 @@
+"""Tests for the run_sql script.
+
+This module provides tests for the run_sql script, ensuring it correctly
+executes SQL queries and handles results appropriately.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+
+from ring.scripts.dependencies import ScriptDependencies
+from ring.scripts.run_sql import run_script
+from ring.tests.unit.scripts.script_tester import ScriptTestBase
+
+
+class TestRunSql(ScriptTestBase):
+    """Test cases for the run_sql script."""
+
+    def test_run_simple_select(self, script_deps: ScriptDependencies):
+        """Test that the script correctly executes a simple SELECT query.
+
+        Args:
+            script_deps (ScriptDependencies): Script dependencies with test database session
+        """
+        # Create a test table and insert data
+        script_deps.db.execute(
+            text("""
+            CREATE TABLE test_table (
+                id INTEGER PRIMARY KEY,
+                name TEXT
+            )
+        """)
+        )
+        script_deps.db.execute(
+            text("""
+            INSERT INTO test_table (id, name) VALUES 
+            (1, 'test1'),
+            (2, 'test2')
+        """)
+        )
+        script_deps.db.commit()
+
+        # Run the script with a simple SELECT query
+        query = "SELECT * FROM test_table ORDER BY id"
+        rv = self.run(run_script, query=query, deps=script_deps)
+
+        # Verify results
+        assert rv is None  # The function returns None as it logs results

--- a/ring/tests/unit/scripts/script_tester.py
+++ b/ring/tests/unit/scripts/script_tester.py
@@ -1,0 +1,40 @@
+"""Base class for script testing.
+
+This module provides a base class for testing Ring scripts with proper dependency injection.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from ring.scripts.dependencies import ScriptDependencies
+
+
+class ScriptTestBase:
+    """Base class for script testing.
+
+    This class provides utilities for running scripts in a test environment
+    with proper dependency injection.
+    """
+
+    def run(
+        self,
+        run_script: Callable[..., Any],
+        deps: ScriptDependencies | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Run a script with optional dependencies.
+
+        Args:
+            run_script (Callable[..., Any]): The script function to run
+            deps (ScriptDependencies | None): Optional dependencies to inject
+            *args (Any): Additional positional arguments for the script
+            **kwargs (Any): Additional keyword arguments for the script
+
+        Returns:
+            Any: The result of running the script
+        """
+        if deps is not None:
+            return run_script(deps=deps, *args, **kwargs)
+        return run_script(*args, **kwargs)


### PR DESCRIPTION
script tests

just did some with cursor, don't care to retroactively add them for deprecated migration scripts

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"neil/scripts-dependencies","parentHead":"5f0ecd4a2fdaeb13ac974125b7b8bb2db9de039d","parentPull":179,"trunk":"dev"}
```
-->
