### PR TITLE
fix: remove unused imports in AdhocLoopNav to pass FE lint/build

### DIFF
--- a/react/src/components/Loops/AdhocLoopNav.tsx
+++ b/react/src/components/Loops/AdhocLoopNav.tsx
@@ -1,10 +1,8 @@
 import { Button } from "@/components/ui/button"
 import { useQueryClient } from "@tanstack/react-query"
-import { useRouter } from "@tanstack/react-router"
 import { Plus } from "lucide-react"
 import { useState } from "react"
 import type { GroupLinked, MinimalLetter } from "../../client"
-import { listLettersLettersLettersGetQueryKey } from "../../client/@tanstack/react-query.gen"
 import AddAdhocLoop from "./AddAdhocLoop"
 
 type AdhocLoopNavProps = {
@@ -15,7 +13,6 @@ type AdhocLoopNavProps = {
 function AdhocLoopNav(props: AdhocLoopNavProps): JSX.Element {
   const [addAdhocLoopOpen, setAddAdhocLoopOpen] = useState(false)
   const queryClient = useQueryClient()
-  const router = useRouter()
 
   const onClick = (): void => {
     queryClient.invalidateQueries({


### PR DESCRIPTION
Remove unused 'listLettersLettersLettersGetQueryKey' import and unused 'router' variable (and its 'useRouter' import) that caused TS6133 errors in the CI frontend-lint-build check.