### PR TITLE
Preserve newlines in issue email responses

### DIFF
--- a/ring/tasks/crud/send_email_task.py
+++ b/ring/tasks/crud/send_email_task.py
@@ -7,7 +7,38 @@ in both HTML and plain text versions.
 
 from __future__ import annotations
 
+import html
+import re
+
 from ring.email_util import EmailDraft, construct_email_draft
+
+_URL_RE = re.compile(r"https?://[^\s<>\"]+")
+
+
+def _split_response_display(response_text: str) -> tuple[str | None, str]:
+    """Split a compiled response into participant name and body text."""
+    if ": " in response_text:
+        name, _, body = response_text.partition(": ")
+        return name, body
+    return None, response_text
+
+
+def _linkify_escaped_text(escaped_text: str) -> str:
+    """Turn http(s) URLs in already-escaped text into anchor tags."""
+
+    def replacer(match: re.Match[str]) -> str:
+        url = match.group(0)
+        return (
+            f'<a href="{url}" style="color:#2b6cb0;text-decoration:underline;">'
+            f"{url}</a>"
+        )
+
+    return _URL_RE.sub(replacer, escaped_text)
+
+
+def _format_response_body_html(text: str) -> str:
+    """Format response body text for HTML email bodies."""
+    return _linkify_escaped_text(html.escape(text))
 
 
 def construct_question_html(
@@ -32,7 +63,7 @@ def construct_question_html(
   </ul>
 </div>
 """.format(
-        question=question,
+        question=html.escape(question),
         responses="".join(
             [construct_response_html(response) for response in responses]
         ),
@@ -48,25 +79,40 @@ def construct_response_html(response: tuple[str, list[str]]) -> str:
     Returns:
         str: HTML string containing the formatted response and images
     """
+    participant_name, body = _split_response_display(response[0])
+    name_html = (
+        (
+            '<div style="font-weight:600;font-size:15px;color:#2d3748;'
+            'margin-bottom:4px;">{name}</div>'
+        ).format(name=html.escape(participant_name))
+        if participant_name
+        else ""
+    )
+    body_html = (
+        '<p style="margin:0;font-size:15px;line-height:1.5;color:#1a202c;'
+        'white-space:pre-line;">{text}</p>'
+    ).format(text=_format_response_body_html(body))
     image_htmls = "".join(
         [
             (
                 '<img src="{url}" alt="Image" '
                 'style="display:block; margin:8px 0 0; width:auto; '
                 'height:auto; max-width:100%; border-radius:6px;" />'
-            ).format(url=url)
+            ).format(url=html.escape(url, quote=True))
             for url in response[1]
         ]
     )
     return """
 <li style="margin-bottom: 12px; list-style: none;">
   <div style="padding: 12px 14px; border-radius: 8px; border: 1px solid #e2e8f0; background-color: #ffffff;">
-    <p style="margin: 0; font-size: 15px; line-height: 1.5; color: #1a202c;">{text}</p>
+    {name_html}
+    {body_html}
     {images}
   </div>
 </li>
 """.format(
-        text=response[0],
+        name_html=name_html,
+        body_html=body_html,
         images=image_htmls,
     )
 

--- a/ring/tests/unit/tasks/crud/send_email_task_test.py
+++ b/ring/tests/unit/tasks/crud/send_email_task_test.py
@@ -18,7 +18,7 @@ class TestSendEmailTask:
         html_body = construct_response_html(response)
 
         assert "white-space:pre-line" in html_body
-        assert "Line one\nLine two" not in html_body
+        assert "Line one\nLine two" in html_body
         assert "Line one" in html_body
         assert "Line two" in html_body
         assert "Alice" in html_body

--- a/ring/tests/unit/tasks/crud/send_email_task_test.py
+++ b/ring/tests/unit/tasks/crud/send_email_task_test.py
@@ -1,0 +1,79 @@
+"""Tests for letter send email task construction."""
+
+from __future__ import annotations
+
+from ring.tasks.crud.send_email_task import (
+    construct_question_html,
+    construct_response_html,
+    construct_send_letter_email,
+)
+
+
+class TestSendEmailTask:
+    """Test suite for issue/letter send email formatting."""
+
+    def test_construct_response_html_preserves_newlines(self) -> None:
+        response = ("Alice: Line one\nLine two", [])
+
+        html_body = construct_response_html(response)
+
+        assert "white-space:pre-line" in html_body
+        assert "Line one\nLine two" not in html_body
+        assert "Line one" in html_body
+        assert "Line two" in html_body
+        assert "Alice" in html_body
+
+    def test_construct_response_html_linkifies_urls(self) -> None:
+        response = (
+            "Bob: See https://example.com/path for details",
+            [],
+        )
+
+        html_body = construct_response_html(response)
+
+        assert (
+            '<a href="https://example.com/path" '
+            'style="color:#2b6cb0;text-decoration:underline;">'
+            "https://example.com/path</a>"
+        ) in html_body
+
+    def test_construct_response_html_escapes_html_characters(self) -> None:
+        response = ("Carol: Use <b>tags</b> & ampersands", [])
+
+        html_body = construct_response_html(response)
+
+        assert "&lt;b&gt;tags&lt;/b&gt; &amp; ampersands" in html_body
+        assert "<b>tags</b>" not in html_body
+
+    def test_construct_question_html_escapes_question_text(self) -> None:
+        html_body = construct_question_html(
+            "What is <script>alert(1)</script>?",
+            [],
+        )
+
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html_body
+        assert "<script>" not in html_body
+
+    def test_construct_send_letter_email_includes_formatted_responses(
+        self,
+    ) -> None:
+        letter_dict = {
+            "Favorite memory?": [
+                ("Dana: First line\nSecond line", []),
+            ],
+        }
+
+        email_draft = construct_send_letter_email(
+            ["user@example.com"],
+            "Ring Newsletter #1 for Friends",
+            "lttr_abc123",
+            letter_dict,
+        )
+
+        html_body = email_draft.message["Body"]["Html"]["Data"]
+        text_body = email_draft.message["Body"]["Text"]["Data"]
+
+        assert "white-space:pre-line" in html_body
+        assert "First line" in html_body
+        assert "Second line" in html_body
+        assert "Dana: First line\nSecond line" in text_body


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves formatting of the newsletter/issue email sent when a letter is published.

- Preserves line breaks in response text using `white-space: pre-line`, matching the website's `whitespace-pre-line` behavior
- Splits participant names into a separate heading (like the published letter view)
- Escapes HTML in question/response text
- Linkifies `http(s)` URLs in response bodies

## Test plan

- [x] Added unit tests in `ring/tests/unit/tasks/crud/send_email_task_test.py`
- [ ] `uv run pytest ring/tests/unit/tasks/crud/send_email_task_test.py`
- [ ] Send a test issue email with multi-line responses and confirm formatting in Gmail/Apple Mail
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c92c2f8-a050-4b77-80da-7d5777b46fbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c92c2f8-a050-4b77-80da-7d5777b46fbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

