### PR TITLE
feat: auto-expand response input boxes as content grows

### DIFF
--- a/react/src/components/Question/DraftQuestion.tsx
+++ b/react/src/components/Question/DraftQuestion.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Flex, Heading, Modal, ModalBody, ModalCloseButton, ModalCo
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { useEffect, useRef, useState } from "react";
+import { useAutoResizeTextarea } from "../../hooks/useAutoResizeTextarea";
 import { FaTrash } from "react-icons/fa";
 import {
   deleteImageResponsesResponseResponseApiIdDeleteImageDelete,
@@ -41,6 +42,7 @@ function ResponseBlock(props: ResponseBlockProps) {
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const savingStartTimeRef = useRef<number | null>(null);
   const showToast = useCustomToast();
+  const textareaRef = useAutoResizeTextarea(responseText);
 
   // Update local state when response prop changes
   useEffect(() => {
@@ -92,6 +94,7 @@ function ResponseBlock(props: ResponseBlockProps) {
   return (
     <Box my="10px">
       <Textarea
+        ref={textareaRef}
         size="md"
         variant="filled"
         value={responseText}
@@ -100,6 +103,8 @@ function ResponseBlock(props: ResponseBlockProps) {
         placeholder={isSaving ? "Saving..." : "Type your response..."}
         opacity={isSaving ? 0.7 : 1}
         transition="opacity 0.2s ease"
+        overflow="hidden"
+        resize="none"
       />
       {isSaving && (
         <Box fontSize="sm" color="gray.500" mt={1}>

--- a/react/src/components/Question/LateAnswerQuestion.tsx
+++ b/react/src/components/Question/LateAnswerQuestion.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Heading, Textarea, useColorModeValue } from "@chakra-ui/re
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { useState } from "react";
+import { useAutoResizeTextarea } from "../../hooks/useAutoResizeTextarea";
 import {
     PublicQuestion,
     upsertResponseQuestionsQuestionQuestionApiIdUpsertResponsePost,
@@ -30,6 +31,7 @@ function LateAnswerQuestion({
     const showToast = useCustomToast();
     const [responseText, setResponseText] = useState("");
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const textareaRef = useAutoResizeTextarea(responseText);
 
     if (!currentUser) {
         return <Box>Loading...</Box>;
@@ -115,12 +117,15 @@ function LateAnswerQuestion({
 
             <Box mb="3">
                 <Textarea
+                    ref={textareaRef}
                     size="md"
                     variant="filled"
                     value={responseText}
                     onChange={handleResponseChange}
                     placeholder="Add your late answer here..."
                     minH="100px"
+                    overflow="hidden"
+                    resize="none"
                 />
             </Box>
 

--- a/react/src/hooks/useAutoResizeTextarea.ts
+++ b/react/src/hooks/useAutoResizeTextarea.ts
@@ -1,0 +1,25 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export function useAutoResizeTextarea(value: string) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const minHeightRef = useRef<number | null>(null);
+
+  const captureMinHeight = useCallback((node: HTMLTextAreaElement | null) => {
+    if (node && minHeightRef.current === null) {
+      minHeightRef.current = node.offsetHeight;
+    }
+    (textareaRef as React.MutableRefObject<HTMLTextAreaElement | null>).current =
+      node;
+  }, []);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    textarea.style.height = "auto";
+    const minH = minHeightRef.current ?? 0;
+    textarea.style.height = `${Math.max(textarea.scrollHeight, minH)}px`;
+  }, [value]);
+
+  return captureMinHeight;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Response textareas for answering questions now automatically expand in height as the user types longer responses. The textareas never shrink below their default/initial height, keeping the same look when empty while being responsive to longer content.

## Changes

### New: `useAutoResizeTextarea` hook (`react/src/hooks/useAutoResizeTextarea.ts`)
- Captures the textarea's initial rendered height on mount as the minimum height floor
- On every value change, resets height to `auto` then sets it to `max(scrollHeight, minHeight)`
- Returns a callback ref compatible with Chakra UI's `Textarea` `ref` prop

### Updated: `DraftQuestion.tsx` (`ResponseBlock`)
- Wired up the auto-resize hook to the draft response textarea
- Added `overflow="hidden"` and `resize="none"` to prevent scrollbars and the manual drag-resize handle

### Updated: `LateAnswerQuestion.tsx`
- Wired up the same auto-resize hook to the late answer textarea
- Added `overflow="hidden"` and `resize="none"` for consistent behavior

## How it works

The hook uses a callback ref to capture the textarea DOM node's `offsetHeight` on first render, storing it as the minimum height. A `useEffect` keyed on the text value resets `style.height` to `"auto"` (to allow shrinking when text is deleted) then sets it to the greater of `scrollHeight` and the captured minimum, so the box never gets smaller than its default size.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3464929-f46a-46ef-9e5e-1291fa32c94b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3464929-f46a-46ef-9e5e-1291fa32c94b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

