### PR TITLE
feat: minimum responder percentage before send

### DIFF
--- a/react/openapi.json
+++ b/react/openapi.json
@@ -12,7 +12,9 @@
   "paths": {
     "/login/access-token": {
       "post": {
-        "tags": ["login"],
+        "tags": [
+          "login"
+        ],
         "summary": "Login Access Token",
         "description": "Authenticate user and generate access token.\n\nValidates user credentials and generates a JWT access token for authenticated sessions.\n\nArgs:\n    form_data (OAuth2PasswordRequestForm): OAuth2 password request form containing username and password\n    req_dep (RequestDependenciesBase): Request dependencies including database session\n\nReturns:\n    Token: JWT access token with bearer type\n\nRaises:\n    HTTPException: 400 if credentials are invalid",
         "operationId": "login_access_token_login_access_token_post",
@@ -52,7 +54,9 @@
     },
     "/impersonate-user-token": {
       "post": {
-        "tags": ["login"],
+        "tags": [
+          "login"
+        ],
         "summary": "Impersonate User Token",
         "operationId": "impersonate_user_token_impersonate_user_token_post",
         "security": [
@@ -97,7 +101,9 @@
     },
     "/login/test-token": {
       "post": {
-        "tags": ["login"],
+        "tags": [
+          "login"
+        ],
         "summary": "Test Token",
         "description": "Test endpoint for validating access tokens.\n\nThis endpoint is deprecated and will be removed in future versions.\n\nRaises:\n    NotImplementedError: Always raises this error as the endpoint is deprecated",
         "operationId": "test_token_login_test_token_post",
@@ -119,7 +125,9 @@
     },
     "/reset-password:request/{email}": {
       "post": {
-        "tags": ["login"],
+        "tags": [
+          "login"
+        ],
         "summary": "Reset Password Request",
         "description": "Initiate password reset process for a user.\n\nGenerates a one-time token and sends a password reset email to the user.\n\nArgs:\n    email (str): User's email address\n    req_dep (RequestDependenciesBase): Request dependencies including database session\n\nReturns:\n    ResponseMessage: Confirmation message of email sent\n\nRaises:\n    HTTPException: 400 if user with email doesn't exist",
         "operationId": "reset_password_request_reset_password_request__email__post",
@@ -160,7 +168,9 @@
     },
     "/reset-password/{token}": {
       "post": {
-        "tags": ["login"],
+        "tags": [
+          "login"
+        ],
         "summary": "Reset Password",
         "description": "Reset user's password using a valid reset token.\n\nValidates the reset token and updates the user's password if token is valid.\n\nArgs:\n    token (str): Password reset token\n    new_password_data (NewPassword): New password data\n    req_dep (RequestDependenciesBase): Request dependencies including database session\n\nReturns:\n    ResponseMessage: Confirmation message of password update\n\nRaises:\n    HTTPException: 400 if token is invalid, expired, or already used",
         "operationId": "reset_password_reset_password__token__post",
@@ -211,7 +221,9 @@
     },
     "/password-recovery-html-content/{email}": {
       "post": {
-        "tags": ["login"],
+        "tags": [
+          "login"
+        ],
         "summary": "Recover Password Html Content",
         "description": "Generate HTML content for password recovery email.\n\nThis endpoint is deprecated and will be removed in future versions.\n\nArgs:\n    email (str): User's email address\n\nRaises:\n    NotImplementedError: Always raises this error as the endpoint is deprecated",
         "operationId": "recover_password_html_content_password_recovery_html_content__email__post",
@@ -254,7 +266,9 @@
     },
     "/parties/me": {
       "get": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Read User Me",
         "description": "Get the current authenticated user's information.\n\nArgs:\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    User: Current user's information",
         "operationId": "read_user_me_parties_me_get",
@@ -277,7 +291,9 @@
         ]
       },
       "delete": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Delete User Me",
         "description": "Delete current user (deprecated).\n\nNote:\n    This endpoint is not implemented and is deprecated.",
         "operationId": "delete_user_me_parties_me_delete",
@@ -297,7 +313,9 @@
         "deprecated": true
       },
       "patch": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Update User Me",
         "description": "Update current user's information.\n\nArgs:\n    current_user_update_data (UserUpdate): User update parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    User: Updated user information\n\nRaises:\n    HTTPException: If new email is already registered by another user",
         "operationId": "update_user_me_parties_me_patch",
@@ -342,7 +360,9 @@
     },
     "/parties/user": {
       "post": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Create User",
         "description": "Create a new user (deprecated).\n\nArgs:\n    user (UserCreate): User creation parameters\n    req_dep (RequestDependenciesBase): Request dependencies\n\nReturns:\n    User: Created user\n\nRaises:\n    HTTPException: If email is already registered\n\nNote:\n    This endpoint is deprecated. Use /register/{token} instead.",
         "operationId": "create_user_parties_user_post",
@@ -383,7 +403,9 @@
     },
     "/parties/register/{token}": {
       "post": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Register User",
         "description": "Register a new user with an invite token.\n\nArgs:\n    token (str): Invite token\n    user (UserCreate): User creation parameters\n    req_dep (RequestDependenciesBase): Request dependencies\n\nReturns:\n    User: Created user\n\nRaises:\n    HTTPException: If token is invalid, expired, already used, or email mismatch",
         "operationId": "register_user_parties_register__token__post",
@@ -434,7 +456,9 @@
     },
     "/parties/users": {
       "get": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Read Users",
         "description": "Get a list of users with pagination.\n\nArgs:\n    skip (int, optional): Number of records to skip. Defaults to 0.\n    limit (int, optional): Maximum number of records to return. Defaults to 100.\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Sequence[User]: List of users",
         "operationId": "read_users_parties_users_get",
@@ -495,7 +519,9 @@
     },
     "/parties/user/{user_api_id}": {
       "get": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Read User By Id",
         "description": "Get a user by their API identifier.\n\nArgs:\n    user_api_id (str): API identifier of the user\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    User: User information\n\nRaises:\n    HTTPException: If user not found",
         "operationId": "read_user_by_id_parties_user__user_api_id__get",
@@ -541,7 +567,9 @@
     },
     "/parties/me/password": {
       "patch": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Update Password Me",
         "description": "Update current user's password.\n\nArgs:\n    update_password_data (UserUpdatePassword): Password update parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    ResponseMessage: Success message\n\nRaises:\n    HTTPException: If current password is incorrect or new password is same as current",
         "operationId": "update_password_me_parties_me_password_patch",
@@ -586,7 +614,9 @@
     },
     "/parties/{user_api_id}/admin": {
       "patch": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Update User Admin",
         "description": "Update a user's admin status.\n\nArgs:\n    user_api_id (str): API identifier of the user to update\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    ResponseMessage: Success message\n\nRaises:\n    HTTPException: If user is not an admin",
         "operationId": "update_user_admin_parties__user_api_id__admin_patch",
@@ -632,7 +662,9 @@
     },
     "/parties/signup": {
       "post": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Signup",
         "description": "Sign up a new user without invitation (deprecated).\n\nNote:\n    This endpoint is not implemented and is deprecated.",
         "operationId": "signup_parties_signup_post",
@@ -654,7 +686,9 @@
     },
     "/parties/{user_id}": {
       "delete": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Delete User",
         "description": "Delete any user (deprecated).\n\nNote:\n    This endpoint is not implemented and is deprecated.",
         "operationId": "delete_user_parties__user_id__delete",
@@ -674,7 +708,9 @@
         "deprecated": true
       },
       "patch": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Update User",
         "description": "Update any user (deprecated).\n\nNote:\n    This endpoint is not implemented and is deprecated.",
         "operationId": "update_user_parties__user_id__patch",
@@ -696,7 +732,9 @@
     },
     "/parties/group": {
       "post": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Create Group",
         "description": "Create a new group.\n\nArgs:\n    group (GroupCreate): Group creation parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Created group\n\nRaises:\n    HTTPException: If group creation fails",
         "operationId": "create_group_parties_group_post",
@@ -741,7 +779,9 @@
     },
     "/parties/groups/": {
       "get": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "List Groups",
         "description": "List all groups a user is a member of.\n\nArgs:\n    user_api_id (str): API identifier of the user\n    skip (int, optional): Number of records to skip. Defaults to 0.\n    limit (int, optional): Maximum number of records to return. Defaults to 100.\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Sequence[Group]: List of groups",
         "operationId": "list_groups_parties_groups__get",
@@ -811,7 +851,9 @@
     },
     "/parties/group/{group_api_id}": {
       "get": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Read Group",
         "description": "Get details of a specific group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Group details\n\nRaises:\n    HTTPException: If group not found or user is not a member",
         "operationId": "read_group_parties_group__group_api_id__get",
@@ -855,7 +897,9 @@
         }
       },
       "patch": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Update Group",
         "description": "Update group information.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    group (GroupUpdate): Group update parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Updated group\n\nRaises:\n    HTTPException: If no updates provided, user not authorized, or invalid cycle length",
         "operationId": "update_group_parties_group__group_api_id__patch",
@@ -911,7 +955,9 @@
     },
     "/parties/group/{group_api_id}:add_member/{user_api_id}": {
       "post": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Add User To Group",
         "description": "Add a user to a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    user_api_id (str): API identifier of the user to add\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Updated group\n\nRaises:\n    HTTPException: If group or user not found",
         "operationId": "add_user_to_group_parties_group__group_api_id__add_member__user_api_id__post",
@@ -966,7 +1012,9 @@
     },
     "/parties/group/{group_api_id}:remove_member/{user_api_id}": {
       "post": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Remove User From Group",
         "description": "Remove a user from a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    user_api_id (str): API identifier of the user to remove\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Updated group\n\nRaises:\n    HTTPException: If group not found, user not authorized, or invalid operation",
         "operationId": "remove_user_from_group_parties_group__group_api_id__remove_member__user_api_id__post",
@@ -1021,7 +1069,9 @@
     },
     "/parties/group/{group_api_id}:add_members": {
       "post": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Add Members",
         "description": "Add multiple members to a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    add_members (AddMembers): List of email addresses to invite\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Updated group\n\nNote:\n    - Existing users will be added directly to the group\n    - Non-registered users will receive email invitations\n    - New members are automatically added to in-progress and upcoming letters",
         "operationId": "add_members_parties_group__group_api_id__add_members_post",
@@ -1077,7 +1127,9 @@
     },
     "/parties/group/{group_api_id}:replace_default_questions": {
       "post": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Replace Group Default Questions",
         "description": "Replace a group's default questions.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    default_questions (ReplaceDefaultQuestions): New list of default questions\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Updated group\n\nRaises:\n    HTTPException: If group not found or user not authorized",
         "operationId": "replace_group_default_questions_parties_group__group_api_id__replace_default_questions_post",
@@ -1133,7 +1185,9 @@
     },
     "/parties/group/{group_api_id}/key-value": {
       "get": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Read Group Key Values",
         "description": "Get all key-value pairs for a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    GroupKeyValue: Dictionary of all key-value pairs\n\nRaises:\n    HTTPException: If group not found or user is not a member",
         "operationId": "read_group_key_values_parties_group__group_api_id__key_value_get",
@@ -1177,7 +1231,9 @@
         }
       },
       "put": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Full Replace Group Key Values",
         "description": "Replace all key-value pairs for a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    updates (GroupKeyValue): New key-value pairs\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    GroupKeyValue: Updated key-value pairs\n\nRaises:\n    HTTPException: If group not found or user is not a member",
         "operationId": "full_replace_group_key_values_parties_group__group_api_id__key_value_put",
@@ -1233,7 +1289,9 @@
     },
     "/parties/group/{group_api_id}/key-value/{key}": {
       "get": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Read Group Key Value",
         "description": "Get a specific key-value pair for a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    key (str): Key to retrieve\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    GroupKeyValueBase: Key-value pair\n\nRaises:\n    HTTPException: If group not found or user is not a member",
         "operationId": "read_group_key_value_parties_group__group_api_id__key_value__key__get",
@@ -1288,7 +1346,9 @@
     },
     "/parties/group/{group_api_id}/key-value:update": {
       "post": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Upsert Group Key Value",
         "description": "Update or delete a single key-value pair for a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    update (SingleGroupKeyValueUpdate): Update operation details\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    GroupKeyValueBase: Updated key-value pair\n\nRaises:\n    HTTPException: If group not found or user is not a member",
         "operationId": "upsert_group_key_value_parties_group__group_api_id__key_value_update_post",
@@ -1344,7 +1404,9 @@
     },
     "/parties/group/{group_api_id}/key-value:bulk-update": {
       "post": {
-        "tags": ["parties"],
+        "tags": [
+          "parties"
+        ],
         "summary": "Bulk Update Group Key Values",
         "description": "Update or delete multiple key-value pairs for a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    updates (BulkGroupKeyValueUpdate): List of update operations\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    GroupKeyValue: All key-value pairs after updates\n\nRaises:\n    HTTPException: If group not found or user is not a member",
         "operationId": "bulk_update_group_key_values_parties_group__group_api_id__key_value_bulk_update_post",
@@ -1400,7 +1462,9 @@
     },
     "/letters/letter": {
       "post": {
-        "tags": ["letters"],
+        "tags": [
+          "letters"
+        ],
         "summary": "Add Next Letter",
         "description": "Create a new letter for a group.\n\nCreates a new letter with default questions if there are no letters\ncurrently in progress or upcoming for the group.\n\nArgs:\n    letter (LetterCreate): Letter creation parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Letter: Newly created letter\n\nRaises:\n    ValueError: If there is already a letter in progress or upcoming",
         "operationId": "add_next_letter_letters_letter_post",
@@ -1445,7 +1509,9 @@
     },
     "/letters/letter:{letter_type}": {
       "post": {
-        "tags": ["letters"],
+        "tags": [
+          "letters"
+        ],
         "summary": "Add Next Letter",
         "operationId": "add_next_letter_letters_letter__letter_type__post",
         "security": [
@@ -1499,7 +1565,9 @@
     },
     "/letters/letters/": {
       "get": {
-        "tags": ["letters"],
+        "tags": [
+          "letters"
+        ],
         "summary": "List Letters",
         "description": "List letters for a specific group.\n\nRetrieves a paginated list of letters belonging to the specified group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    skip (int, optional): Number of records to skip for pagination. Defaults to 0.\n    limit (int, optional): Maximum number of records to return. Defaults to 100.\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Sequence[Letter]: List of letters",
         "operationId": "list_letters_letters_letters__get",
@@ -1585,7 +1653,9 @@
     },
     "/letters/letter/{letter_api_id}": {
       "get": {
-        "tags": ["letters"],
+        "tags": [
+          "letters"
+        ],
         "summary": "Read Letter",
         "description": "Retrieve a specific letter by its API identifier.\n\nArgs:\n    letter_api_id (str): API identifier of the letter\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Letter: The requested letter\n\nRaises:\n    IDNotFoundException: If letter with given API ID is not found",
         "operationId": "read_letter_letters_letter__letter_api_id__get",
@@ -1631,7 +1701,9 @@
     },
     "/letters/letters:dashboard": {
       "get": {
-        "tags": ["letters"],
+        "tags": [
+          "letters"
+        ],
         "summary": "List Dashboard Letters",
         "description": "List letters for the dashboard view.\n\nRetrieves letters that are upcoming, in progress, or recently completed\n(within the last 8 days) for the current user.\n\nArgs:\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    dict[str, list[Letter]]: Dictionary containing categorized letters",
         "operationId": "list_dashboard_letters_letters_letters_dashboard_get",
@@ -1656,7 +1728,9 @@
     },
     "/letters/letter/{letter_api_id}:edit_letter": {
       "post": {
-        "tags": ["letters"],
+        "tags": [
+          "letters"
+        ],
         "summary": "Edit Letter",
         "description": "Update a letter's details.\n\nUpdates the send time of a letter. For upcoming letters, ensures the new\nsend time is after any in-progress letter's send time.\n\nArgs:\n    letter_api_id (str): API identifier of the letter to edit\n    letter (LetterUpdate): Updated letter details\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Letter: Updated letter\n\nRaises:\n    AssertionError: If new send time violates timing constraints\n    IDNotFoundException: If letter with given API ID is not found",
         "operationId": "edit_letter_letters_letter__letter_api_id__edit_letter_post",
@@ -1712,7 +1786,9 @@
     },
     "/letters/letter/{letter_api_id}:add_question": {
       "post": {
-        "tags": ["letters"],
+        "tags": [
+          "letters"
+        ],
         "summary": "Add Question",
         "description": "Add a new question to a letter.\n\nCreates and adds a new question to the specified letter. The question can\noptionally be associated with an author.\n\n:param letter_api_id: API identifier of the letter\n:type letter_api_id: str\n:param question: Question creation parameters\n:type question: QuestionCreate\n:param req_dep: Request dependencies including database session and auth\n:type req_dep: AuthenticatedRequestDependencies\n:raises IDNotFoundException: If letter or author with given API ID is not found\n:return: Updated letter with the new question\n:rtype: Letter",
         "operationId": "add_question_letters_letter__letter_api_id__add_question_post",
@@ -1768,7 +1844,9 @@
     },
     "/letters/letter/{letter_api_id}:generate_question": {
       "post": {
-        "tags": ["letters"],
+        "tags": [
+          "letters"
+        ],
         "summary": "Generate Question",
         "description": "Generate a question using LLM without saving it.",
         "operationId": "generate_question_letters_letter__letter_api_id__generate_question_post",
@@ -1824,7 +1902,9 @@
     },
     "/schedule/schedule/{group_api_id}": {
       "get": {
-        "tags": ["schedule"],
+        "tags": [
+          "schedule"
+        ],
         "summary": "Get Schedule For Group",
         "description": "Get a group's schedule by its API identifier.\n\nArgs:\n    group_api_id: API identifier of the group\n    req_dep: Request dependencies including database session\n\nReturns:\n    Schedule: The group's schedule with its associated tasks\n\nRaises:\n    HTTPException: If the group is not found or user lacks permission",
         "operationId": "get_schedule_for_group_schedule_schedule__group_api_id__get",
@@ -1870,7 +1950,9 @@
     },
     "/questions/question/{question_api_id}:upsert_response": {
       "post": {
-        "tags": ["questions"],
+        "tags": [
+          "questions"
+        ],
         "summary": "Upsert Response",
         "description": "Create or update a response to a question.\n\nIf a response already exists (identified by api_identifier or participant),\nupdates it. Otherwise, creates a new response.\n\nArgs:\n    question_api_id (str): API identifier of the question\n    response (ResponseUpsert): Response creation/update parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Question: Updated question with the new/updated response\n\nRaises:\n    IDNotFoundException: If question or response with given API ID is not found",
         "operationId": "upsert_response_questions_question__question_api_id__upsert_response_post",
@@ -1926,7 +2008,9 @@
     },
     "/questions/question/{question_api_id}:upload_image": {
       "post": {
-        "tags": ["questions"],
+        "tags": [
+          "questions"
+        ],
         "summary": "Upload Image",
         "description": "Upload an image as part of a response to a question.\n\nCreates a new response if one doesn't exist for the current user,\nthen attaches the uploaded image to it.\n\nArgs:\n    question_api_id (str): API identifier of the question\n    response_image (UploadFile): Image file to upload\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Question: Updated question with the response containing the new image\n\nRaises:\n    IDNotFoundException: If question with given API ID is not found",
         "operationId": "upload_image_questions_question__question_api_id__upload_image_post",
@@ -1982,7 +2066,9 @@
     },
     "/questions/question/{question_api_id}": {
       "delete": {
-        "tags": ["questions"],
+        "tags": [
+          "questions"
+        ],
         "summary": "Delete Question",
         "description": "Delete a question.\n\nOnly the question author or group admin can delete a question.\nQuestions with responses cannot be deleted.\n\nArgs:\n    question_api_id (str): API identifier of the question to delete\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nRaises:\n    HTTPException: If question not found, user not authorized, or question has responses",
         "operationId": "delete_question_questions_question__question_api_id__delete",
@@ -2021,7 +2107,9 @@
     },
     "/responses/response/{response_api_id}:edit_response": {
       "post": {
-        "tags": ["responses"],
+        "tags": [
+          "responses"
+        ],
         "summary": "Edit Response",
         "description": "Update the text content of a response.\n\nArgs:\n    response_api_id (str): API identifier of the response to edit\n    response (ResponseCreateBase): Updated response content\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Response: Updated response\n\nRaises:\n    IDNotFoundException: If response with given API ID is not found",
         "operationId": "edit_response_responses_response__response_api_id__edit_response_post",
@@ -2077,7 +2165,9 @@
     },
     "/responses/response/{response_api_id}:upload_image": {
       "post": {
-        "tags": ["responses"],
+        "tags": [
+          "responses"
+        ],
         "summary": "Upload Image",
         "description": "Upload images to attach to a response.\n\nThis endpoint is deprecated. Use the question-level image upload endpoint instead.\n\nArgs:\n    response_api_id (str): API identifier of the response\n    response_images (list[UploadFile]): List of image files to upload\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Response: Updated response with attached images\n\nRaises:\n    IDNotFoundException: If response with given API ID is not found",
         "operationId": "upload_image_responses_response__response_api_id__upload_image_post",
@@ -2134,7 +2224,9 @@
     },
     "/responses/response/{response_api_id}:delete_image": {
       "delete": {
-        "tags": ["responses"],
+        "tags": [
+          "responses"
+        ],
         "summary": "Delete Image",
         "description": "Delete an image from a response.\n\nRemoves the image association and deletes the Image model row.\nThe S3 file is not deleted to avoid data loss.\n\nArgs:\n    response_api_id (str): API identifier of the response\n    s3_url (str): S3 URL of the image to delete\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Response: Updated response without the deleted image\n\nRaises:\n    IDNotFoundException: If response with given API ID is not found\n    ValueError: If image is not found in the response",
         "operationId": "delete_image_responses_response__response_api_id__delete_image_delete",
@@ -2189,7 +2281,9 @@
     },
     "/invites/": {
       "post": {
-        "tags": ["invites"],
+        "tags": [
+          "invites"
+        ],
         "summary": "Create Invite",
         "description": "Create a new invite for a user to join a group.\n\nArgs:\n    invite (InviteCreate): Invite creation parameters including email and group_api_id\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Invite: Created invite\n\nRaises:\n    HTTPException: If email is already invited, already registered, or group not found",
         "operationId": "create_invite_invites__post",
@@ -2234,7 +2328,9 @@
     },
     "/invites/token/{token}": {
       "get": {
-        "tags": ["invites"],
+        "tags": [
+          "invites"
+        ],
         "summary": "Validate Token",
         "description": "Validate an invite token and return the associated invite.\n\nArgs:\n    token (str): The invite token to validate\n    req_dep (RequestDependenciesBase): Request dependencies\n\nReturns:\n    Invite: The invite associated with the token\n\nRaises:\n    HTTPException: If token is invalid, expired, or already used",
         "operationId": "validate_token_invites_token__token__get",
@@ -2275,7 +2371,9 @@
     },
     "/notifications/subscription": {
       "post": {
-        "tags": ["notifications"],
+        "tags": [
+          "notifications"
+        ],
         "summary": "Post Subscription",
         "description": "Create a new web push notification subscription.\n\nCreates a subscription for the authenticated user to receive web push\nnotifications. If a subscription with the same endpoint already exists,\nreturns a message indicating this instead of creating a duplicate.\n\nArgs:\n    subscription (SubscriptionCreate): Subscription details including endpoint and keys\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session\n\nReturns:\n    ResponseMessage: Message indicating success or existing subscription\n\nRaises:\n    HTTPException: If user is not authenticated",
         "operationId": "post_subscription_notifications_subscription_post",
@@ -2320,7 +2418,9 @@
     },
     "/llm/completion": {
       "post": {
-        "tags": ["llm"],
+        "tags": [
+          "llm"
+        ],
         "summary": "Generate Completion",
         "description": "Generate a completion for the given request.\n\nGenerates a completion for the given request.\n\nArgs:\n    completion_request (CompletionRequest): Completion request details\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session\n\nReturns:\n    CompletionResponse: Completion response details\n\nRaises:\n    HTTPException: If user is not authenticated",
         "operationId": "generate_completion_llm_completion_post",
@@ -2365,7 +2465,9 @@
     },
     "/search/raw-search": {
       "get": {
-        "tags": ["search"],
+        "tags": [
+          "search"
+        ],
         "summary": "Raw Search",
         "description": "Search the search table for a given query.\n\nArgs:\n    query: The search query string\n    search_type: Type of search to perform (semantic, keyword, or dual)\n    limit: Maximum number of results to return\n    db: Database session\n\nReturns:\n    RawSearchResponse containing matching results and total count",
         "operationId": "raw_search_search_raw_search_get",
@@ -2425,7 +2527,9 @@
     },
     "/search/search": {
       "get": {
-        "tags": ["search"],
+        "tags": [
+          "search"
+        ],
         "summary": "Perform Search",
         "operationId": "perform_search_search_search_get",
         "security": [
@@ -2489,7 +2593,9 @@
     },
     "/notebook/documents": {
       "post": {
-        "tags": ["notebook"],
+        "tags": [
+          "notebook"
+        ],
         "summary": "Create Document Endpoint",
         "description": "Create a new document.\n\nArgs:\n    document (DocumentCreate): Document creation parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Document: Newly created document",
         "operationId": "create_document_endpoint_notebook_documents_post",
@@ -2532,7 +2638,9 @@
         }
       },
       "get": {
-        "tags": ["notebook"],
+        "tags": [
+          "notebook"
+        ],
         "summary": "List Documents",
         "description": "List documents for a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    List[Document]: List of documents",
         "operationId": "list_documents_notebook_documents_get",
@@ -2582,7 +2690,9 @@
     },
     "/notebook/documents/{document_api_id}": {
       "get": {
-        "tags": ["notebook"],
+        "tags": [
+          "notebook"
+        ],
         "summary": "Get Document Endpoint",
         "description": "Get a document by its API identifier.\n\nArgs:\n    document_api_id (str): API identifier of the document\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Document: The requested document\n\nRaises:\n    IDNotFoundException: If document with given API ID is not found",
         "operationId": "get_document_endpoint_notebook_documents__document_api_id__get",
@@ -2626,7 +2736,9 @@
         }
       },
       "put": {
-        "tags": ["notebook"],
+        "tags": [
+          "notebook"
+        ],
         "summary": "Update Document Endpoint",
         "description": "Update a document.\n\nArgs:\n    document_api_id (str): API identifier of the document\n    document_update (DocumentUpdate): Document update parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Document: Updated document\n\nRaises:\n    IDNotFoundException: If document with given API ID is not found",
         "operationId": "update_document_endpoint_notebook_documents__document_api_id__put",
@@ -2740,7 +2852,9 @@
           }
         },
         "type": "object",
-        "required": ["member_emails"],
+        "required": [
+          "member_emails"
+        ],
         "title": "AddMembers",
         "description": "Schema for adding members to a group.\n\nAttributes:\n    member_emails (list[str]): List of email addresses to invite"
       },
@@ -2795,7 +2909,10 @@
           }
         },
         "type": "object",
-        "required": ["username", "password"],
+        "required": [
+          "username",
+          "password"
+        ],
         "title": "Body_login_access_token_login_access_token_post"
       },
       "Body_upload_image_questions_question__question_api_id__upload_image_post": {
@@ -2807,7 +2924,9 @@
           }
         },
         "type": "object",
-        "required": ["response_image"],
+        "required": [
+          "response_image"
+        ],
         "title": "Body_upload_image_questions_question__question_api_id__upload_image_post"
       },
       "Body_upload_image_responses_response__response_api_id__upload_image_post": {
@@ -2822,7 +2941,9 @@
           }
         },
         "type": "object",
-        "required": ["response_images"],
+        "required": [
+          "response_images"
+        ],
         "title": "Body_upload_image_responses_response__response_api_id__upload_image_post"
       },
       "BulkGroupKeyValueUpdate": {
@@ -2838,7 +2959,9 @@
           }
         },
         "type": "object",
-        "required": ["updates"],
+        "required": [
+          "updates"
+        ],
         "title": "BulkGroupKeyValueUpdate",
         "description": "Schema for bulk updating multiple key-value pairs.\n\nThis model allows multiple key-value operations to be performed in a single request.\nEach update in the list can be either a 'set' or 'delete' operation.\n\nAttributes:\n    updates (list[SingleGroupKeyValueUpdate]): List of update operations to perform\n\nNote:\n    At least one update operation must be provided"
       },
@@ -2850,7 +2973,9 @@
           }
         },
         "type": "object",
-        "required": ["prompt"],
+        "required": [
+          "prompt"
+        ],
         "title": "CompletionRequest"
       },
       "CompletionResponse": {
@@ -2861,7 +2986,9 @@
           }
         },
         "type": "object",
-        "required": ["text"],
+        "required": [
+          "text"
+        ],
         "title": "CompletionResponse"
       },
       "DashboardLetters": {
@@ -2889,7 +3016,11 @@
           }
         },
         "type": "object",
-        "required": ["upcoming", "in_progress", "recently_completed"],
+        "required": [
+          "upcoming",
+          "in_progress",
+          "recently_completed"
+        ],
         "title": "DashboardLetters",
         "description": "Model for the letters dashboard view.\n\nGroups letters by their status for dashboard display.\n\nAttributes:\n    upcoming (list[PublicLetter]): Letters scheduled for the future\n    in_progress (list[PublicLetter]): Currently active letters\n    recently_completed (list[PublicLetter]): Recently finished letters"
       },
@@ -2912,7 +3043,11 @@
           }
         },
         "type": "object",
-        "required": ["name", "content", "group_api_id"],
+        "required": [
+          "name",
+          "content",
+          "group_api_id"
+        ],
         "title": "DocumentCreate",
         "description": "Schema for creating a new document."
       },
@@ -3008,7 +3143,9 @@
           }
         },
         "type": "object",
-        "required": ["prompt"],
+        "required": [
+          "prompt"
+        ],
         "title": "GenerateQuestionRequest"
       },
       "GenerateQuestionResponse": {
@@ -3019,7 +3156,9 @@
           }
         },
         "type": "object",
