### PR TITLE
add pr-approval-check gh workflow

### DIFF
--- a/.github/workflows/pr-approval-check.yml
+++ b/.github/workflows/pr-approval-check.yml
@@ -1,0 +1,123 @@
+name: PR Approval Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    name: Require approval or skip label
+    runs-on: ubuntu-latest
+    env:
+      SKIP_LABEL: "URGENT: SKIP PR APPROVAL"
+      # Optional hardening: set to "true" to require that a user with write/admin
+      # permissions applied the skip label (prevents contributors from bypassing).
+      REQUIRE_PRIVILEGED_LABEL_ADDER: "true"
+    steps:
+      - name: Check approvals (with skip label)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const core = require("@actions/core");
+            const { context, github } = require("@actions/github");
+
+            const pr = context.payload.pull_request ?? (
+              await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request?.number || context.payload.review?.pull_request_url?.split("/").pop()
+              })
+            ).data;
+
+            if (pr.draft) {
+              core.info("PR is draft; passing.");
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = pr.number;
+            const skipLabel = process.env.SKIP_LABEL;
+
+            // 1) If the skip label is present, optionally verify who added it
+            const hasSkip = pr.labels.some(l => l.name === skipLabel);
+
+            if (hasSkip) {
+              core.info(`Skip label "${skipLabel}" present.`);
+
+              if (process.env.REQUIRE_PRIVILEGED_LABEL_ADDER === "true") {
+                // Find the most recent "labeled" event for this label
+                const events = await github.paginate(github.rest.issues.listEvents, {
+                  owner, repo, issue_number: pull_number, per_page: 100
+                });
+                const lastLabelEvent = [...events].reverse().find(e =>
+                  e.event === "labeled" && e.label && e.label.name === skipLabel
+                );
+                if (!lastLabelEvent) {
+                  core.setFailed(`Skip label found, but couldn't verify who applied it.`);
+                  return;
+                }
+                const actor = lastLabelEvent.actor.login;
+                const perm = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner, repo, username: actor
+                });
+                const level = perm.data.permission; // admin|write|maintain|triage|read
+                if (!["admin","maintain","write"].includes(level)) {
+                  core.setFailed(`Skip label was applied by @${actor} (permission=${level}), not allowed to bypass.`);
+                  return;
+                }
+                core.info(`Skip label applied by @${actor} (permission=${level}); bypass allowed.`);
+              }
+
+              return; // allow bypass
+            }
+
+            // 2) Otherwise, require ≥1 approval (excluding the PR author, and counting the latest state per reviewer)
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner, repo, pull_number, per_page: 100
+            });
+
+            // Reduce to each reviewer's latest state (submitted_at)
+            const latestByUser = new Map();
+            for (const r of reviews) {
+              // GitHub sometimes includes outdated/dismissed—latest state wins
+              const key = r.user?.login ?? "unknown";
+              const curr = latestByUser.get(key);
+              if (!curr || new Date(r.submitted_at || r.dismissed_at || 0) > new Date(curr.when || 0)) {
+                latestByUser.set(key, {
+                  state: r.state, // APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED
+                  when: r.submitted_at || r.dismissed_at || null
+                });
+              }
+            }
+
+            // Count approvals excluding PR author and dismissed/overruled states
+            const author = pr.user.login;
+            let approvals = 0;
+            for (const [user, info] of latestByUser.entries()) {
+              if (user === author) continue; // ignore self-approval
+              if (info.state === "APPROVED") approvals += 1;
+            }
+
+            core.info(`Approvals (excluding author): ${approvals}`);
+            if (approvals >= 1) {
+              core.info("Approval requirement satisfied.");
+              return;
+            }
+
+            // Help message if failing
+            const msg = [
+              "❌ PR requires at least one approval OR the label:",
+              `   "${skipLabel}"`,
+              "",
+              "Tips:",
+              "• Ask a teammate to approve the PR, or",
+              `• Add the label "${skipLabel}" for urgent bypass.`,
+            ].join("\n");
+            core.setFailed(msg);

--- a/.github/workflows/pr-approval-check.yml
+++ b/.github/workflows/pr-approval-check.yml
@@ -24,9 +24,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require("@actions/core");
-            const { context, github } = require("@actions/github");
-
             const pr = context.payload.pull_request ?? (
               await github.rest.pulls.get({
                 owner: context.repo.owner,


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"dev","parentHead":"","trunk":"dev"}
```
-->
