### PR TITLE
Fix horizontal scroll from wide images on published loops

### DIFF
--- a/react/src/components/Common/SingleUploadImage.tsx
+++ b/react/src/components/Common/SingleUploadImage.tsx
@@ -110,7 +110,7 @@ interface S3MediaProps {
 
 function S3MediaContainer({ children }: { children: React.ReactNode }) {
   return (
-    <div className="rounded-md hover:shadow-md transition-all duration-200 shadow-sm overflow-hidden inline-block p-2 relative">
+    <div className="rounded-md hover:shadow-md transition-all duration-200 shadow-sm overflow-hidden block w-full max-w-[400px] min-w-0 p-2 relative">
       {children}
     </div>
   )
@@ -123,7 +123,7 @@ export function S3Image({ s3Key, alt, handleDelete }: S3MediaProps) {
       <img
         src={url}
         alt={alt}
-        className="max-w-[400px] max-h-[300px] object-contain hover:scale-[1.02] transition-all duration-200"
+        className="h-auto w-full max-h-[300px] object-contain hover:scale-[1.02] transition-all duration-200"
       />
       {handleDelete && (
         <Button
@@ -150,7 +150,7 @@ export function S3Video({
       <video
         src={url}
         controls
-        className="max-w-[400px] max-h-[300px] object-contain"
+        className="h-auto w-full max-h-[300px] object-contain"
       >
         <track kind="captions" />
       </video>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Published loop responses render images with `S3Image`, which used a fixed `max-w-[400px]` on the `<img>` inside an `inline-block` container with padding. On typical phone widths (~390px or less), that combination could exceed the viewport and force a small horizontal scroll.

## Changes

- **`S3MediaContainer`**: Switched from `inline-block` to `block w-full max-w-[400px] min-w-0` so the media block respects the parent width and can shrink on narrow viewports.
- **`S3Image` / `S3Video`**: Replaced fixed `max-w-[400px]` on the media with `w-full` so images/videos scale to the container (still capped at 400px by the wrapper, with `max-h-[300px]` unchanged).

This affects published questions and draft previews consistently since they share the same components.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a7d66cb-7a87-41c8-8bd9-8d837974f0c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a7d66cb-7a87-41c8-8bd9-8d837974f0c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