-        "required": ["generated_text"],
+        "required": [
+          "generated_text"
+        ],
         "title": "GenerateQuestionResponse"
       },
       "GroupCreate": {
@@ -3034,7 +3173,10 @@
           }
         },
         "type": "object",
-        "required": ["name", "admin_api_identifier"],
+        "required": [
+          "name",
+          "admin_api_identifier"
+        ],
         "title": "GroupCreate",
         "description": "Schema for creating a new group.\n\nAttributes:\n    name (str): Name of the group (inherited from GroupBase)\n    admin_api_identifier (str): API identifier of the user who will be admin"
       },
@@ -3048,7 +3190,9 @@
           }
         },
         "type": "object",
-        "required": ["key_values"],
+        "required": [
+          "key_values"
+        ],
         "title": "GroupKeyValue",
         "description": "Schema for group key-value responses.\n\nThis model represents the complete key-value store for a group, containing\nall key-value pairs in a dictionary format.\n\nAttributes:\n    key_values (dict[str, Any]): Dictionary containing all key-value pairs for the group"
       },
@@ -3065,7 +3209,10 @@
           }
         },
         "type": "object",
-        "required": ["key", "value"],
+        "required": [
+          "key",
+          "value"
+        ],
         "title": "GroupKeyValueBase",
         "description": "Base schema for group key-value operations.\n\nThis is the base model that defines the fundamental structure of a key-value pair.\nIt is used as a building block for other key-value related schemas.\n\nAttributes:\n    key (str): The key identifier for the value\n    value (Any): The value associated with the key, can be any JSON-serializable type"
       },
