### PR TITLE
Show responder count on group letter listing cards

### DIFF
--- a/react/src/client/types.gen.ts
+++ b/react/src/client/types.gen.ts
@@ -365,6 +365,7 @@ export type MediaType = 'image' | 'video';
  *
  * Attributes:
  * group (GroupUnlinked): Group the letter belongs to
+ * responders (list[UserUnlinked]): Users who have responded
  */
 export type MinimalLetter = {
     api_identifier: string;
@@ -375,6 +376,7 @@ export type MinimalLetter = {
     title?: string | null;
     letter_type: LetterType;
     group: GroupUnlinked;
+    responders: Array<UserUnlinked>;
 };
 
 /**

--- a/react/src/components/Loops/AdhocLoopsTab.tsx
+++ b/react/src/components/Loops/AdhocLoopsTab.tsx
@@ -43,6 +43,7 @@ export function AdhocLoopsTab({
               loops={inProgressLoops}
               heading="In Progress"
               subheading="Add your response now!"
+              showResponderCount={true}
             />
           )}
 
@@ -51,6 +52,7 @@ export function AdhocLoopsTab({
               loops={upcomingLoops}
               heading="Upcoming Issues"
               subheading="You can add questions to the upcoming issues before they are available for responses."
+              showResponderCount={true}
             />
           )}
 
@@ -61,6 +63,7 @@ export function AdhocLoopsTab({
                   new Date(a.send_at).getTime() - new Date(b.send_at).getTime(),
               )}
               heading="Published Issues"
+              showResponderCount={true}
             />
           )}
         </div>

--- a/react/src/components/Loops/LoopsTab.tsx
+++ b/react/src/components/Loops/LoopsTab.tsx
@@ -22,6 +22,7 @@ export function LoopsTab({
           loops={inProgressLoops}
           heading="In Progress"
           subheading="Add your response now!"
+          showResponderCount={true}
         />
       )}
 
@@ -30,6 +31,7 @@ export function LoopsTab({
           loops={upcomingLoops}
           heading="Upcoming Issues"
           subheading="You can add questions to the upcoming issues before they are available for responses."
+          showResponderCount={true}
         />
       )}
 
@@ -40,6 +42,7 @@ export function LoopsTab({
               new Date(a.send_at).getTime() - new Date(b.send_at).getTime(),
           )}
           heading="Published Issues"
+          showResponderCount={true}
         />
       )}
     </div>

--- a/ring/letters/crud/letter.py
+++ b/ring/letters/crud/letter.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 from loguru import logger
 from sqlalchemy import ColumnElement, select
+from sqlalchemy.orm import selectinload
 
 from ring.api_identifier import util as api_identifier_crud
 from ring.async_scheduler.scheduler import job_factory
@@ -24,6 +25,7 @@ from ring.letters.constants import (
 from ring.letters.crud.question import create_question
 from ring.letters.models.letter_model import Letter
 from ring.letters.models.question_model import Question
+from ring.letters.models.response_model import Response
 from ring.parties.models.group_model import Group
 from ring.parties.models.user_model import User
 from ring.search.crud.hybrid_search import (
@@ -64,7 +66,15 @@ def get_letters(
         IDNotFoundException: If group with given API ID is not found
     """
     group = api_identifier_crud.get_model(db, Group, api_id=group_api_id)
-    query = select(Letter).filter(Letter.group == group)
+    query = (
+        select(Letter)
+        .filter(Letter.group == group)
+        .options(
+            selectinload(Letter.questions)
+            .selectinload(Question.responses)
+            .selectinload(Response.participant)
+        )
+    )
     if letter_type:
         query = query.filter(Letter.letter_type == letter_type)
     query = query.offset(skip).limit(limit)

--- a/ring/ring_pydantic/linked_schemas.py
+++ b/ring/ring_pydantic/linked_schemas.py
@@ -105,9 +105,11 @@ class MinimalLetter(Letter):
 
     Attributes:
         group (GroupUnlinked): Group the letter belongs to
+        responders (list[UserUnlinked]): Users who have responded
     """
 
     group: "GroupUnlinked"
+    responders: list["UserUnlinked"]
 
 
 class PublicLetter(Letter):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issue/loop cards on the group letter listing page now show how many members have responded.

- Extended `MinimalLetter` API schema with a `responders` field (same shape as `PublicLetter`)
- Eager-load questions, responses, and participants when listing group letters to avoid N+1 queries
- Enabled `showResponderCount` on both the Loops and Adhoc Loops tabs

## Test plan

- [ ] Open a group's Loops tab and confirm in-progress, upcoming, and published cards show "N responder(s)"
- [ ] Verify adhoc loops show the same responder count
- [ ] Confirm letters with no responses show "0 responders"
- [ ] Run `ring test run` — `test_list_letters` should still pass with the updated schema

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-313ae9f7-d03d-4ddf-9fb3-186b641aaa38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-313ae9f7-d03d-4ddf-9fb3-186b641aaa38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

