### PR TITLE
Add Cursor Cloud environment for full Ring stack

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,73 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+########################################################
+# Base tooling (git + sudo required for Cloud Agents)
+########################################################
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gnupg \
+    openssl \
+    git \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+########################################################
+# Docker (fuse-overlayfs + iptables-legacy for nested Docker)
+########################################################
+
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg \
+      | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    chmod a+r /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+https://download.docker.com/linux/ubuntu \
+$(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+      | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y \
+      docker-ce=5:28.5.2-1~ubuntu.24.04~noble \
+      docker-ce-cli=5:28.5.2-1~ubuntu.24.04~noble \
+      containerd.io \
+      docker-buildx-plugin \
+      docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y fuse-overlayfs && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/docker && \
+    printf '%s\n' '{' \
+    '  "storage-driver": "fuse-overlayfs"' \
+    '}' > /etc/docker/daemon.json
+RUN apt-get update && apt-get install -y iptables && rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+########################################################
+# Node.js 22 + pnpm
+########################################################
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    corepack enable && \
+    corepack prepare pnpm@10.33.3 --activate && \
+    rm -rf /var/lib/apt/lists/*
+
+########################################################
+# Ubuntu user (Cloud Agents run as ubuntu)
+########################################################
+
+RUN id -u ubuntu &>/dev/null || useradd -m -s /bin/bash ubuntu
+RUN groupadd -f docker && usermod -aG docker ubuntu
+RUN usermod -aG sudo ubuntu
+RUN echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu && \
+    chmod 0440 /etc/sudoers.d/ubuntu
+
+USER ubuntu
+WORKDIR /home/ubuntu
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/home/ubuntu/.local/bin:${PATH}"
+RUN uv python install 3.12

--- a/.cursor/cloud-start.sh
+++ b/.cursor/cloud-start.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+COMPOSE=(sudo docker compose -f compose.core.yml -f compose.dev.yml --profile dev)
+
+ensure_network() {
+  if ! sudo docker network inspect ring-network >/dev/null 2>&1; then
+    sudo docker network create ring-network
+  fi
+}
+
+ensure_ssl() {
+  if [[ ! -f localhost.crt || ! -f localhost.key ]]; then
+    bash dev_util/ssl.sh
+  fi
+}
+
+ensure_env() {
+  if [[ -f .env ]]; then
+    return
+  fi
+
+  cat > .env <<'EOF'
+ENVIRONMENT=local
+API_PORT=8001
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_RESULT_BACKEND=redis://redis:6379/0
+SQLALCHEMY_DATABASE_URI=postgresql://ring-postgres:ring-postgres@db:5432/ring
+COCKROACH_DATABASE_URI=cockroachdb://ringcockroach:ringcockroach@cockroach:26257/ring?sslmode=require
+JWT_SIGNING_ALGORITHM=HS256
+VITE_API_URL=https://localhost
+BACKEND_CORS_ORIGINS="https://localhost:5173 http://localhost:5173"
+SW_DEV=true
+VITE_MAINTENANCE_MODE=false
+EOF
+
+  {
+    echo "JWT_SIGNING_KEY=$(openssl rand -hex 32)"
+    echo "LLM_SERVICE_API_KEY=$(openssl rand -hex 32)"
+    echo "VAPID_PRIVATE_KEY=$(openssl rand -hex 32)"
+  } >> .env
+}
+
+wait_for_cockroach() {
+  local attempt
+  for attempt in $(seq 1 60); do
+    if sudo docker exec ring-cockroach ./cockroach sql \
+      --certs-dir=/root/.cockroach-certs \
+      -d ring \
+      -e "SELECT 1" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "CockroachDB did not become ready in time" >&2
+  return 1
+}
+
+enable_vector_index() {
+  sudo docker exec ring-cockroach ./cockroach sql \
+    --certs-dir=/root/.cockroach-certs \
+    -d ring \
+    -e "SET CLUSTER SETTING feature.vector_index.enabled = true;" \
+    || true
+}
+
+ensure_network
+ensure_ssl
+if [[ -f certs/node.key ]]; then
+  chmod 600 certs/node.key
+fi
+ensure_env
+
+"${COMPOSE[@]}" up --build --detach
+
+wait_for_cockroach
+enable_vector_index
+
+"${COMPOSE[@]}" exec -T -w /src/ring api alembic upgrade head
+
+cd react
+exec pnpm run dev -- --host 0.0.0.0

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,15 @@
+{
+  "name": "Ring full stack",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "install": "uv sync --group dev --group ai && cd react && pnpm install && test -f certs/node.key && chmod 600 certs/node.key || true",
+  "start": "sudo service docker start",
+  "terminals": [
+    {
+      "name": "ring",
+      "command": "bash .cursor/cloud-start.sh"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -184,4 +184,7 @@ certs/client.ringcockroach.*
 ssh-key-2025-05-16*
 
 node_modules/
-.cursor/
+.cursor/*
+!.cursor/environment.json
+!.cursor/Dockerfile
+!.cursor/cloud-start.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a committed Cursor Cloud Environment so Cloud Desktop agents can boot Ring with Docker, Python/Node dependencies, and the full dev compose stack without manual setup each session.

## Changes

- **`.cursor/environment.json`** — Dockerfile-based build, `uv sync` + `pnpm install` on boot, Docker daemon start, and a `ring` terminal that runs the stack
- **`.cursor/Dockerfile`** — Ubuntu 24.04 with nested Docker (`fuse-overlayfs`), Node 22, pnpm, uv, Python 3.12, git, and sudo
- **`.cursor/cloud-start.sh`** — Creates `.env`/SSL if missing, brings up compose, enables Cockroach vector index, runs migrations, starts Vite on `0.0.0.0`
- **`.gitignore`** — Un-ignore the three `.cursor/` files (rest of `.cursor/` stays ignored)

## How to use

1. Merge this PR (or start a Cloud Agent from this branch).
2. In **Cloud Agents → Environments**, delete any old saved snapshot for Ring if it overrides the Dockerfile.
3. Start a new Cloud Desktop agent from `dev` (after merge) or this branch.
4. Open the **ring** terminal — API at `https://localhost/api/v1/`, frontend at port 5173.

## Notes

- `.env` is generated on first start with random secrets; for persistent credentials use Cursor **Secrets**.
- First compose build may take several minutes; subsequent agents benefit from Docker layer caching.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a373decc-3461-43c9-8adb-e5274229058a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a373decc-3461-43c9-8adb-e5274229058a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