@@ -3087,6 +3234,17 @@
           "cycle_length": {
             "type": "integer",
             "title": "Cycle Length"
+          },
+          "min_responder_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Responder Ratio"
           },
           "members": {
             "items": {
@@ -3156,10 +3314,26 @@
           "cycle_length": {
             "type": "integer",
             "title": "Cycle Length"
+          },
+          "min_responder_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Responder Ratio"
           }
         },
         "type": "object",
-        "required": ["name", "api_identifier", "created_at", "cycle_length"],
+        "required": [
+          "name",
+          "api_identifier",
+          "created_at",
+          "cycle_length"
+        ],
         "title": "GroupUnlinked",
         "description": "Schema for groups without linked relationships.\n\nInherits all fields from Group but excludes relationship data."
       },
@@ -3186,11 +3360,22 @@
               }
             ],
             "title": "Cycle Length"
+          },
+          "min_responder_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Responder Ratio"
           }
         },
         "type": "object",
         "title": "GroupUpdate",
-        "description": "Schema for updating an existing group.\n\nAttributes:\n    name (str | None): New name for the group, optional\n    cycle_length (int | None): New cycle length in days, optional"
+        "description": "Schema for updating an existing group.\n\nAttributes:\n    name (str | None): New name for the group, optional\n    cycle_length (int | None): New cycle length in days, optional\n    min_responder_ratio (float | None): Minimum share of participants who\n        must respond before send (0-1). Use 0 to disable deferral. Omit or\n        set null to use the default (0.5)."
       },
       "HTTPValidationError": {
         "properties": {
@@ -3216,7 +3401,10 @@
           }
         },
         "type": "object",
-        "required": ["s3_url", "media_type"],
+        "required": [
+          "s3_url",
+          "media_type"
+        ],
         "title": "Image",
         "description": "Schema for image data.\n\nRepresents an image stored in S3 with its media type.\n\nAttributes:\n    s3_url (str): S3 key/path for the image\n    media_type (MediaType): Type of media (image/video)"
       },
@@ -3232,7 +3420,10 @@
           }
         },
         "type": "object",
-        "required": ["email", "group_api_id"],
+        "required": [
+          "email",
+          "group_api_id"
+        ],
         "title": "InviteCreate",
         "description": "Schema for creating a new invite.\n\nAttributes:\n    email (str): Email address of the invitee (inherited from InviteBase)\n    group_api_id (str): API identifier of the group to invite to"
       },
@@ -3307,19 +3498,29 @@
           }
         },
         "type": "object",
-        "required": ["group_api_identifier", "send_at"],
+        "required": [
+          "group_api_identifier",
+          "send_at"
+        ],
         "title": "LetterCreate",
         "description": "Schema for creating a new letter.\n\nAttributes:\n    group_api_identifier (str): API identifier of the group to create the letter for\n    send_at (AwareDatetime): Scheduled time to send the letter"
       },
       "LetterStatus": {
         "type": "string",
-        "enum": ["UPCOMING", "IN_PROGRESS", "SENT"],
+        "enum": [
+          "UPCOMING",
+          "IN_PROGRESS",
+          "SENT"
+        ],
         "title": "LetterStatus",
         "description": "Enumeration of possible letter statuses.\nRepresents the different states a letter can be in within the system:\n- UPCOMING: Letter is scheduled but not yet active\n- IN_PROGRESS: Letter is currently active and accepting responses\n- SENT: Letter has been completed and sent"
       },
       "LetterType": {
         "type": "string",
-        "enum": ["CYCLIC", "ADHOC"],
+        "enum": [
+          "CYCLIC",
+          "ADHOC"
+        ],
         "title": "LetterType",
         "description": ""
       },
@@ -3421,7 +3622,10 @@
       },
       "MediaType": {
         "type": "string",
-        "enum": ["image", "video"],
+        "enum": [
+          "image",
+          "video"
+        ],
         "title": "MediaType",
         "description": "Enumeration of supported media types.\n\nAttributes:\n    IMAGE: Image files (e.g., jpg, png)\n    VIDEO: Video files"
       },
@@ -3471,6 +3675,34 @@
           },
           "group": {
             "$ref": "#/components/schemas/GroupUnlinked"
+          },
+          "responders": {
+            "items": {
+              "$ref": "#/components/schemas/UserUnlinked"
+            },
+            "type": "array",
+            "title": "Responders"
+          },
+          "required_responders": {
+            "type": "integer",
+            "title": "Required Responders",
+            "default": 0
+          },
+          "responder_count": {
+            "type": "integer",
+            "title": "Responder Count",
+            "default": 0
+          },
+          "send_threshold_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Send Threshold Ratio"
           }
         },
         "type": "object",
@@ -3480,10 +3712,11 @@
           "send_at",
           "created_at",
           "letter_type",
-          "group"
+          "group",
+          "responders"
         ],
         "title": "MinimalLetter",
-        "description": "Minimal letter model.\n\nAttributes:\n    group (GroupUnlinked): Group the letter belongs to"
+        "description": "Minimal letter model.\n\nAttributes:\n    group (GroupUnlinked): Group the letter belongs to\n    responders (list[UserUnlinked]): Users who have responded\n    required_responders (int): Minimum unique responders needed before send\n    responder_count (int): Current unique responder count\n    send_threshold_ratio (float | None): Effective ratio gate, or null if disabled"
       },
       "NewPassword": {
         "properties": {
@@ -3493,7 +3726,9 @@
           }
         },
         "type": "object",
