### PR TITLE
fix github actions pr review checks

### DIFF
--- a/.github/workflows/pr-approval-check.yml
+++ b/.github/workflows/pr-approval-check.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  issues: read
 
 jobs:
   check:
@@ -28,13 +29,28 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = context.payload.pull_request ?? (
-              await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.pull_request?.number || context.payload.review?.pull_request_url?.split("/").pop()
-              })
-            ).data;
+            // Extract PR number reliably from different event types
+            let pull_number;
+            if (context.payload.pull_request?.number) {
+              pull_number = context.payload.pull_request.number;
+            } else if (context.payload.review?.pull_request?.number) {
+              pull_number = context.payload.review.pull_request.number;
+            } else if (context.payload.review?.pull_request_url) {
+              // Extract from URL: https://api.github.com/repos/owner/repo/pulls/123
+              const match = context.payload.review.pull_request_url.match(/\/pulls\/(\d+)$/);
+              pull_number = match ? parseInt(match[1], 10) : null;
+            } else {
+              core.setFailed("Could not determine PR number from event payload");
+              return;
+            }
+
+            // Always fetch the full PR object via API to ensure labels are populated
+            const prResponse = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pull_number
+            });
+            const pr = prResponse.data;
 
             if (pr.draft) {
               core.info("PR is draft; passing.");
@@ -43,11 +59,16 @@ jobs:
 
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const pull_number = pr.number;
             const skipLabel = process.env.SKIP_LABEL;
 
+            // Fetch labels separately to ensure they're populated (PR API response may not include labels)
+            const issueResponse = await github.rest.issues.get({
+              owner, repo, issue_number: pull_number
+            });
+            const labels = issueResponse.data.labels || [];
+
             // 1) If the skip label is present, optionally verify who added it
-            const hasSkip = pr.labels.some(l => l.name === skipLabel);
+            const hasSkip = labels.some(l => l.name === skipLabel);
 
             if (hasSkip) {
               core.info(`Skip label "${skipLabel}" present.`);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens the PR approval check workflow to be robust across event types and properly handle labels and approvals.
> 
> - Reliably determines `pull_number` from multiple event payloads; always fetches full PR via API
> - Adds `issues: read` permission and retrieves labels using `issues.get` instead of relying on PR payload
> - Verifies skip label usage by inspecting latest label event and collaborator permission before allowing bypass
> - Computes approvals from latest review states, excluding the PR author; outputs clearer failure messaging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34799f16dd08a8613e392881cf6a1543733c33be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->