### PR TITLE
Image upload timeouts

### DIFF
--- a/dev.nginx.conf
+++ b/dev.nginx.conf
@@ -65,6 +65,11 @@ server {
     location /api/v1/ {
         proxy_pass http://ring-api:8001/;
         client_max_body_size 500M;
+
+        # Timeout settings to prevent hanging requests
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
     }
 
     location / {

--- a/prod.nginx.conf
+++ b/prod.nginx.conf
@@ -68,6 +68,11 @@ server {
     location /api/v1/ {
         proxy_pass http://ring-api:8001/;
         client_max_body_size 500M;
+
+        # Timeout settings to prevent hanging requests
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
     }
 
     location /api/v1/docs {

--- a/ring/fastapp/dependencies.py
+++ b/ring/fastapp/dependencies.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import boto3
+from botocore.config import Config
 from fastapi import Depends, HTTPException, WebSocket, status
 from loguru import logger
 from mypy_boto3_s3 import S3Client
@@ -165,9 +166,14 @@ async def get_websocket_request_dependencies(
 
 
 async def get_s3_client_dependencies() -> S3Client:
-    """Get an asynchronous AWS S3 client.
+    """Get an AWS S3 client with timeout configuration.
 
     Returns:
-        S3Client: Boto3 S3 client for asynchronous operations
+        S3Client: Boto3 S3 client with configured timeouts
     """
-    return boto3.client("s3")  # type: ignore
+    s3_config = Config(
+        connect_timeout=60,  # 60 seconds to establish connection
+        read_timeout=300,  # 5 minutes for read operations (uploads/downloads)
+        retries={"max_attempts": 3, "mode": "standard"},
+    )
+    return boto3.client("s3", config=s3_config)  # type: ignore


### PR DESCRIPTION
Add nginx and S3 client timeouts to prevent hanging requests.

Previously, the server could block indefinitely on image uploads due to a lack of timeout configurations in nginx and the S3 client, leading to long service unavailability.

---
<a href="https://cursor.com/background-agent?bcId=bc-1175bdc5-1065-4c37-b971-2aad7a14f7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1175bdc5-1065-4c37-b971-2aad7a14f7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