-        "required": ["new_password"],
+        "required": [
+          "new_password"
+        ],
         "title": "NewPassword",
         "description": "Schema for setting a new password (e.g., after reset).\n\nAttributes:\n    new_password (str): User's new password"
       },
@@ -3564,6 +3799,27 @@
             },
             "type": "array",
             "title": "Participants"
+          },
+          "required_responders": {
+            "type": "integer",
+            "title": "Required Responders",
+            "default": 0
+          },
+          "responder_count": {
+            "type": "integer",
+            "title": "Responder Count",
+            "default": 0
+          },
+          "send_threshold_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Send Threshold Ratio"
           }
         },
         "type": "object",
@@ -3579,7 +3835,7 @@
           "participants"
         ],
         "title": "PublicLetter",
-        "description": "Public letter model with linked relationships.\n\nA version of the Letter model that includes public information about participants\nand responses.\n\nAttributes:\n    group (GroupUnlinked): Group the letter belongs to\n    questions (list[PublicQuestion]): Questions with public responses\n    responders (list[UserUnlinked]): Users who have responded\n    participants (list[UserUnlinked]): All participants in the letter"
+        "description": "Public letter model with linked relationships.\n\nA version of the Letter model that includes public information about participants\nand responses.\n\nAttributes:\n    group (GroupUnlinked): Group the letter belongs to\n    questions (list[PublicQuestion]): Questions with public responses\n    responders (list[UserUnlinked]): Users who have responded\n    participants (list[UserUnlinked]): All participants in the letter\n    required_responders (int): Minimum unique responders needed before send\n    responder_count (int): Current unique responder count\n    send_threshold_ratio (float | None): Effective ratio gate, or null if disabled"
       },
       "PublicQuestion": {
         "properties": {
@@ -3644,7 +3900,10 @@
           }
         },
         "type": "object",
-        "required": ["question_text", "author_api_id"],
+        "required": [
+          "question_text",
+          "author_api_id"
+        ],
         "title": "QuestionCreate",
         "description": "Schema for creating a new question.\n\nAttributes:\n    question_text (str): The text content of the question\n    author_api_id (str | None): API identifier of the question's author, optional"
       },
@@ -3706,7 +3965,11 @@
           }
         },
         "type": "object",
-        "required": ["question_text", "api_identifier", "created_at"],
+        "required": [
+          "question_text",
+          "api_identifier",
+          "created_at"
+        ],
         "title": "QuestionUnlinked",
         "description": "Schema for question without linked relationships.\n\nInherits all fields from Question but excludes relationship data."
       },
@@ -3725,7 +3988,10 @@
           }
         },
         "type": "object",
-        "required": ["results", "total"],
+        "required": [
+          "results",
+          "total"
+        ],
         "title": "RawSearchResponse"
       },
       "RawSearchResult": {
@@ -3736,7 +4002,9 @@
           }
         },
         "type": "object",
-        "required": ["raw_text"],
+        "required": [
+          "raw_text"
+        ],
         "title": "RawSearchResult"
       },
       "ReplaceDefaultQuestions": {
@@ -3750,7 +4018,9 @@
           }
         },
         "type": "object",
-        "required": ["questions"],
+        "required": [
+          "questions"
+        ],
         "title": "ReplaceDefaultQuestions",
         "description": "Schema for replacing a group's default questions.\n\nAttributes:\n    questions (list[str]): New list of default questions"
       },
@@ -3762,7 +4032,9 @@
           }
         },
         "type": "object",
-        "required": ["response_text"],
+        "required": [
+          "response_text"
+        ],
         "title": "ResponseCreateBase",
         "description": "Base schema for response creation operations.\n\nInherits response_text field from ResponseBase."
       },
@@ -3825,7 +4097,9 @@
           }
         },
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "ResponseMessage",
         "description": "Standard response message model.\n\nUsed for API endpoints that return a simple message response.\n\nAttributes:\n    message (str): The response message text"
       },
@@ -3846,7 +4120,11 @@
           }
         },
         "type": "object",
-        "required": ["response_text", "api_identifier", "created_at"],
+        "required": [
+          "response_text",
+          "api_identifier",
+          "created_at"
+        ],
         "title": "ResponseUnlinked",
         "description": "Schema for response without linked relationships.\n\nInherits all fields from Response but excludes relationship data."
       },
@@ -3880,7 +4158,9 @@
           }
         },
         "type": "object",
-        "required": ["response_text"],
+        "required": [
+          "response_text"
+        ],
         "title": "ResponseUpsert",
         "description": "Schema for creating or updating a response.\n\nAttributes:\n    response_text (str): The text content of the response\n    participant_api_identifier (Optional[str]): API identifier of the participant, optional\n    api_identifier (Optional[str]): API identifier of an existing response, optional"
       },
@@ -3937,7 +4217,10 @@
           }
         },
         "type": "object",
-        "required": ["group", "tasks"],
+        "required": [
+          "group",
+          "tasks"
+        ],
         "title": "ScheduleLinked",
         "description": "Schedule model with linked relationships.\n\nExtends the base Schedule model to include the associated group and tasks.\n\nAttributes:\n    group (GroupUnlinked): The group this schedule belongs to\n    tasks (list[TaskUnlinked]): Tasks in the schedule"
       },
@@ -3952,7 +4235,9 @@
           }
         },
         "type": "object",
-        "required": ["tasks"],
+        "required": [
+          "tasks"
+        ],
         "title": "ScheduleUnlinked",
         "description": "Schema for schedule data with unlinked task relationships.\n\nThis schema extends the base Schedule schema and includes a list of tasks,\nusing the unlinked task schema to avoid circular references.\n\nAttributes:\n    tasks: List of tasks associated with this schedule"
       },
@@ -3971,7 +4256,10 @@
           }
         },
         "type": "object",
-        "required": ["results", "total"],
+        "required": [
+          "results",
+          "total"
+        ],
         "title": "SearchResponse"
       },
       "SearchResult": {
@@ -4002,13 +4290,20 @@
           }
         },
         "type": "object",
-        "required": ["model", "type"],
+        "required": [
+          "model",
+          "type"
+        ],
         "title": "SearchResult",
         "description": "Search result model that can hold different types of models based on type field.\n\nAttributes:\n    model (Any): The model instance\n    type (str): The type of the model"
       },
       "SearchType": {
         "type": "string",
-        "enum": ["semantic", "keyword", "dual"],
+        "enum": [
+          "semantic",
+          "keyword",
+          "dual"
+        ],
         "title": "SearchType"
       },
       "SingleGroupKeyValueUpdate": {
@@ -4030,13 +4325,19 @@
           },
           "operation": {
             "type": "string",
-            "enum": ["set", "delete"],
+            "enum": [
+              "set",
+              "delete"
+            ],
             "title": "Operation",
             "description": "Operation to perform: 'set' to update/create, 'delete' to remove"
           }
         },
         "type": "object",
-        "required": ["key", "operation"],
+        "required": [
+          "key",
+          "operation"
+        ],
         "title": "SingleGroupKeyValueUpdate",
         "description": "Schema for updating a single group key-value pair.\n\nThis model extends GroupKeyValueBase to include an operation field that specifies\nwhether to set or delete the key-value pair.\n\nAttributes:\n    key (str): The key identifier to update\n    value (Any | None): The value to set (required for 'set' operation, ignored for 'delete')\n    operation (Literal[\"set\", \"delete\"]): The operation to perform on the key-value pair\n\nNote:\n    For 'delete' operations, the value field is ignored"
       },
@@ -4069,7 +4370,11 @@
           }
         },
         "type": "object",
-        "required": ["endpoint", "keys", "user_api_identifier"],
+        "required": [
+          "endpoint",
+          "keys",
+          "user_api_identifier"
+        ],
         "title": "SubscriptionCreate",
         "description": "Schema for creating a new subscription.\n\nInherits endpoint and keys from SubscriptionBase and adds user identification.\n\nAttributes:\n    endpoint (str): Push notification endpoint URL\n    keys (dict[str, str | float | bool]): Dictionary containing encryption keys and auth info\n    user_api_identifier (str): API identifier of the user to subscribe"
       },
@@ -4095,7 +4400,12 @@
           }
         },
         "type": "object",
-        "required": ["type", "status", "execute_at", "arguments"],
+        "required": [
+          "type",
+          "status",
+          "execute_at",
+          "arguments"
+        ],
         "title": "TaskUnlinked",
         "description": "Schema for task data without linked relationships.\n\nThis schema extends the base Task schema but excludes any linked relationships,\nuseful for nested serialization to avoid circular references."
       },
@@ -4111,7 +4421,10 @@
           }
         },
         "type": "object",
-        "required": ["access_token", "token_type"],
+        "required": [
+          "access_token",
+          "token_type"
+        ],
         "title": "Token",
         "description": "Authentication token schema.\n\nRepresents the structure of an authentication token response.\n\nAttributes:\n    access_token (str): The JWT access token string\n    token_type (str): The type of token (e.g., \"bearer\")"
       },
@@ -4131,7 +4444,11 @@
           }
         },
         "type": "object",
-        "required": ["email", "name", "password"],
+        "required": [
+          "email",
+          "name",
+          "password"
+        ],
         "title": "UserCreate",
         "description": "Schema for creating a new user.\n\nAttributes:\n    email (str): User's email address (inherited from UserBase)\n    name (str): User's display name (inherited from UserBase)\n    password (str): User's password (will be hashed)"
       },
@@ -4200,7 +4517,12 @@
           }
         },
         "type": "object",
-        "required": ["email", "name", "api_identifier", "admin"],
+        "required": [
+          "email",
+          "name",
+          "api_identifier",
+          "admin"
+        ],
         "title": "UserUnlinked",
         "description": "Schema for users without linked relationships.\n\nInherits all fields from User but excludes relationship data."
       },
@@ -4245,7 +4567,10 @@
           }
         },
         "type": "object",
-        "required": ["current_password", "new_password"],
+        "required": [
+          "current_password",
+          "new_password"
+        ],
         "title": "UserUpdatePassword",
         "description": "Schema for updating a user's password.\n\nAttributes:\n    current_password (str): User's current password\n    new_password (str): User's new password"
       },
@@ -4275,7 +4600,11 @@
           }
         },
         "type": "object",
-        "required": ["loc", "msg", "type"],
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
         "title": "ValidationError"
       }
     },

