### PR TITLE
don't raise exceptions for stale search documents

### DIFF
--- a/ring/api_identifier/util.py
+++ b/ring/api_identifier/util.py
@@ -120,7 +120,10 @@ def get_model(db: Session, model_cls: type[API_CLS], api_id: str) -> API_CLS:
 
 
 def get_models(
-    db: Session, model_cls: type[API_CLS], api_ids: list[str]
+    db: Session,
+    model_cls: type[API_CLS],
+    api_ids: list[str],
+    raise_on_missing: bool = True,
 ) -> Sequence[API_CLS]:
     """Retrieve multiple model instances by their API identifiers.
 
@@ -128,6 +131,7 @@ def get_models(
         db (Session): SQLAlchemy database session
         model_cls (type[API_CLS]): The model class to query
         api_ids (list[str]): List of API identifiers to look up
+        raise_on_missing (bool): Whether to raise an exception if any API identifier is not found
 
     Returns:
         Sequence[API_CLS]: Sequence of model instances matching the API identifiers
@@ -135,20 +139,15 @@ def get_models(
     Raises:
         IDNotFoundException: If any API identifier is not found
     """
-    try:
-        models = (
-            db.query(model_cls)
-            .filter(model_cls.api_identifier.in_(api_ids))
-            .all()
-        )
-        if len(models) == len(api_ids):
-            return models
-        missing_api_ids = set(api_ids) - {
-            model.api_identifier for model in models
-        }
+    models = (
+        db.query(model_cls).filter(model_cls.api_identifier.in_(api_ids)).all()
+    )
+    if len(models) == len(api_ids):
+        return models
+    missing_api_ids = set(api_ids) - {model.api_identifier for model in models}
+    if raise_on_missing:
         raise IDNotFoundException(model_cls, list(missing_api_ids))
-    except NoResultFound:
-        raise IDNotFoundException(model_cls, api_ids)
+    return models
 
 
 def bulk_get_models(

--- a/ring/search/crud/hybrid_search.py
+++ b/ring/search/crud/hybrid_search.py
@@ -204,8 +204,9 @@ def hydrate_results(
 ) -> list[APIIdentified]:
     return get_models(
         db,
-        SEARCH_REGISTRY[model_type.value].model_class,
+        SEARCH_REGISTRY[model_type].model_class,
         model_api_identifiers,
+        raise_on_missing=False,
     )
 
 
@@ -217,9 +218,11 @@ def search(
     search_type: SearchType = SearchType.DUAL,
 ) -> list[APIIdentified]:
     search_results = dual_search_hybrid_search_document(db, query, limit)
+    print(search_results)
     model_ids_by_type = get_model_ids_from_hybrid_search_documents(
         db, search_results
     )
+    print(model_ids_by_type)
     hydrated_results = []
     for model_type, model_api_identifiers in model_ids_by_type.items():
         hydrated_results.extend(

--- a/ring/search/crud/hybrid_search.py
+++ b/ring/search/crud/hybrid_search.py
@@ -218,11 +218,9 @@ def search(
     search_type: SearchType = SearchType.DUAL,
 ) -> list[APIIdentified]:
     search_results = dual_search_hybrid_search_document(db, query, limit)
-    print(search_results)
     model_ids_by_type = get_model_ids_from_hybrid_search_documents(
         db, search_results
     )
-    print(model_ids_by_type)
     hydrated_results = []
     for model_type, model_api_identifiers in model_ids_by_type.items():
         hydrated_results.extend(


### PR DESCRIPTION
search results were returning 404 probably because they have stale search documents (I don't know why nor do I care.) 

Follow-up to auto-clean-up stale search documents required

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"dev","parentHead":"","trunk":"dev"}
```
-->
