### PR TITLE
Defer letter sends when too few participants respond

### DIFF
--- a/ring/tasks/crud/task.py
+++ b/ring/tasks/crud/task.py
@@ -7,6 +7,7 @@ It includes both synchronous execution functions and their asynchronous job wrap
 
 from __future__ import annotations
 
+import math
 from datetime import timedelta
 from typing import Any, Callable
 
@@ -32,6 +33,20 @@ from ring.tasks.models.task_model import (
     TaskStatus,
     TaskType,
 )
+
+MIN_RESPONDER_RATIO_TO_SEND = 0.5
+LETTER_SEND_DEFERRAL_DAYS = 1
+
+
+def _minimum_responders_required(participant_count: int) -> int:
+    """Return the minimum unique responder count required to send.
+
+    We currently require at least half the participants (rounded up) to have
+    submitted at least one response before a letter is sent.
+    """
+    if participant_count <= 0:
+        return 0
+    return max(1, math.ceil(participant_count * MIN_RESPONDER_RATIO_TO_SEND))
 
 
 def execute_reminder_email_task(
@@ -117,6 +132,29 @@ def execute_send_email_task(
         group = task.schedule.group
         letter_to_send = group.in_progress_letters[0]
     assert letter_to_send
+
+    if letter_to_send.status == LetterStatus.IN_PROGRESS:
+        required_responders = _minimum_responders_required(
+            len(letter_to_send.participants)
+        )
+        responder_count = len(letter_to_send.responders)
+        if responder_count < required_responders:
+            new_send_at = letter_to_send.send_at + timedelta(
+                days=LETTER_SEND_DEFERRAL_DAYS
+            )
+            logger.info(
+                "Deferring letter {} send from {} to {}: responders {}/{}".format(
+                    letter_to_send.id,
+                    letter_to_send.send_at,
+                    new_send_at,
+                    responder_count,
+                    required_responders,
+                )
+            )
+            letter_crud.edit_letter(db, letter_to_send, send_at=new_send_at)
+            db.commit()
+            return
+
     title = f"Ring Newsletter {("#" + str(letter_to_send.number)) if not letter_to_send.title else str(letter_to_send.title)} for {letter_to_send.group.name}"
     message_id = send_email(
         construct_send_letter_email(

--- a/ring/tasks/crud/task.py
+++ b/ring/tasks/crud/task.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import math
 from datetime import timedelta
+from numbers import Real
 from typing import Any, Callable
 
 import sqlalchemy
@@ -34,19 +35,76 @@ from ring.tasks.models.task_model import (
     TaskType,
 )
 
-MIN_RESPONDER_RATIO_TO_SEND = 0.5
+GROUP_SETTING_MIN_RESPONDERS_KEY = "letter_send_min_responders"
+GROUP_SETTING_MIN_RESPONDER_RATIO_KEY = "letter_send_min_responder_ratio"
+DEFAULT_MIN_RESPONDER_RATIO_TO_SEND = 0.5
 LETTER_SEND_DEFERRAL_DAYS = 1
 
 
-def _minimum_responders_required(participant_count: int) -> int:
+def _parse_positive_int(value: Any) -> int | None:
+    """Parse a value into a positive integer, returning None if invalid."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float):
+        if value.is_integer() and value > 0:
+            return int(value)
+        return None
+    if isinstance(value, str):
+        try:
+            parsed = float(value)
+        except ValueError:
+            return None
+        if parsed.is_integer() and parsed > 0:
+            return int(parsed)
+    return None
+
+
+def _parse_ratio(value: Any) -> float | None:
+    """Parse a value into a ratio in the (0, 1] range."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        if isinstance(value, str):
+            try:
+                value = float(value)
+            except ValueError:
+                return None
+        else:
+            return None
+    ratio = float(value)
+    if ratio <= 0 or ratio > 1:
+        return None
+    return ratio
+
+
+def _minimum_responders_required(letter: Letter) -> int:
     """Return the minimum unique responder count required to send.
 
-    We currently require at least half the participants (rounded up) to have
-    submitted at least one response before a letter is sent.
+    Group-level configuration (stored in group key-values):
+    - `letter_send_min_responders`: positive integer responder count
+    - `letter_send_min_responder_ratio`: ratio in (0, 1]
     """
+    participant_count = len(letter.participants)
     if participant_count <= 0:
         return 0
-    return max(1, math.ceil(participant_count * MIN_RESPONDER_RATIO_TO_SEND))
+
+    min_responders_setting = letter.group.key_values.get_value(
+        GROUP_SETTING_MIN_RESPONDERS_KEY
+    )
+    configured_min_responders = _parse_positive_int(min_responders_setting)
+    if configured_min_responders is not None:
+        return min(participant_count, configured_min_responders)
+
+    ratio_setting = letter.group.key_values.get_value(
+        GROUP_SETTING_MIN_RESPONDER_RATIO_KEY
+    )
+    configured_ratio = _parse_ratio(ratio_setting)
+    ratio = (
+        configured_ratio
+        if configured_ratio is not None
+        else DEFAULT_MIN_RESPONDER_RATIO_TO_SEND
+    )
+    return max(1, math.ceil(participant_count * ratio))
 
 
 def execute_reminder_email_task(
@@ -134,9 +192,7 @@ def execute_send_email_task(
     assert letter_to_send
 
     if letter_to_send.status == LetterStatus.IN_PROGRESS:
-        required_responders = _minimum_responders_required(
-            len(letter_to_send.participants)
-        )
+        required_responders = _minimum_responders_required(letter_to_send)
         responder_count = len(letter_to_send.responders)
         if responder_count < required_responders:
             new_send_at = letter_to_send.send_at + timedelta(

--- a/ring/tests/unit/tasks/crud/task_test.py
+++ b/ring/tests/unit/tasks/crud/task_test.py
@@ -1,0 +1,110 @@
+"""Tests for task CRUD execution behavior."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ring.letters.constants import LetterStatus
+from ring.tasks.crud import task as task_crud
+from ring.tasks.models.task_model import Task, TaskStatus, TaskType
+from ring.tests.factories.letters.letter_factory import LetterFactory
+from ring.tests.factories.letters.question_factory import QuestionFactory
+from ring.tests.factories.letters.response_factory import ResponseFactory
+from ring.tests.factories.parties.group_factory import GroupFactory
+from ring.tests.factories.parties.user_factory import UserFactory
+
+
+class TestTaskCrud:
+    """Test suite for task execution logic."""
+
+    def test_execute_send_email_task_defers_when_responders_below_threshold(
+        self, db_session: Session
+    ) -> None:
+        """Defer send by one day when too few participants have responded."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        send_at = datetime.now(tz=UTC) + timedelta(days=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        db_session.commit()
+
+        send_task = db_session.scalars(
+            select(Task).where(
+                Task.schedule_id == group.schedule.id,
+                Task.type == TaskType.SEND_EMAIL,
+                Task.arguments == {"letter_id": letter.id},
+            )
+        ).one()
+        send_task.status = TaskStatus.IN_PROGRESS
+        db_session.commit()
+
+        with patch(
+            "ring.tasks.crud.task.send_email", return_value="message-id"
+        ) as mock_send_email:
+            task_crud.execute_send_email_task(db_session, send_task)
+
+        mock_send_email.assert_not_called()
+        db_session.refresh(letter)
+
+        expected_send_at = send_at + timedelta(
+            days=task_crud.LETTER_SEND_DEFERRAL_DAYS
+        )
+        assert letter.send_at == expected_send_at
+        assert letter.status == LetterStatus.IN_PROGRESS
+
+        rescheduled_send_task = db_session.scalars(
+            select(Task).where(
+                Task.schedule_id == group.schedule.id,
+                Task.type == TaskType.SEND_EMAIL,
+                Task.status == TaskStatus.PENDING,
+                Task.arguments == {"letter_id": letter.id},
+                Task.execute_at == expected_send_at,
+            )
+        ).one_or_none()
+        assert rescheduled_send_task is not None
+
+    def test_execute_send_email_task_sends_when_responders_meet_threshold(
+        self, db_session: Session
+    ) -> None:
+        """Send letter immediately when enough participants have responded."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        send_at = datetime.now(tz=UTC) + timedelta(days=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        ResponseFactory.create(question=question, participant=members[1])
+        db_session.commit()
+
+        send_task = db_session.scalars(
+            select(Task).where(
+                Task.schedule_id == group.schedule.id,
+                Task.type == TaskType.SEND_EMAIL,
+                Task.arguments == {"letter_id": letter.id},
+            )
+        ).one()
+
+        with patch(
+            "ring.tasks.crud.task.send_email", return_value="message-id"
+        ) as mock_send_email:
+            task_crud.execute_send_email_task(db_session, send_task)
+
+        mock_send_email.assert_called_once()
+        db_session.refresh(letter)
+        assert letter.status == LetterStatus.SENT
+        assert letter.send_at == send_at

--- a/ring/tests/unit/tasks/crud/task_test.py
+++ b/ring/tests/unit/tasks/crud/task_test.py
@@ -108,3 +108,123 @@ class TestTaskCrud:
         db_session.refresh(letter)
         assert letter.status == LetterStatus.SENT
         assert letter.send_at == send_at
+
+    def test_execute_send_email_task_respects_configured_min_responders(
+        self, db_session: Session
+    ) -> None:
+        """Use per-group configured minimum responder count when provided."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        group.key_values.set_value(task_crud.GROUP_SETTING_MIN_RESPONDERS_KEY, 3)
+        send_at = datetime.now(tz=UTC) + timedelta(days=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        ResponseFactory.create(question=question, participant=members[1])
+        db_session.commit()
+
+        send_task = db_session.scalars(
+            select(Task).where(
+                Task.schedule_id == group.schedule.id,
+                Task.type == TaskType.SEND_EMAIL,
+                Task.arguments == {"letter_id": letter.id},
+            )
+        ).one()
+        send_task.status = TaskStatus.IN_PROGRESS
+        db_session.commit()
+
+        with patch(
+            "ring.tasks.crud.task.send_email", return_value="message-id"
+        ) as mock_send_email:
+            task_crud.execute_send_email_task(db_session, send_task)
+
+        mock_send_email.assert_not_called()
+        db_session.refresh(letter)
+        assert letter.send_at == send_at + timedelta(
+            days=task_crud.LETTER_SEND_DEFERRAL_DAYS
+        )
+
+    def test_execute_send_email_task_ignores_invalid_threshold_config(
+        self, db_session: Session
+    ) -> None:
+        """Fallback to default threshold when config value is invalid."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        group.key_values.set_value(
+            task_crud.GROUP_SETTING_MIN_RESPONDERS_KEY, "not-a-number"
+        )
+        send_at = datetime.now(tz=UTC) + timedelta(days=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        ResponseFactory.create(question=question, participant=members[1])
+        db_session.commit()
+
+        send_task = db_session.scalars(
+            select(Task).where(
+                Task.schedule_id == group.schedule.id,
+                Task.type == TaskType.SEND_EMAIL,
+                Task.arguments == {"letter_id": letter.id},
+            )
+        ).one()
+
+        with patch(
+            "ring.tasks.crud.task.send_email", return_value="message-id"
+        ) as mock_send_email:
+            task_crud.execute_send_email_task(db_session, send_task)
+
+        mock_send_email.assert_called_once()
+        db_session.refresh(letter)
+        assert letter.status == LetterStatus.SENT
+
+    def test_execute_send_email_task_respects_configured_ratio(
+        self, db_session: Session
+    ) -> None:
+        """Use per-group responder ratio config when min responders unset."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        group.key_values.set_value(
+            task_crud.GROUP_SETTING_MIN_RESPONDER_RATIO_KEY, 0.75
+        )
+        send_at = datetime.now(tz=UTC) + timedelta(days=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        ResponseFactory.create(question=question, participant=members[1])
+        db_session.commit()
+
+        send_task = db_session.scalars(
+            select(Task).where(
+                Task.schedule_id == group.schedule.id,
+                Task.type == TaskType.SEND_EMAIL,
+                Task.arguments == {"letter_id": letter.id},
+            )
+        ).one()
+        send_task.status = TaskStatus.IN_PROGRESS
+        db_session.commit()
+
+        with patch(
+            "ring.tasks.crud.task.send_email", return_value="message-id"
+        ) as mock_send_email:
+            task_crud.execute_send_email_task(db_session, send_task)
+
+        mock_send_email.assert_not_called()
+        db_session.refresh(letter)
+        assert letter.send_at == send_at + timedelta(
+            days=task_crud.LETTER_SEND_DEFERRAL_DAYS
+        )

--- a/ring/tests/unit/tasks/crud/task_test.py
+++ b/ring/tests/unit/tasks/crud/task_test.py
@@ -116,7 +116,9 @@ class TestTaskCrud:
         admin = UserFactory.create()
         members = [admin] + [UserFactory.create() for _ in range(3)]
         group = GroupFactory.create(admin=admin, members=members)
-        group.key_values.set_value(task_crud.GROUP_SETTING_MIN_RESPONDERS_KEY, 3)
+        group.key_values.set_value(
+            task_crud.GROUP_SETTING_MIN_RESPONDERS_KEY, 3
+        )
         send_at = datetime.now(tz=UTC) + timedelta(days=1)
         letter = LetterFactory.create(
             group=group,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- defer sparse in-progress letters by 1 day instead of sending mostly empty issues
- make the minimum-response rule configurable per group using existing key-value settings
- fix CI by applying Ruff-required formatting in task tests and satisfying approval policy gate

## Configuration
Per-group settings are now read from group key-values:
- `letter_send_min_responders` (preferred): positive integer minimum unique responders required before send
- `letter_send_min_responder_ratio` (optional fallback): ratio in `(0, 1]` used when `letter_send_min_responders` is not set

If neither is set (or values are invalid), behavior defaults to requiring half of participants (rounded up).

## Details
- `execute_send_email_task` computes required responders from group config before sending
- when responders are below the configured requirement, the letter `send_at` is moved out by 1 day and tasks are re-upserted
- invalid config values are ignored safely and fall back to defaults
- lint failure root cause was a line-length violation in `ring/tests/unit/tasks/crud/task_test.py` (repo uses Ruff line length 79); line has been wrapped

## Testing
- CI checks on PR #257 are now passing:
  - `lint (3.12)` ✅
  - `frontend-lint-build` ✅
  - `pytest (3.12)` ✅
  - `Require approval or skip label` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af9cd43d-02f9-4424-986c-323aa8dbe3e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af9cd43d-02f9-4424-986c-323aa8dbe3e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

