### PR TITLE
Allow uploading multiple images at once

### DIFF
--- a/react/src/components/Common/SingleUploadImage.tsx
+++ b/react/src/components/Common/SingleUploadImage.tsx
@@ -6,7 +6,7 @@ import {
   IconButton,
   Image,
   Input,
-  ScaleFade,
+  Spinner,
   VStack,
 } from "@chakra-ui/react";
 import { useState } from "react";
@@ -64,7 +64,7 @@ export function SingleUploadImage({
   onUpdateFile,
   name,
 }: SingleUploadImageProps): JSX.Element {
-  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
 
   const handleFileChange = async (
     event: React.ChangeEvent<HTMLInputElement>
@@ -73,11 +73,16 @@ export function SingleUploadImage({
     if (!files || files.length === 0) {
       return;
     }
-    const selectedFiles = files as FileList;
-    const file = selectedFiles?.[0];
-    setUploadedFile(file);
-    await onUpdateFile(file);
-    setUploadedFile(null);
+    setIsUploading(true);
+    try {
+      const uploadPromises = Array.from(files).map((file) =>
+        onUpdateFile(file)
+      );
+      await Promise.all(uploadPromises);
+    } finally {
+      setIsUploading(false);
+      event.target.value = "";
+    }
   };
 
   return (
@@ -97,31 +102,18 @@ export function SingleUploadImage({
         _hover={{ bg: "blackAlpha.600" }}
       >
         <VStack>
-          {uploadedFile == null && <Icon as={MdAddPhotoAlternate} />}
+          {isUploading ? <Spinner size="sm" /> : <Icon as={MdAddPhotoAlternate} />}
         </VStack>
       </Center>
 
-      {uploadedFile && (
-        <ScaleFade initialScale={0.9} in={uploadedFile !== null}>
-          <Image
-            w="100%"
-            h={"100%"}
-            src={URL.createObjectURL(uploadedFile)}
-            alt="Uploaded"
-          />
-        </ScaleFade>
-      )}
-
       <Input
-        required
         style={{ display: "none" }}
         type="file"
-        // id="file"
-        // name="file"
         id={name}
         name={name}
+        multiple
         onChange={handleFileChange}
-        isDisabled={uploadedFile !== null}
+        isDisabled={isUploading}
         accept="image/*, video/*"
       />
     </Center>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On iPhone (and other mobile browsers), users could only select one photo at a time when uploading images. This made uploading multiple photos tedious since each one required a separate tap through the file picker.

## Solution

Updated the `SingleUploadImage` component to support multi-file selection:

- Added the `multiple` attribute to the hidden `<input type="file">` element, which allows the browser's native file picker to support multi-select
- Updated `handleFileChange` to iterate over all selected files and upload them in parallel via `Promise.all`
- Reset the file input value after upload completes so the same files can be re-selected if needed
- Replaced the single-file image preview with a spinner indicator during upload
- Removed unused `ScaleFade` import

The backend already supports receiving individual upload requests (one file per API call), so no server-side changes are needed — each selected file is uploaded as a separate request in parallel.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed649037-83de-433f-998b-c15580a9e304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed649037-83de-433f-998b-c15580a9e304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

