### PR TITLE
Add development environment setup with AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Architecture overview
+
+Ring is a collaborative letter/newsletter platform (LetterLoop clone) with three main components:
+
+| Component | Tech | Port |
+|-----------|------|------|
+| **Backend API** | FastAPI + SQLAlchemy + CockroachDB | 8001 (via Docker) |
+| **Frontend** | React + Vite + ChakraUI + TanStack | 5173 (Vite dev server) |
+| **Nginx** | Reverse proxy for API + SSL | 443/80 (via Docker) |
+| **CockroachDB** | Database (PostgreSQL-compatible) | 26257 (via Docker) |
+
+The `ring` CLI (installed via `uv sync`) provides dev workflow commands — see `README.md` for the full list.
+
+### Starting services
+
+All backend services run via Docker Compose. The `ring` CLI wraps docker compose commands:
+
+```bash
+# Activate venv first
+source .venv/bin/activate
+
+# Start CockroachDB + API + Nginx
+sudo docker compose -f compose.core.yml -f compose.dev.yml --profile dev up --build --detach
+
+# Run database migrations (runs inside the API container)
+sudo docker compose -f compose.core.yml -f compose.dev.yml --profile dev exec -w /src/ring api alembic upgrade head
+
+# Start frontend dev server
+cd react && pnpm run dev
+```
+
+**Gotcha:** CockroachDB requires vector indexes to be enabled before migrations will succeed. Run this once after the CockroachDB container first starts:
+```bash
+sudo docker exec ring-cockroach ./cockroach sql --certs-dir=/root/.cockroach-certs -d ring -e "SET CLUSTER SETTING feature.vector_index.enabled = true;"
+```
+
+### Lint, test, build
+
+- **Python lint:** `uv run ruff format --diff && uv run ruff check`
+- **Frontend lint:** `cd react && pnpm run lint` (uses Biome with `--apply-unsafe`; ~21 pre-existing security warnings are expected)
+- **TypeScript check:** `cd react && npx tsc --noEmit`
+- **Backend tests:** Run via Docker using `compose.test.yml`:
+  ```bash
+  sudo docker compose -f compose.test.yml --profile test up --build --detach
+  sudo docker logs -f ring-test-runner
+  ```
+  Tests use a separate CockroachDB instance on port 8008. 242/243 tests pass; 1 pre-existing `IntegrityError` in `TestGroupApi::test_list_groups`.
+- **Frontend build:** `cd react && pnpm run build`
+
+### Important notes
+
+- The `.env` file is required at the repo root with keys documented in `README.md`. It is `.gitignore`d.
+- SSL certificates are generated via `bash dev_util/ssl.sh` and stored in `localhost.crt`, `localhost.key` (for Nginx) and `certs/` (for CockroachDB). Cert `certs/node.key` must have `chmod 600`.
+- Docker commands require `sudo` in the Cloud Agent VM.
+- The frontend Vite dev server at `https://localhost:5173` communicates with the backend through the Nginx reverse proxy at `https://localhost/api/v1/`.
+- The LLM microservice (`llm/`) is optional and requires additional setup (Ollama or Gemini/OpenAI API keys).

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -77,17 +77,4 @@ export default defineConfig({
     wasm(),
     topLevelAwait(),
   ],
-  server: {
-    https: {
-      key: "../localhost.key",
-      cert: "../localhost.crt",
-    },
-    proxy: {
-      "/api": {
-        target: "http://localhost:8001",
-        changeOrigin: true,
-        secure: false,
-      },
-    },
-  },
 });

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -77,4 +77,17 @@ export default defineConfig({
     wasm(),
     topLevelAwait(),
   ],
+  server: {
+    https: {
+      key: "../localhost.key",
+      cert: "../localhost.crt",
+    },
+    proxy: {
+      "/api": {
+        target: "http://localhost:8001",
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 });

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12.1"
 
 [manifest]
@@ -1065,7 +1065,7 @@ wheels = [
 [[package]]
 name = "llm"
 version = "0.1.0"
-source = { virtual = "llm" }
+source = { editable = "llm" }
 dependencies = [
     { name = "fastapi", extra = ["all"] },
     { name = "google-genai" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for the Ring codebase.

### Changes
- **`AGENTS.md`** — Added Cursor Cloud-specific development instructions covering architecture, service startup, lint/test/build commands, and important gotchas (e.g. CockroachDB vector index enablement).
- **`uv.lock`** — Minor revision bump from running `uv sync`.

### Environment Setup Verified

| Check | Status |
|-------|--------|
| Python deps (`uv sync --group dev --group ai`) | Pass |
| Frontend deps (`pnpm install`) | Pass |
| Docker services (CockroachDB, API, Nginx) | Pass |
| Database migrations (`alembic upgrade head`) | Pass |
| Python lint (`ruff format --diff`, `ruff check`) | Pass |
| Frontend lint (`biome check`) | Pass (21 pre-existing warnings) |
| TypeScript type check (`tsc --noEmit`) | Pass |
| Backend tests (242/243 pass, 1 pre-existing failure) | Pass |
| Frontend dev server (Vite) | Pass |
| E2E flow: user creation, login, group + letter creation | Pass |

### Demo

The Ring app was tested end-to-end: user account created via API, login through the UI, group creation, and letter creation all verified working.

[ring_app_demo_login_and_groups.mp4](https://cursor.com/agents/bc-e52f55a6-78d3-4695-bc28-9a11162fa773/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fring_app_demo_login_and_groups.mp4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e52f55a6-78d3-4695-bc28-9a11162fa773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e52f55a6-78d3-4695-bc28-9a11162fa773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