--- a/react/src/client/types.gen.ts
+++ b/react/src/client/types.gen.ts
@@ -208,6 +208,7 @@ export type GroupLinked = {
     api_identifier: string;
     created_at: string;
     cycle_length: number;
+    min_responder_ratio?: number | null;
     members: Array<UserUnlinked>;
     letters: Array<LetterUnlinked>;
     schedule: ScheduleUnlinked | null;
@@ -225,6 +226,7 @@ export type GroupUnlinked = {
     api_identifier: string;
     created_at: string;
     cycle_length: number;
+    min_responder_ratio?: number | null;
 };
 
 /**
@@ -237,6 +239,7 @@ export type GroupUnlinked = {
 export type GroupUpdate = {
     name?: string | null;
     cycle_length?: number | null;
+    min_responder_ratio?: number | null;
 };
 
 export type HttpValidationError = {
@@ -377,6 +380,9 @@ export type MinimalLetter = {
     letter_type: LetterType;
     group: GroupUnlinked;
     responders: Array<UserUnlinked>;
+    required_responders: number;
+    responder_count: number;
+    send_threshold_ratio?: number | null;
 };
 
 /**
@@ -413,6 +419,9 @@ export type PublicLetter = {
     questions: Array<PublicQuestion>;
     responders: Array<UserUnlinked>;
     participants: Array<UserUnlinked>;
+    required_responders: number;
+    responder_count: number;
+    send_threshold_ratio?: number | null;
 };
 
 /**

--- a/react/src/client/types.gen.ts
+++ b/react/src/client/types.gen.ts
@@ -235,6 +235,9 @@ export type GroupUnlinked = {
  * Attributes:
  * name (str | None): New name for the group, optional
  * cycle_length (int | None): New cycle length in days, optional
+ * min_responder_ratio (float | None): Minimum share of participants who
+ * must respond before send (0-1). Use 0 to disable deferral. Omit or
+ * set null to use the default (0.5).
  */
 export type GroupUpdate = {
     name?: string | null;
@@ -369,6 +372,9 @@ export type MediaType = 'image' | 'video';
  * Attributes:
  * group (GroupUnlinked): Group the letter belongs to
  * responders (list[UserUnlinked]): Users who have responded
+ * required_responders (int): Minimum unique responders needed before send
+ * responder_count (int): Current unique responder count
+ * send_threshold_ratio (float | None): Effective ratio gate, or null if disabled
  */
 export type MinimalLetter = {
     api_identifier: string;
@@ -380,8 +386,8 @@ export type MinimalLetter = {
     letter_type: LetterType;
     group: GroupUnlinked;
     responders: Array<UserUnlinked>;
-    required_responders: number;
-    responder_count: number;
+    required_responders?: number;
+    responder_count?: number;
     send_threshold_ratio?: number | null;
 };
 
@@ -406,6 +412,9 @@ export type NewPassword = {
  * questions (list[PublicQuestion]): Questions with public responses
  * responders (list[UserUnlinked]): Users who have responded
  * participants (list[UserUnlinked]): All participants in the letter
+ * required_responders (int): Minimum unique responders needed before send
+ * responder_count (int): Current unique responder count
+ * send_threshold_ratio (float | None): Effective ratio gate, or null if disabled
  */
 export type PublicLetter = {
     api_identifier: string;
@@ -419,8 +428,8 @@ export type PublicLetter = {
     questions: Array<PublicQuestion>;
     responders: Array<UserUnlinked>;
     participants: Array<UserUnlinked>;
-    required_responders: number;
-    responder_count: number;
+    required_responders?: number;
+    responder_count?: number;
     send_threshold_ratio?: number | null;
 };
 

--- a/react/src/components/Groups/GroupLoopSettings.tsx
+++ b/react/src/components/Groups/GroupLoopSettings.tsx
@@ -32,6 +32,16 @@ type QuestionField = {
 type FormData = {
   questions: QuestionField[]
   cycle_length: number
+  min_responder_percent: number
+}
+
+const DEFAULT_MIN_RESPONDER_PERCENT = 50
+
+function displayMinResponderPercent(ratio: number | null | undefined): number {
+  if (ratio == null) {
+    return DEFAULT_MIN_RESPONDER_PERCENT
+  }
+  return Math.round(ratio * 100)
 }
 
 function GroupLoopSettings({ groupId }: { groupId: string }) {
@@ -63,6 +73,9 @@ function GroupLoopSettings({ groupId }: { groupId: string }) {
         question_text: question.question_text,
       })),
       cycle_length: group.cycle_length,
+      min_responder_percent: displayMinResponderPercent(
+        group.min_responder_ratio,
+      ),
     },
   })
 
@@ -140,6 +153,18 @@ function GroupLoopSettings({ groupId }: { groupId: string }) {
       })
     }
 
