### PR TITLE
Tab url hash fragments

### DIFF
--- a/react/src/hooks/useAuth.ts
+++ b/react/src/hooks/useAuth.ts
@@ -34,9 +34,12 @@ const useAuth = (next?: string) => {
         ...readUserMePartiesMeGetOptions({}),
       });
       // Redirect to the next parameter if provided, otherwise go to home
-      // Use window.location.href to preserve hash fragments
+      // TanStack Router should handle hash fragments when included in the path
       if (next) {
-        window.location.href = next;
+        // Parse the next URL to extract all parts (pathname, search, hash)
+        const url = new URL(next, window.location.origin);
+        const fullPath = url.pathname + url.search + url.hash;
+        navigate({ to: fullPath });
       } else {
         navigate({ to: "/" });
       }

--- a/react/src/hooks/useAuth.ts
+++ b/react/src/hooks/useAuth.ts
@@ -34,12 +34,18 @@ const useAuth = (next?: string) => {
         ...readUserMePartiesMeGetOptions({}),
       });
       // Redirect to the next parameter if provided, otherwise go to home
-      // TanStack Router should handle hash fragments when included in the path
+      // Use TanStack Router's hash option to preserve hash fragments
       if (next) {
-        // Parse the next URL to extract all parts (pathname, search, hash)
+        // Parse the next URL to extract pathname, search, and hash
         const url = new URL(next, window.location.origin);
-        const fullPath = url.pathname + url.search + url.hash;
-        navigate({ to: fullPath });
+        const pathname = url.pathname;
+        const search = url.search;
+        const hash = url.hash.slice(1); // Remove the '#' character
+        
+        navigate({
+          to: pathname + search,
+          ...(hash && { hash: hash as any }),
+        });
       } else {
         navigate({ to: "/" });
       }

--- a/react/src/hooks/useAuth.ts
+++ b/react/src/hooks/useAuth.ts
@@ -42,10 +42,16 @@ const useAuth = (next?: string) => {
         const search = url.search;
         const hash = url.hash.slice(1); // Remove the '#' character
         
-        navigate({
-          to: pathname + search,
-          ...(hash && { hash: hash as any }),
-        });
+        if (hash) {
+          navigate({
+            to: pathname + search,
+            hash: hash,
+          });
+        } else {
+          navigate({
+            to: pathname + search,
+          });
+        }
       } else {
         navigate({ to: "/" });
       }

--- a/react/src/hooks/useAuth.ts
+++ b/react/src/hooks/useAuth.ts
@@ -34,7 +34,12 @@ const useAuth = (next?: string) => {
         ...readUserMePartiesMeGetOptions({}),
       });
       // Redirect to the next parameter if provided, otherwise go to home
-      navigate({ to: next || "/" });
+      // Use window.location.href to preserve hash fragments
+      if (next) {
+        window.location.href = next;
+      } else {
+        navigate({ to: "/" });
+      }
     },
     onError: (err: AxiosError<LoginAccessTokenLoginAccessTokenPostError>) => {
       const errDetail =

--- a/react/src/main.tsx
+++ b/react/src/main.tsx
@@ -43,7 +43,7 @@ client.instance.interceptors.response.use(
   (error) => {
     if (error.response?.status === 401) {
       localStorage.removeItem("access_token");
-      const currentPath = window.location.pathname + window.location.search;
+      const currentPath = window.location.pathname + window.location.search + window.location.hash;
       // Only add next parameter if we're not already on the login page
       if (window.location.pathname !== "/login") {
         const nextParam = encodeURIComponent(currentPath);

--- a/react/src/routes/_layout.tsx
+++ b/react/src/routes/_layout.tsx
@@ -23,7 +23,9 @@ export const Route = createFileRoute("/_layout")({
       // If authentication fails, redirect to login with the current path as next parameter
       // Only add next parameter if we're not already on the login page
       if (location.pathname !== "/login") {
-        const currentPath = location.pathname + location.search;
+        // Include hash fragment from window.location since TanStack Router's location might not have it
+        const hash = typeof window !== "undefined" ? window.location.hash : "";
+        const currentPath = location.pathname + location.search + hash;
         throw redirect({
           to: "/login",
           search: {

--- a/react/src/routes/_layout/groups_/$groupId/loops.tsx
+++ b/react/src/routes/_layout/groups_/$groupId/loops.tsx
@@ -12,7 +12,7 @@ import {
 } from "@chakra-ui/react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { Suspense } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { MinimalLetter } from "../../../../client";
 import {
   listLettersLettersLettersGetOptions,
@@ -80,14 +80,17 @@ function LoopsContentLoader() {
   const tabsConfig = [
     {
       title: "Loops",
+      hash: "loops",
       component: () => <LoopsTab loops={props.loops.filter(loop => loop.letter_type === "CYCLIC")} group={group} />
     },
     {
       title: "Adhoc Loops",
+      hash: "adhoc-loops",
       component: () => <AdhocLoopsTab loops={props.loops.filter(loop => loop.letter_type === "ADHOC")} group={group} />
     },
     {
       title: "Key Values",
+      hash: "key-values",
       component: () => (
         <GroupKeyValuesTable
           keyValues={{
@@ -99,13 +102,62 @@ function LoopsContentLoader() {
     },
     {
       title: "LLM Playground",
+      hash: "llm-playground",
       component: () => <LLMPlayground />
     },
     {
       title: "Documents",
+      hash: "documents",
       component: () => <DocumentsGrid groupApiId={groupId} />
     }
   ];
+
+  // Map hash fragments to tab indices (memoized for stability)
+  const hashToIndex = useMemo(
+    () => new Map(tabsConfig.map((tab, index) => [tab.hash, index])),
+    [tabsConfig.length] // Only recreate if number of tabs changes
+  );
+  
+  // Get initial tab index from hash fragment
+  const getInitialTabIndex = (): number => {
+    if (typeof window !== "undefined") {
+      const hash = window.location.hash.slice(1); // Remove the '#' character
+      const index = hashToIndex.get(hash);
+      return index !== undefined ? index : 0;
+    }
+    return 0;
+  };
+
+  const [tabIndex, setTabIndex] = useState(getInitialTabIndex);
+
+  // Update hash when tab changes
+  const handleTabChange = (index: number) => {
+    setTabIndex(index);
+    const hash = tabsConfig[index]?.hash;
+    if (hash) {
+      window.location.hash = hash;
+    }
+  };
+
+  // Listen for hash changes (e.g., browser back/forward)
+  useEffect(() => {
+    const handleHashChange = () => {
+      const hash = window.location.hash.slice(1);
+      const index = hashToIndex.get(hash);
+      if (index !== undefined) {
+        setTabIndex(index);
+      }
+    };
+
+    window.addEventListener("hashchange", handleHashChange);
+    
+    // Also check hash on mount in case it was set before component mounted
+    handleHashChange();
+
+    return () => {
+      window.removeEventListener("hashchange", handleHashChange);
+    };
+  }, [hashToIndex]);
 
   return (
     <Container maxW="full">
@@ -140,7 +192,7 @@ function LoopsContentLoader() {
         borderRadius="xl"
         boxShadow="md"
       >
-        <Tabs variant="enclosed">
+        <Tabs variant="enclosed" index={tabIndex} onChange={handleTabChange}>
           <TabList overflowX="auto" overflowY="hidden" flexWrap="nowrap">
             {tabsConfig.map((tab, index) => (
               <Tab

--- a/react/src/routes/login.tsx
+++ b/react/src/routes/login.tsx
@@ -45,16 +45,29 @@ export const Route = createFileRoute("/login")({
     ) {
       // If already authenticated and there's a next parameter, redirect there
       // Otherwise redirect to home
-      // If next contains a hash fragment, use window.location.href to preserve it
-      // since TanStack Router's redirect doesn't preserve hash fragments
-      if (search.next && search.next.includes("#")) {
-        if (typeof window !== "undefined") {
-          window.location.href = search.next;
-          return; // Navigation will happen, no need to throw redirect
+      // TanStack Router should handle hash fragments when included in the path
+      if (search.next) {
+        try {
+          // Parse the next URL to extract all parts (pathname, search, hash)
+          const baseUrl = typeof window !== "undefined" ? window.location.origin : "http://localhost";
+          const url = new URL(search.next, baseUrl);
+          const fullPath = url.pathname + url.search + url.hash;
+          throw redirect({
+            to: fullPath,
+          });
+        } catch (e) {
+          // If URL parsing fails (e.g., relative path), use the next parameter directly
+          if (e instanceof TypeError) {
+            throw redirect({
+              to: search.next,
+            });
+          }
+          // Re-throw redirect exceptions
+          throw e;
         }
       }
       throw redirect({
-        to: search.next || "/",
+        to: "/",
       });
     }
   },

--- a/react/src/routes/login.tsx
+++ b/react/src/routes/login.tsx
@@ -45,33 +45,16 @@ export const Route = createFileRoute("/login")({
     ) {
       // If already authenticated and there's a next parameter, redirect there
       // Otherwise redirect to home
-      // Use TanStack Router's hash option to preserve hash fragments
-      if (search.next) {
-        try {
-          // Parse the next URL to extract pathname, search, and hash
-          const baseUrl = typeof window !== "undefined" ? window.location.origin : "http://localhost";
-          const url = new URL(search.next, baseUrl);
-          const pathname = url.pathname;
-          const searchParams = url.search;
-          const hash = url.hash.slice(1); // Remove the '#' character
-          
-          throw redirect({
-            to: pathname + searchParams,
-            ...(hash && { hash: hash as any }),
-          });
-        } catch (e) {
-          // If URL parsing fails (e.g., relative path), use the next parameter directly
-          if (e instanceof TypeError) {
-            throw redirect({
-              to: search.next,
-            });
-          }
-          // Re-throw redirect exceptions
-          throw e;
+      // If next contains a hash fragment, use window.location.href to preserve it
+      // since redirect doesn't support hash option the same way navigate does
+      if (search.next && search.next.includes("#")) {
+        if (typeof window !== "undefined") {
+          window.location.href = search.next;
+          return; // Navigation will happen, no need to throw redirect
         }
       }
       throw redirect({
-        to: "/",
+        to: search.next || "/",
       });
     }
   },

--- a/react/src/routes/login.tsx
+++ b/react/src/routes/login.tsx
@@ -45,6 +45,14 @@ export const Route = createFileRoute("/login")({
     ) {
       // If already authenticated and there's a next parameter, redirect there
       // Otherwise redirect to home
+      // If next contains a hash fragment, use window.location.href to preserve it
+      // since TanStack Router's redirect doesn't preserve hash fragments
+      if (search.next && search.next.includes("#")) {
+        if (typeof window !== "undefined") {
+          window.location.href = search.next;
+          return; // Navigation will happen, no need to throw redirect
+        }
+      }
       throw redirect({
         to: search.next || "/",
       });

--- a/react/src/routes/login.tsx
+++ b/react/src/routes/login.tsx
@@ -45,16 +45,39 @@ export const Route = createFileRoute("/login")({
     ) {
       // If already authenticated and there's a next parameter, redirect there
       // Otherwise redirect to home
-      // If next contains a hash fragment, use window.location.href to preserve it
-      // since redirect doesn't support hash option the same way navigate does
-      if (search.next && search.next.includes("#")) {
-        if (typeof window !== "undefined") {
-          window.location.href = search.next;
-          return; // Navigation will happen, no need to throw redirect
+      // Use TanStack Router's hash option to preserve hash fragments
+      if (search.next) {
+        try {
+          // Parse the next URL to extract pathname, search, and hash
+          const baseUrl = typeof window !== "undefined" ? window.location.origin : "http://localhost";
+          const url = new URL(search.next, baseUrl);
+          const pathname = url.pathname;
+          const searchParams = url.search;
+          const hash = url.hash.slice(1); // Remove the '#' character
+          
+          if (hash) {
+            throw redirect({
+              to: pathname + searchParams,
+              hash: hash,
+            });
+          } else {
+            throw redirect({
+              to: pathname + searchParams,
+            });
+          }
+        } catch (e) {
+          // If URL parsing fails (e.g., relative path), use the next parameter directly
+          if (e instanceof TypeError) {
+            throw redirect({
+              to: search.next,
+            });
+          }
+          // Re-throw redirect exceptions
+          throw e;
         }
       }
       throw redirect({
-        to: search.next || "/",
+        to: "/",
       });
     }
   },

--- a/react/src/routes/login.tsx
+++ b/react/src/routes/login.tsx
@@ -45,15 +45,19 @@ export const Route = createFileRoute("/login")({
     ) {
       // If already authenticated and there's a next parameter, redirect there
       // Otherwise redirect to home
-      // TanStack Router should handle hash fragments when included in the path
+      // Use TanStack Router's hash option to preserve hash fragments
       if (search.next) {
         try {
-          // Parse the next URL to extract all parts (pathname, search, hash)
+          // Parse the next URL to extract pathname, search, and hash
           const baseUrl = typeof window !== "undefined" ? window.location.origin : "http://localhost";
           const url = new URL(search.next, baseUrl);
-          const fullPath = url.pathname + url.search + url.hash;
+          const pathname = url.pathname;
+          const searchParams = url.search;
+          const hash = url.hash.slice(1); // Remove the '#' character
+          
           throw redirect({
-            to: fullPath,
+            to: pathname + searchParams,
+            ...(hash && { hash: hash as any }),
           });
         } catch (e) {
           // If URL parsing fails (e.g., relative path), use the next parameter directly


### PR DESCRIPTION
Add URL hash fragment support for group page tabs to enable direct linking and bookmarking of specific tabs.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f2c5cf3-1498-45c5-8378-9a9b8c9827e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3f2c5cf3-1498-45c5-8378-9a9b8c9827e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