+    const currentMinResponderPercent = displayMinResponderPercent(
+      group.min_responder_ratio,
+    )
+    if (data.min_responder_percent !== currentMinResponderPercent) {
+      cycleUpdateMutation.mutate({
+        body: {
+          min_responder_ratio: data.min_responder_percent / 100,
+        },
+        path: { group_api_id: groupId },
+      })
+    }
+
     defaultQuestionsMutation.mutate({
       body: {
         questions: data.questions.map((question) => question.question_text),
@@ -184,6 +209,45 @@ function GroupLoopSettings({ groupId }: { groupId: string }) {
               {errors.cycle_length && (
                 <p className="text-sm text-destructive">
                   {errors.cycle_length.message}
+                </p>
+              )}
+            </div>
+            <div className="mt-4 space-y-1">
+              <Label htmlFor="min_responder_percent">
+                Minimum responses before send
+              </Label>
+              {editMode ? (
+                <Input
+                  id="min_responder_percent"
+                  {...register("min_responder_percent", {
+                    valueAsNumber: true,
+                    required: "Minimum response percentage is required",
+                    min: {
+                      value: 0,
+                      message: "Percentage must be at least 0",
+                    },
+                    max: {
+                      value: 100,
+                      message: "Percentage must be at most 100",
+                    },
+                  })}
+                  type="number"
+                  step={5}
+                />
+              ) : (
+                <p className="py-2 text-foreground">
+                  {displayMinResponderPercent(group.min_responder_ratio)}%
+                  {group.min_responder_ratio === 0 ? " (disabled)" : ""}
+                </p>
+              )}
+              <p className="text-sm text-muted-foreground">
+                If not enough members have responded by the send date, the issue
+                is delayed by one day and retried. Set to 0% to send on schedule
+                regardless of responses.
+              </p>
+              {errors.min_responder_percent && (
+                <p className="text-sm text-destructive">
+                  {errors.min_responder_percent.message}
                 </p>
               )}
             </div>

--- a/react/src/components/Loops/LoopCard.tsx
+++ b/react/src/components/Loops/LoopCard.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import type { MinimalLetter, PublicLetter, UserLinked } from "../../client"
 import { readUserMePartiesMeGetQueryKey } from "../../client/@tanstack/react-query.gen"
+import { formatResponderProgress } from "../../util/loopResponderProgress"
 
 export function LoopCard(props: {
   loop: MinimalLetter | PublicLetter
@@ -54,28 +55,9 @@ export function LoopCard(props: {
     return null
   }
 
-  const getResponderCount = (): string | null => {
-    if (!props.showResponderCount) {
-      return null
-    }
-
-    const loop = props.loop
-    if (
-      loop.status === "IN_PROGRESS" &&
-      "required_responders" in loop &&
-      "responder_count" in loop &&
-      loop.required_responders > 0
-    ) {
-      return `${loop.responder_count} of ${loop.required_responders} responses needed`
-    }
-
-    if ("responders" in loop) {
-      const count = loop.responders.length
-      return `${count} responder${count !== 1 ? "s" : ""}`
-    }
-
-    return null
-  }
+  const responderCount = props.showResponderCount
+    ? formatResponderProgress(props.loop)
+    : null
 
   const getUnansweredQuestionsCount = () => {
     if (
@@ -95,7 +77,6 @@ export function LoopCard(props: {
     return 0
   }
 
-  const responderCount = getResponderCount()
   const unansweredCount = getUnansweredQuestionsCount()
 
   return (

--- a/react/src/components/Loops/LoopCard.tsx
+++ b/react/src/components/Loops/LoopCard.tsx
@@ -54,14 +54,26 @@ export function LoopCard(props: {
     return null
   }
 
-  const getResponderCount = () => {
-    if (
-      props.showResponderCount &&
-      "responders" in props.loop &&
-      props.loop.responders
-    ) {
-      return props.loop.responders.length
+  const getResponderCount = (): string | null => {
+    if (!props.showResponderCount) {
+      return null
     }
+
+    const loop = props.loop
+    if (
+      loop.status === "IN_PROGRESS" &&
+      "required_responders" in loop &&
+      "responder_count" in loop &&
+      loop.required_responders > 0
+    ) {
+      return `${loop.responder_count} of ${loop.required_responders} responses needed`
+    }
+
+    if ("responders" in loop) {
+      const count = loop.responders.length
+      return `${count} responder${count !== 1 ? "s" : ""}`
+    }
+
     return null
   }
 
@@ -108,9 +120,7 @@ export function LoopCard(props: {
               {sendDate.toLocaleDateString()}
             </p>
             {responderCount !== null && (
-              <p className="text-sm text-muted-foreground">
-                {responderCount} responder{responderCount !== 1 ? "s" : ""}
-              </p>
+              <p className="text-sm text-muted-foreground">{responderCount}</p>
             )}
             {unansweredCount > 0 && (
               <p className="text-sm font-medium text-orange-500">

--- a/react/src/util/loopResponderProgress.ts
+++ b/react/src/util/loopResponderProgress.ts
@@ -1,0 +1,20 @@
+import type { MinimalLetter, PublicLetter } from "../client"
+
+type LoopWithResponderProgress = MinimalLetter | PublicLetter
+
+export function formatResponderProgress(
+  loop: LoopWithResponderProgress,
+): string | null {
+  if (
+    loop.status === "IN_PROGRESS" &&
+    loop.required_responders > 0
+  ) {
+    return `${loop.responder_count} of ${loop.required_responders} responses needed`
+  }
+
+  if (loop.responder_count > 0) {
+    return `${loop.responder_count} responder${loop.responder_count !== 1 ? "s" : ""}`
+  }
+
+  return null
+}

--- a/react/src/util/loopResponderProgress.ts
+++ b/react/src/util/loopResponderProgress.ts
@@ -5,15 +5,15 @@ type LoopWithResponderProgress = MinimalLetter | PublicLetter
 export function formatResponderProgress(
   loop: LoopWithResponderProgress,
 ): string | null {
-  if (
-    loop.status === "IN_PROGRESS" &&
-    loop.required_responders > 0
-  ) {
-    return `${loop.responder_count} of ${loop.required_responders} responses needed`
+  const requiredResponders = loop.required_responders ?? 0
+  const responderCount = loop.responder_count ?? 0
+
+  if (loop.status === "IN_PROGRESS" && requiredResponders > 0) {
+    return `${responderCount} of ${requiredResponders} responses needed`
   }
 
-  if (loop.responder_count > 0) {
-    return `${loop.responder_count} responder${loop.responder_count !== 1 ? "s" : ""}`
+  if (responderCount > 0) {
+    return `${responderCount} responder${responderCount !== 1 ? "s" : ""}`
   }
 
   return null

--- a/ring/letters/crud/letter.py
+++ b/ring/letters/crud/letter.py
@@ -521,12 +521,21 @@ def postpend_upcoming_letters(db: Session, letter_ids: list[int]) -> None:
     This task is triggered when letters need to be moved from IN_PROGRESS to
     SENT status. It also creates a new upcoming letter for the affected groups.
 
+    Letters below the responder send threshold are deferred instead of marked
+    SENT without an email.
+
     Args:
         db (Session): Database session
         letter_ids (list[int]): IDs of letters to postpend
     """
+    from ring.letters.send_threshold import (
+        defer_letter_send_if_below_threshold,
+    )
+
     letters = db.scalars(select(Letter).where(Letter.id.in_(letter_ids))).all()
     for letter in letters:
+        if defer_letter_send_if_below_threshold(db, letter):
+            continue
         letter.status = LetterStatus.SENT
         create_letter_with_questions(
             db,

--- a/ring/letters/crud/letter.py
+++ b/ring/letters/crud/letter.py
@@ -514,12 +514,13 @@ def promote_and_create_new_letters(db: Session, letter_ids: list[int]) -> None:
     db.commit()
 
 
-@job_factory("postpend_upcoming_letters")
-def postpend_upcoming_letters(db: Session, letter_ids: list[int]) -> None:
+def postpend_upcoming_letters_with_session(
+    db: Session, letter_ids: list[int]
+) -> None:
     """Move letters to SENT status.
 
-    This task is triggered when letters need to be moved from IN_PROGRESS to
-    SENT status. It also creates a new upcoming letter for the affected groups.
+    This helper is used by the scheduled postpend job and tests that need to
+    provide their own transaction-scoped session.
 
     Letters below the responder send threshold are deferred instead of marked
     SENT without an email.
@@ -543,6 +544,20 @@ def postpend_upcoming_letters(db: Session, letter_ids: list[int]) -> None:
             letter.send_at + timedelta(days=letter.group.cycle_length),
         )
     db.commit()
+
+
+@job_factory("postpend_upcoming_letters")
+def postpend_upcoming_letters(db: Session, letter_ids: list[int]) -> None:
+    """Move letters to SENT status.
+
+    This task is triggered when letters need to be moved from IN_PROGRESS to
+    SENT status. It also creates a new upcoming letter for the affected groups.
+
+    Args:
+        db (Session): Database session
+        letter_ids (list[int]): IDs of letters to postpend
+    """
+    postpend_upcoming_letters_with_session(db, letter_ids)
 
 
 def add_participants(

--- a/ring/letters/models/letter_model.py
+++ b/ring/letters/models/letter_model.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from pydantic import BaseModel
 from sqlalchemy import (
     Column,
     Constraint,
@@ -178,3 +179,22 @@ class Letter(Base, APIIdentified, PydanticModel, CreatedAtMixin):
             for response in question.responses
         }
         return list(respondents)
+
+    def to_pydantic(self) -> BaseModel:
+        """Convert to PublicLetter including send-threshold progress fields."""
+        from ring.letters.send_threshold import (
+            effective_send_threshold_ratio,
+            letter_responder_count,
+            minimum_responders_required,
+        )
+
+        model = self.PYDANTIC_MODEL.model_validate(self)
+        return model.model_copy(
+            update={
+                "required_responders": minimum_responders_required(self),
+                "responder_count": letter_responder_count(self),
+                "send_threshold_ratio": effective_send_threshold_ratio(
+                    self.group
+                ),
+            }
+        )

--- a/ring/letters/models/letter_model.py
+++ b/ring/letters/models/letter_model.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel
 from sqlalchemy import (
     Column,
     Constraint,
@@ -179,22 +178,3 @@ class Letter(Base, APIIdentified, PydanticModel, CreatedAtMixin):
             for response in question.responses
         }
         return list(respondents)
-
-    def to_pydantic(self) -> BaseModel:
-        """Convert to PublicLetter including send-threshold progress fields."""
-        from ring.letters.send_threshold import (
-            effective_send_threshold_ratio,
-            letter_responder_count,
-            minimum_responders_required,
-        )
-
-        model = self.PYDANTIC_MODEL.model_validate(self)
-        return model.model_copy(
-            update={
-                "required_responders": minimum_responders_required(self),
-                "responder_count": letter_responder_count(self),
-                "send_threshold_ratio": effective_send_threshold_ratio(
-                    self.group
-                ),
-            }
-        )

--- a/ring/letters/send_threshold.py
+++ b/ring/letters/send_threshold.py
@@ -1,0 +1,179 @@
+"""Send-threshold helpers for deferring letter sends until enough members respond."""
+
+from __future__ import annotations
+
+import math
+from datetime import timedelta
+from numbers import Real
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from ring.letters.constants import LetterStatus
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from ring.letters.models.letter_model import Letter
+    from ring.parties.models.group_model import Group
+
+GROUP_SETTING_MIN_RESPONDERS_KEY = "letter_send_min_responders"
+GROUP_SETTING_MIN_RESPONDER_RATIO_KEY = "letter_send_min_responder_ratio"
+DEFAULT_MIN_RESPONDER_RATIO_TO_SEND = 0.5
+LETTER_SEND_DEFERRAL_DAYS = 1
+
+
+def parse_positive_int(value: Any) -> int | None:
+    """Parse a value into a positive integer, returning None if invalid."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float):
+        if value.is_integer() and value > 0:
+            return int(value)
+        return None
+    if isinstance(value, str):
+        try:
+            parsed = float(value)
+        except ValueError:
+            return None
+        if parsed.is_integer() and parsed > 0:
+            return int(parsed)
+    return None
+
+
+def parse_ratio(value: Any) -> float | None:
+    """Parse a value into a ratio in the [0, 1] range."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        try:
+            value = float(value)
+        except ValueError:
+            return None
+    elif not isinstance(value, Real):
+        return None
+    ratio = float(value)
+    if ratio < 0 or ratio > 1:
+        return None
+    return ratio
+
+
+def is_send_threshold_disabled(group: Group) -> bool:
+    """Return True when the group has explicitly disabled the send threshold."""
+    ratio_setting = group.key_values.get_value(
+        GROUP_SETTING_MIN_RESPONDER_RATIO_KEY
+    )
+    if ratio_setting is None:
+        return False
+    configured_ratio = parse_ratio(ratio_setting)
+    return configured_ratio == 0.0
+
+
+def get_group_min_responder_ratio(group: Group) -> float | None:
+    """Return the configured responder ratio, or None when using the default."""
+    ratio_setting = group.key_values.get_value(
+        GROUP_SETTING_MIN_RESPONDER_RATIO_KEY
+    )
+    if ratio_setting is None:
+        return None
+    configured_ratio = parse_ratio(ratio_setting)
+    if configured_ratio is None:
+        return None
+    return configured_ratio
+
+
+def effective_send_threshold_ratio(group: Group) -> float | None:
+    """Return the effective ratio used for send gating, or None when disabled."""
+    if (
+        parse_positive_int(
+            group.key_values.get_value(GROUP_SETTING_MIN_RESPONDERS_KEY)
+        )
+        is not None
+    ):
+        return None
+    configured_ratio = get_group_min_responder_ratio(group)
+    if configured_ratio is not None:
+        if configured_ratio == 0.0:
+            return None
+        return configured_ratio
+    return DEFAULT_MIN_RESPONDER_RATIO_TO_SEND
+
+
+def set_group_min_responder_ratio(group: Group, ratio: float | None) -> None:
+    """Persist the group's minimum responder ratio in key-values."""
+    if ratio is None:
+        group.key_values.delete_value(GROUP_SETTING_MIN_RESPONDER_RATIO_KEY)
+        return
+    parsed = parse_ratio(ratio)
+    if parsed is None:
+        raise ValueError("min_responder_ratio must be between 0 and 1")
+    group.key_values.set_value(GROUP_SETTING_MIN_RESPONDER_RATIO_KEY, parsed)
+
+
+def minimum_responders_required(letter: Letter) -> int:
+    """Return the minimum unique responder count required to send.
+
+    Group-level configuration (stored in group key-values):
+    - `letter_send_min_responders`: positive integer responder count
+    - `letter_send_min_responder_ratio`: ratio in [0, 1]; 0 disables the gate
+    """
+    participant_count = len(letter.participants)
+    if participant_count <= 0:
+        return 0
+
+    min_responders_setting = letter.group.key_values.get_value(
+        GROUP_SETTING_MIN_RESPONDERS_KEY
+    )
+    configured_min_responders = parse_positive_int(min_responders_setting)
+    if configured_min_responders is not None:
+        return min(participant_count, configured_min_responders)
+
+    configured_ratio = get_group_min_responder_ratio(letter.group)
+    if configured_ratio is not None:
+        if configured_ratio == 0.0:
+            return 0
+        return max(1, math.ceil(participant_count * configured_ratio))
+
+    return max(
+        1, math.ceil(participant_count * DEFAULT_MIN_RESPONDER_RATIO_TO_SEND)
+    )
+
+
+def letter_responder_count(letter: Letter) -> int:
+    """Return the number of unique participants who have responded."""
+    return len(letter.responders)
+
+
+def defer_letter_send_if_below_threshold(db: Session, letter: Letter) -> bool:
+    """Defer a letter's send date when the responder threshold is not met.
+
+    Returns:
+        True if the send was deferred, False otherwise.
+    """
+    from ring.letters.crud import letter as letter_crud
+
+    if letter.status != LetterStatus.IN_PROGRESS:
+        return False
+
+    required_responders = minimum_responders_required(letter)
+    if required_responders <= 0:
+        return False
+
+    responder_count = letter_responder_count(letter)
+    if responder_count >= required_responders:
+        return False
+
+    new_send_at = letter.send_at + timedelta(days=LETTER_SEND_DEFERRAL_DAYS)
+    logger.info(
+        "Deferring letter {} send from {} to {}: responders {}/{}".format(
+            letter.id,
+            letter.send_at,
+            new_send_at,
+            responder_count,
+            required_responders,
+        )
+    )
+    letter_crud.edit_letter(db, letter, send_at=new_send_at)
+    return True

--- a/ring/parties/api/group.py
+++ b/ring/parties/api/group.py
@@ -233,7 +233,12 @@ async def update_group(
     Raises:
         HTTPException: If no updates provided, user not authorized, or invalid cycle length
     """
-    if not group.name and group.cycle_length is None:
+    if (
+        not group.name
+        and group.cycle_length is None
+        and group.min_responder_ratio is None
+        and "min_responder_ratio" not in group.model_fields_set
+    ):
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "No updates provided")
     db_group = api_identifier_crud.get_model(
         req_dep.db, Group, api_id=group_api_id
@@ -254,6 +259,16 @@ async def update_group(
         group_crud.update_cycle_length(
             req_dep.db, db_group, group.cycle_length
         )
+    if "min_responder_ratio" in group.model_fields_set:
+        try:
+            group_crud.update_min_responder_ratio(
+                req_dep.db, db_group, group.min_responder_ratio
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                str(exc),
+            ) from exc
     req_dep.db.commit()
     return db_group
 

--- a/ring/parties/crud/group.py
+++ b/ring/parties/crud/group.py
@@ -15,6 +15,7 @@ from ring.api_identifier import util as api_identifier_crud
 from ring.letters.constants import DEFAULT_QUESTIONS, LetterStatus
 from ring.letters.crud.default_question import replace_default_questions
 from ring.letters.models.letter_model import Letter
+from ring.letters.send_threshold import set_group_min_responder_ratio
 from ring.parties.models.group_model import Group
 from ring.parties.models.user_model import User
 from ring.search.crud.hybrid_search import (
@@ -25,10 +26,6 @@ from ring.search.models.hybrid_search import (
     HybridSearchDocument,
     SearchableType,
 )
-from ring.tasks.crud import (
-    schedule as schedule_crud,
-)
-from ring.tasks.models.task_model import TaskType
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -95,6 +92,23 @@ def update_cycle_length(db: Session, group: Group, cycle_length: int) -> Group:
         Group: Updated group
     """
     group.cycle_length = cycle_length
+    return group
+
+
+def update_min_responder_ratio(
+    db: Session, group: Group, min_responder_ratio: float | None
+) -> Group:
+    """Update the minimum responder ratio for letter sends.
+
+    Args:
+        db (Session): Database session
+        group (Group): Group to update
+        min_responder_ratio (float | None): Ratio in [0, 1], or None for default
+
+    Returns:
+        Group: Updated group
+    """
+    set_group_min_responder_ratio(group, min_responder_ratio)
     return group
 
 

--- a/ring/parties/models/group_model.py
+++ b/ring/parties/models/group_model.py
@@ -19,9 +19,9 @@ from ring.created_at import CreatedAtMixin
 from ring.letters.constants import LetterStatus, LetterType
 from ring.letters.models.default_question_model import DefaultQuestion
 from ring.letters.models.letter_model import Letter
+from ring.letters.send_threshold import get_group_min_responder_ratio
 from ring.parties.models.group_key_value import GroupKeyValue
 from ring.parties.models.user_group_assocation import user_group_association
-from ring.ring_pydantic.linked_schemas import GroupLinked
 from ring.ring_pydantic.pydantic_model import PydanticModel
 from ring.sqlalchemy_base import Base
 from ring.tasks.models.schedule_model import Schedule
@@ -130,6 +130,11 @@ class Group(Base, PydanticModel, APIIdentified, CreatedAtMixin):
             self._admin = admin
         else:
             raise ValueError("Admin must be a member of the group")
+
+    @hybrid_property
+    def min_responder_ratio(self) -> float | None:
+        """Configured minimum responder ratio before send, or None for default."""
+        return get_group_min_responder_ratio(self)
 
     @hybrid_property
     def cyclic_letters(self) -> list[Letter]:

--- a/ring/parties/models/group_model.py
+++ b/ring/parties/models/group_model.py
@@ -22,6 +22,7 @@ from ring.letters.models.letter_model import Letter
 from ring.letters.send_threshold import get_group_min_responder_ratio
 from ring.parties.models.group_key_value import GroupKeyValue
 from ring.parties.models.user_group_assocation import user_group_association
+from ring.ring_pydantic.linked_schemas import GroupLinked
 from ring.ring_pydantic.pydantic_model import PydanticModel
 from ring.sqlalchemy_base import Base
 from ring.tasks.models.schedule_model import Schedule

--- a/ring/parties/schemas/group.py
+++ b/ring/parties/schemas/group.py
@@ -30,10 +30,14 @@ class GroupUpdate(BaseModel):
     Attributes:
         name (str | None): New name for the group, optional
         cycle_length (int | None): New cycle length in days, optional
+        min_responder_ratio (float | None): Minimum share of participants who
+            must respond before send (0-1). Use 0 to disable deferral. Omit or
+            set null to use the default (0.5).
     """
 
     name: str | None = None
     cycle_length: int | None = None
+    min_responder_ratio: float | None = None
 
 
 class AddMembers(BaseModel):
@@ -64,6 +68,8 @@ class Group(GroupBase):
         api_identifier (str): Unique API identifier for the group
         created_at (AwareDatetime): Timestamp of group creation
         cycle_length (int): Number of days between letters
+        min_responder_ratio (float | None): Configured minimum responder ratio
+            (0-1), or null when using the default (0.5)
     """
 
     model_config = ConfigDict(from_attributes=True)
@@ -71,6 +77,7 @@ class Group(GroupBase):
     api_identifier: str
     created_at: AwareDatetime
     cycle_length: int
+    min_responder_ratio: float | None = None
 
 
 class GroupUnlinked(Group):

--- a/ring/ring_pydantic/linked_schemas.py
+++ b/ring/ring_pydantic/linked_schemas.py
@@ -7,12 +7,13 @@ entities need to be included in the response.
 
 from __future__ import annotations
 
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal, Optional, Self, Union
 
 from loguru import logger
 from pydantic import (
     BaseModel,
     Field,
+    ModelWrapValidatorHandler,
     ValidationInfo,
     computed_field,
     field_validator,
@@ -30,6 +31,29 @@ from ring.parties.schemas.user import User, UserUnlinked
 from ring.s3.schemas.image import WithImageMixin
 from ring.tasks.schemas.schedule import Schedule, ScheduleUnlinked
 from ring.tasks.schemas.task import TaskUnlinked
+
+
+def _populate_letter_send_threshold_fields[T: BaseModel](
+    model: T, letter: Any
+) -> T:
+    """Add send-threshold progress fields when serializing a letter ORM object."""
+    if not hasattr(letter, "group"):
+        return model
+    from ring.letters.send_threshold import (
+        effective_send_threshold_ratio,
+        letter_responder_count,
+        minimum_responders_required,
+    )
+
+    return model.model_copy(
+        update={
+            "required_responders": minimum_responders_required(letter),
+            "responder_count": letter_responder_count(letter),
+            "send_threshold_ratio": effective_send_threshold_ratio(
+                letter.group
+            ),
+        }
+    )
 
 
 class UserLinked(User):
@@ -106,10 +130,26 @@ class MinimalLetter(Letter):
     Attributes:
         group (GroupUnlinked): Group the letter belongs to
         responders (list[UserUnlinked]): Users who have responded
+        required_responders (int): Minimum unique responders needed before send
+        responder_count (int): Current unique responder count
+        send_threshold_ratio (float | None): Effective ratio gate, or null if disabled
     """
 
     group: "GroupUnlinked"
     responders: list["UserUnlinked"]
+    required_responders: int = 0
+    responder_count: int = 0
+    send_threshold_ratio: float | None = None
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def populate_send_threshold_progress(
+        cls,
+        data: Any,
+        handler: ModelWrapValidatorHandler[Self],
+    ) -> Self:
+        model = handler(data)
+        return _populate_letter_send_threshold_fields(model, data)
 
 
 class PublicLetter(Letter):
@@ -123,12 +163,29 @@ class PublicLetter(Letter):
         questions (list[PublicQuestion]): Questions with public responses
         responders (list[UserUnlinked]): Users who have responded
         participants (list[UserUnlinked]): All participants in the letter
+        required_responders (int): Minimum unique responders needed before send
+        responder_count (int): Current unique responder count
+        send_threshold_ratio (float | None): Effective ratio gate, or null if disabled
     """
 
     group: "GroupUnlinked"
     questions: list["PublicQuestion"]
     responders: list["UserUnlinked"]
     participants: list["UserUnlinked"]
+    required_responders: int = 0
+    responder_count: int = 0
+    send_threshold_ratio: float | None = None
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def populate_send_threshold_progress(
+        cls,
+        data: Any,
+        handler: ModelWrapValidatorHandler[Self],
+    ) -> Self:
+        """Fill send-threshold progress fields when validating from ORM letters."""
+        model = handler(data)
+        return _populate_letter_send_threshold_fields(model, data)
 
 
 class DashboardLetters(BaseModel):

--- a/ring/tasks/crud/task.py
+++ b/ring/tasks/crud/task.py
@@ -7,9 +7,7 @@ It includes both synchronous execution functions and their asynchronous job wrap
 
 from __future__ import annotations
 
-import math
 from datetime import timedelta
-from numbers import Real
 from typing import Any, Callable
 
 import sqlalchemy
@@ -21,6 +19,7 @@ from ring.email_util import send_email
 from ring.letters.constants import LetterStatus
 from ring.letters.crud import letter as letter_crud
 from ring.letters.models.letter_model import Letter
+from ring.letters.send_threshold import defer_letter_send_if_below_threshold
 from ring.lib.util import RegistrationDict
 from ring.tasks.crud.reminder_email_task import construct_reminder_email
 from ring.tasks.crud.response_open_email_task import (
@@ -34,77 +33,6 @@ from ring.tasks.models.task_model import (
     TaskStatus,
     TaskType,
 )
-
-GROUP_SETTING_MIN_RESPONDERS_KEY = "letter_send_min_responders"
-GROUP_SETTING_MIN_RESPONDER_RATIO_KEY = "letter_send_min_responder_ratio"
-DEFAULT_MIN_RESPONDER_RATIO_TO_SEND = 0.5
-LETTER_SEND_DEFERRAL_DAYS = 1
-
-
-def _parse_positive_int(value: Any) -> int | None:
-    """Parse a value into a positive integer, returning None if invalid."""
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value if value > 0 else None
-    if isinstance(value, float):
-        if value.is_integer() and value > 0:
-            return int(value)
-        return None
-    if isinstance(value, str):
-        try:
-            parsed = float(value)
-        except ValueError:
-            return None
-        if parsed.is_integer() and parsed > 0:
-            return int(parsed)
-    return None
-
-
-def _parse_ratio(value: Any) -> float | None:
-    """Parse a value into a ratio in the (0, 1] range."""
-    if isinstance(value, bool) or not isinstance(value, Real):
-        if isinstance(value, str):
-            try:
-                value = float(value)
-            except ValueError:
-                return None
-        else:
-            return None
-    ratio = float(value)
-    if ratio <= 0 or ratio > 1:
-        return None
-    return ratio
-
-
-def _minimum_responders_required(letter: Letter) -> int:
-    """Return the minimum unique responder count required to send.
-
-    Group-level configuration (stored in group key-values):
-    - `letter_send_min_responders`: positive integer responder count
-    - `letter_send_min_responder_ratio`: ratio in (0, 1]
-    """
-    participant_count = len(letter.participants)
-    if participant_count <= 0:
-        return 0
-
-    min_responders_setting = letter.group.key_values.get_value(
-        GROUP_SETTING_MIN_RESPONDERS_KEY
-    )
-    configured_min_responders = _parse_positive_int(min_responders_setting)
-    if configured_min_responders is not None:
-        return min(participant_count, configured_min_responders)
-
-    ratio_setting = letter.group.key_values.get_value(
-        GROUP_SETTING_MIN_RESPONDER_RATIO_KEY
-    )
-    configured_ratio = _parse_ratio(ratio_setting)
-    ratio = (
-        configured_ratio
-        if configured_ratio is not None
-        else DEFAULT_MIN_RESPONDER_RATIO_TO_SEND
-    )
-    return max(1, math.ceil(participant_count * ratio))
 
 
 def execute_reminder_email_task(
@@ -191,27 +119,11 @@ def execute_send_email_task(
         letter_to_send = group.in_progress_letters[0]
     assert letter_to_send
 
-    if letter_to_send.status == LetterStatus.IN_PROGRESS:
-        required_responders = _minimum_responders_required(letter_to_send)
-        responder_count = len(letter_to_send.responders)
-        if responder_count < required_responders:
-            new_send_at = letter_to_send.send_at + timedelta(
-                days=LETTER_SEND_DEFERRAL_DAYS
-            )
-            logger.info(
-                "Deferring letter {} send from {} to {}: responders {}/{}".format(
-                    letter_to_send.id,
-                    letter_to_send.send_at,
-                    new_send_at,
-                    responder_count,
-                    required_responders,
-                )
-            )
-            letter_crud.edit_letter(db, letter_to_send, send_at=new_send_at)
-            db.commit()
-            return
+    if defer_letter_send_if_below_threshold(db, letter_to_send):
+        db.commit()
+        return
 
-    title = f"Ring Newsletter {("#" + str(letter_to_send.number)) if not letter_to_send.title else str(letter_to_send.title)} for {letter_to_send.group.name}"
+    title = f"Ring Newsletter {('#' + str(letter_to_send.number)) if not letter_to_send.title else str(letter_to_send.title)} for {letter_to_send.group.name}"
     message_id = send_email(
         construct_send_letter_email(
             [u.email for u in letter_to_send.participants],

--- a/ring/tests/unit/letters/crud/postpend_letter_test.py
+++ b/ring/tests/unit/letters/crud/postpend_letter_test.py
@@ -1,0 +1,68 @@
+"""Tests for postpend letter behavior with send thresholds."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from ring.letters.constants import LetterStatus
+from ring.letters.crud import letter as letter_crud
+from ring.letters.send_threshold import LETTER_SEND_DEFERRAL_DAYS
+from ring.tests.factories.letters.letter_factory import LetterFactory
+from ring.tests.factories.letters.question_factory import QuestionFactory
+from ring.tests.factories.letters.response_factory import ResponseFactory
+from ring.tests.factories.parties.group_factory import GroupFactory
+from ring.tests.factories.parties.user_factory import UserFactory
+
+
+class TestPostpendLetters:
+    """Tests for postpend_upcoming_letters threshold handling."""
+
+    def test_postpend_defers_when_responders_below_threshold(
+        self, db_session: Session
+    ) -> None:
+        """Do not mark SENT when threshold is unmet; defer send instead."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        send_at = datetime.now(tz=UTC) + timedelta(days=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        db_session.commit()
+
+        letter_crud.postpend_upcoming_letters(db_session, [letter.id])
+        db_session.refresh(letter)
+
+        assert letter.status == LetterStatus.IN_PROGRESS
+        assert letter.send_at == send_at + timedelta(
+            days=LETTER_SEND_DEFERRAL_DAYS
+        )
+
+    def test_postpend_marks_sent_when_threshold_met(
+        self, db_session: Session
+    ) -> None:
+        """Mark SENT when enough participants have responded."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        send_at = datetime.now(tz=UTC) + timedelta(days=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        ResponseFactory.create(question=question, participant=members[1])
+        db_session.commit()
+
+        letter_crud.postpend_upcoming_letters(db_session, [letter.id])
+        db_session.refresh(letter)
+
+        assert letter.status == LetterStatus.SENT

--- a/ring/tests/unit/letters/crud/postpend_letter_test.py
+++ b/ring/tests/unit/letters/crud/postpend_letter_test.py
@@ -22,7 +22,7 @@ class TestPostpendLetters:
     def run_postpend_job(
         self, db_session: Session, letter_ids: list[int]
     ) -> None:
-        letter_crud.postpend_upcoming_letters.__wrapped__(
+        letter_crud.postpend_upcoming_letters_with_session(
             db_session, letter_ids
         )
 

--- a/ring/tests/unit/letters/crud/postpend_letter_test.py
+++ b/ring/tests/unit/letters/crud/postpend_letter_test.py
@@ -19,6 +19,13 @@ from ring.tests.factories.parties.user_factory import UserFactory
 class TestPostpendLetters:
     """Tests for postpend_upcoming_letters threshold handling."""
 
+    def run_postpend_job(
+        self, db_session: Session, letter_ids: list[int]
+    ) -> None:
+        letter_crud.postpend_upcoming_letters.__wrapped__(
+            db_session, letter_ids
+        )
+
     def test_postpend_defers_when_responders_below_threshold(
         self, db_session: Session
     ) -> None:
@@ -36,7 +43,7 @@ class TestPostpendLetters:
         ResponseFactory.create(question=question, participant=members[0])
         db_session.commit()
 
-        letter_crud.postpend_upcoming_letters(db_session, [letter.id])
+        self.run_postpend_job(db_session, [letter.id])
         db_session.refresh(letter)
 
         assert letter.status == LetterStatus.IN_PROGRESS
@@ -62,7 +69,7 @@ class TestPostpendLetters:
         ResponseFactory.create(question=question, participant=members[1])
         db_session.commit()
 
-        letter_crud.postpend_upcoming_letters(db_session, [letter.id])
+        self.run_postpend_job(db_session, [letter.id])
         db_session.refresh(letter)
 
         assert letter.status == LetterStatus.SENT

--- a/ring/tests/unit/letters/send_threshold_test.py
+++ b/ring/tests/unit/letters/send_threshold_test.py
@@ -1,0 +1,254 @@
+"""Unit tests for letter send-threshold helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.orm import Session
+
+from ring.letters.constants import LetterStatus
+from ring.letters.send_threshold import (
+    DEFAULT_MIN_RESPONDER_RATIO_TO_SEND,
+    GROUP_SETTING_MIN_RESPONDER_RATIO_KEY,
+    GROUP_SETTING_MIN_RESPONDERS_KEY,
+    effective_send_threshold_ratio,
+    get_group_min_responder_ratio,
+    minimum_responders_required,
+    parse_positive_int,
+    parse_ratio,
+    set_group_min_responder_ratio,
+)
+from ring.ring_pydantic.linked_schemas import MinimalLetter, PublicLetter
+from ring.tests.factories.letters.letter_factory import LetterFactory
+from ring.tests.factories.letters.question_factory import QuestionFactory
+from ring.tests.factories.letters.response_factory import ResponseFactory
+from ring.tests.factories.parties.group_factory import GroupFactory
+from ring.tests.factories.parties.user_factory import UserFactory
+
+
+class TestParseHelpers:
+    """Tests for key-value parsing helpers."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (3, 3),
+            ("4", 4),
+            (4.0, 4),
+            (0, None),
+            (-1, None),
+            (True, None),
+            ("not-a-number", None),
+            (2.5, None),
+        ],
+    )
+    def test_parse_positive_int(
+        self, value: object, expected: int | None
+    ) -> None:
+        assert parse_positive_int(value) == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (0.0, 0.0),
+            (0, 0.0),
+            ("0", 0.0),
+            (0.75, 0.75),
+            ("0.5", 0.5),
+            (1.0, 1.0),
+            (-0.1, None),
+            (1.1, None),
+            (True, None),
+            ("bad", None),
+        ],
+    )
+    def test_parse_ratio(self, value: object, expected: float | None) -> None:
+        assert parse_ratio(value) == expected
+
+
+class TestSendThresholdPolicy:
+    """Tests for group and letter threshold resolution."""
+
+    def test_get_group_min_responder_ratio_unset(
+        self, db_session: Session
+    ) -> None:
+        group = GroupFactory.create()
+        db_session.commit()
+        assert get_group_min_responder_ratio(group) is None
+
+    def test_get_group_min_responder_ratio_configured(
+        self, db_session: Session
+    ) -> None:
+        group = GroupFactory.create()
+        group.key_values.set_value(GROUP_SETTING_MIN_RESPONDER_RATIO_KEY, 0.75)
+        db_session.commit()
+        assert get_group_min_responder_ratio(group) == 0.75
+
+    def test_effective_ratio_uses_default_when_unset(
+        self, db_session: Session
+    ) -> None:
+        group = GroupFactory.create()
+        db_session.commit()
+        assert effective_send_threshold_ratio(group) == (
+            DEFAULT_MIN_RESPONDER_RATIO_TO_SEND
+        )
+
+    def test_effective_ratio_none_when_disabled(
+        self, db_session: Session
+    ) -> None:
+        group = GroupFactory.create()
+        group.key_values.set_value(GROUP_SETTING_MIN_RESPONDER_RATIO_KEY, 0)
+        db_session.commit()
+        assert effective_send_threshold_ratio(group) is None
+
+    def test_effective_ratio_none_when_absolute_count_set(
+        self, db_session: Session
+    ) -> None:
+        group = GroupFactory.create()
+        group.key_values.set_value(GROUP_SETTING_MIN_RESPONDERS_KEY, 2)
+        db_session.commit()
+        assert effective_send_threshold_ratio(group) is None
+
+    def test_minimum_responders_default_ratio(
+        self, db_session: Session
+    ) -> None:
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=datetime.now(tz=UTC) + timedelta(days=1),
+        )
+        db_session.commit()
+        assert minimum_responders_required(letter) == 2
+
+    def test_minimum_responders_configured_ratio(
+        self, db_session: Session
+    ) -> None:
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        group.key_values.set_value(GROUP_SETTING_MIN_RESPONDER_RATIO_KEY, 0.75)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=datetime.now(tz=UTC) + timedelta(days=1),
+        )
+        db_session.commit()
+        assert minimum_responders_required(letter) == 3
+
+    def test_minimum_responders_disabled_at_zero(
+        self, db_session: Session
+    ) -> None:
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        group.key_values.set_value(GROUP_SETTING_MIN_RESPONDER_RATIO_KEY, 0)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=datetime.now(tz=UTC) + timedelta(days=1),
+        )
+        db_session.commit()
+        assert minimum_responders_required(letter) == 0
+
+    def test_minimum_responders_absolute_count_takes_precedence(
+        self, db_session: Session
+    ) -> None:
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        group.key_values.set_value(GROUP_SETTING_MIN_RESPONDERS_KEY, 3)
+        group.key_values.set_value(GROUP_SETTING_MIN_RESPONDER_RATIO_KEY, 0.5)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=datetime.now(tz=UTC) + timedelta(days=1),
+        )
+        db_session.commit()
+        assert minimum_responders_required(letter) == 3
+
+    def test_set_group_min_responder_ratio_persists_and_clears(
+        self, db_session: Session
+    ) -> None:
+        group = GroupFactory.create()
+        db_session.commit()
+
+        set_group_min_responder_ratio(group, 0.6)
+        assert get_group_min_responder_ratio(group) == 0.6
+
+        set_group_min_responder_ratio(group, None)
+        assert get_group_min_responder_ratio(group) is None
+
+    def test_set_group_min_responder_ratio_rejects_invalid(self) -> None:
+        group = GroupFactory.build()
+        with pytest.raises(ValueError, match="between 0 and 1"):
+            set_group_min_responder_ratio(group, 1.5)
+
+
+class TestLetterSchemaThresholdFields:
+    """Threshold progress fields are populated via schema validators only."""
+
+    def test_public_letter_model_validate_includes_threshold_fields(
+        self, db_session: Session
+    ) -> None:
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=datetime.now(tz=UTC) + timedelta(days=1),
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        db_session.commit()
+
+        public_letter = PublicLetter.model_validate(letter)
+
+        assert public_letter.required_responders == 2
+        assert public_letter.responder_count == 1
+        assert public_letter.send_threshold_ratio == (
+            DEFAULT_MIN_RESPONDER_RATIO_TO_SEND
+        )
+
+    def test_minimal_letter_model_validate_includes_threshold_fields(
+        self, db_session: Session
+    ) -> None:
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        group.key_values.set_value(GROUP_SETTING_MIN_RESPONDER_RATIO_KEY, 0)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=datetime.now(tz=UTC) + timedelta(days=1),
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        db_session.commit()
+
+        minimal_letter = MinimalLetter.model_validate(letter)
+
+        assert minimal_letter.required_responders == 0
+        assert minimal_letter.responder_count == 1
+        assert minimal_letter.send_threshold_ratio is None
+
+    def test_letter_to_pydantic_uses_schema_validators_only(
+        self, db_session: Session
+    ) -> None:
+        admin = UserFactory.create()
+        group = GroupFactory.create(admin=admin, members=[admin])
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=datetime.now(tz=UTC) + timedelta(days=1),
+        )
+        db_session.commit()
+
+        pydantic_letter = letter.to_pydantic()
+
+        assert pydantic_letter.required_responders == 1
+        assert pydantic_letter.responder_count == 0

--- a/ring/tests/unit/tasks/crud/task_test.py
+++ b/ring/tests/unit/tasks/crud/task_test.py
@@ -9,6 +9,11 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ring.letters.constants import LetterStatus
+from ring.letters.send_threshold import (
+    GROUP_SETTING_MIN_RESPONDER_RATIO_KEY,
+    GROUP_SETTING_MIN_RESPONDERS_KEY,
+    LETTER_SEND_DEFERRAL_DAYS,
+)
 from ring.tasks.crud import task as task_crud
 from ring.tasks.models.task_model import Task, TaskStatus, TaskType
 from ring.tests.factories.letters.letter_factory import LetterFactory
@@ -56,9 +61,7 @@ class TestTaskCrud:
         mock_send_email.assert_not_called()
         db_session.refresh(letter)
 
-        expected_send_at = send_at + timedelta(
-            days=task_crud.LETTER_SEND_DEFERRAL_DAYS
-        )
+        expected_send_at = send_at + timedelta(days=LETTER_SEND_DEFERRAL_DAYS)
         assert letter.send_at == expected_send_at
         assert letter.status == LetterStatus.IN_PROGRESS
 
@@ -116,9 +119,7 @@ class TestTaskCrud:
         admin = UserFactory.create()
         members = [admin] + [UserFactory.create() for _ in range(3)]
         group = GroupFactory.create(admin=admin, members=members)
-        group.key_values.set_value(
-            task_crud.GROUP_SETTING_MIN_RESPONDERS_KEY, 3
-        )
+        group.key_values.set_value(GROUP_SETTING_MIN_RESPONDERS_KEY, 3)
         send_at = datetime.now(tz=UTC) + timedelta(days=1)
         letter = LetterFactory.create(
             group=group,
@@ -148,7 +149,7 @@ class TestTaskCrud:
         mock_send_email.assert_not_called()
         db_session.refresh(letter)
         assert letter.send_at == send_at + timedelta(
-            days=task_crud.LETTER_SEND_DEFERRAL_DAYS
+            days=LETTER_SEND_DEFERRAL_DAYS
         )
 
     def test_execute_send_email_task_ignores_invalid_threshold_config(
@@ -159,7 +160,7 @@ class TestTaskCrud:
         members = [admin] + [UserFactory.create() for _ in range(3)]
         group = GroupFactory.create(admin=admin, members=members)
         group.key_values.set_value(
-            task_crud.GROUP_SETTING_MIN_RESPONDERS_KEY, "not-a-number"
+            GROUP_SETTING_MIN_RESPONDERS_KEY, "not-a-number"
         )
         send_at = datetime.now(tz=UTC) + timedelta(days=1)
         letter = LetterFactory.create(
@@ -196,9 +197,7 @@ class TestTaskCrud:
         admin = UserFactory.create()
         members = [admin] + [UserFactory.create() for _ in range(3)]
         group = GroupFactory.create(admin=admin, members=members)
-        group.key_values.set_value(
-            task_crud.GROUP_SETTING_MIN_RESPONDER_RATIO_KEY, 0.75
-        )
+        group.key_values.set_value(GROUP_SETTING_MIN_RESPONDER_RATIO_KEY, 0.75)
         send_at = datetime.now(tz=UTC) + timedelta(days=1)
         letter = LetterFactory.create(
             group=group,
@@ -228,5 +227,39 @@ class TestTaskCrud:
         mock_send_email.assert_not_called()
         db_session.refresh(letter)
         assert letter.send_at == send_at + timedelta(
-            days=task_crud.LETTER_SEND_DEFERRAL_DAYS
+            days=LETTER_SEND_DEFERRAL_DAYS
         )
+
+    def test_execute_send_email_task_sends_when_threshold_disabled(
+        self, db_session: Session
+    ) -> None:
+        """Send on schedule when responder ratio is explicitly set to zero."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        group.key_values.set_value(GROUP_SETTING_MIN_RESPONDER_RATIO_KEY, 0)
+        send_at = datetime.now(tz=UTC) + timedelta(days=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        QuestionFactory.create(letter=letter)
+        db_session.commit()
+
+        send_task = db_session.scalars(
+            select(Task).where(
+                Task.schedule_id == group.schedule.id,
+                Task.type == TaskType.SEND_EMAIL,
+                Task.arguments == {"letter_id": letter.id},
+            )
+        ).one()
+
+        with patch(
+            "ring.tasks.crud.task.send_email", return_value="message-id"
+        ) as mock_send_email:
+            task_crud.execute_send_email_task(db_session, send_task)
+
+        mock_send_email.assert_called_once()
+        db_session.refresh(letter)
+        assert letter.status == LetterStatus.SENT


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the responder-threshold feature on top of the existing send-deferral logic (PR #257):

- **Shared threshold module** (`ring/letters/send_threshold.py`) used by task execution, letter postpend, and API serialization
- **Group setting** `min_responder_ratio` (0–1) on PATCH/GET group — `0` disables the gate, `null` uses the 50% default
- **Letter progress fields** on `PublicLetter` and `MinimalLetter`: `required_responders`, `responder_count`, `send_threshold_ratio`
- **Postpend bypass fix** — `postpend_upcoming_letters` defers instead of marking `SENT` when threshold is unmet
- **Frontend** — Loop Settings percentage control; in-progress loop cards show "X of Y responses needed"

## Behavior

- A member counts as having responded when they have at least one answer on any question
- If the send date arrives with too few responders, `send_at` is deferred by 1 day and retried
- Denominator is `letter.participants` (snapshot at letter creation)

## Test plan

- [ ] `ring test run` — `task_test.py`, `postpend_letter_test.py`
- [ ] `ring check lint`
- [ ] `cd react && npx tsc --noEmit`
- [ ] Set group minimum to 75%, verify send defers until enough unique responders, then sends
- [ ] Set minimum to 0%, verify send proceeds on schedule with no responses

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-222c1aa8-f17e-427a-adf5-662b1fb3270e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-222c1aa8-f17e-427a-adf5-662b1fb3270e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

