### PR TITLE
fix: service worker auto-update on deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,7 @@ certs/client.ringcockroach.*
 ssh-key-2025-05-16*
 
 node_modules/
+.pnpm-store/
 .cursor/*
 !.cursor/environment.json
 !.cursor/Dockerfile

--- a/react/nginx.conf
+++ b/react/nginx.conf
@@ -1,6 +1,18 @@
 server {
   listen 80;
 
+  location = /sw.js {
+    root /usr/share/nginx/html;
+    add_header Cache-Control "no-cache, no-store, must-revalidate";
+    try_files $uri =404;
+  }
+
+  location = /index.html {
+    root /usr/share/nginx/html;
+    add_header Cache-Control "no-cache, no-store, must-revalidate";
+    try_files $uri =404;
+  }
+
   location / {
     root /usr/share/nginx/html;
     index index.html index.htm;

--- a/react/src/main.tsx
+++ b/react/src/main.tsx
@@ -28,17 +28,8 @@ if (
 }
 /**/
 
-/* PWA */
-const updateSW = registerSW({
-  onNeedRefresh() {
-    if (confirm("New version available. Reload?")) {
-      updateSW(true)
-    }
-  },
-  onOfflineReady() {
-    console.log("PWA is ready for offline use")
-  },
-})
+/* PWA: auto-reload when a new service worker is ready after deploy */
+registerSW({ immediate: true })
 /**/
 
 /* vite Config */

--- a/react/src/sw.js
+++ b/react/src/sw.js
@@ -1,21 +1,14 @@
-import { precacheAndRoute } from "workbox-precaching"
-import { registerRoute } from "workbox-routing"
-import { StaleWhileRevalidate } from "workbox-strategies"
+import { cleanupOutdatedCaches, precacheAndRoute } from "workbox-precaching"
 
-// Precache static assets
 precacheAndRoute(self.__WB_MANIFEST || [])
+cleanupOutdatedCaches()
 
-// Cache API requests
-registerRoute(
-  ({ request }) => request.url.startsWith("https://api.yourdomain.com/"),
-  new StaleWhileRevalidate({
-    cacheName: "api-cache",
-  }),
-)
-
-// Clear cache on activate
-caches.keys().then((names) => {
-  for (const name of names) caches.delete(name)
+// Activate a freshly deployed worker immediately and take over open pages
+self.addEventListener("install", () => {
+  self.skipWaiting()
+})
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim())
 })
 
 // Push notification event listener


### PR DESCRIPTION
## Summary

- Activate new service workers immediately with `skipWaiting()` and `clientsClaim()`
- Stop wiping the Workbox precache on every SW startup
- Remove dead API cache route (`api.yourdomain.com`)
- Use PWA `autoUpdate` registration without a confirm prompt
- Set `no-cache` headers on `/sw.js` and `/index.html` so deploys propagate

## Test plan

- [ ] Deploy to prod and confirm existing users get the new build without manual cache clear
- [ ] Verify push notifications still work
- [ ] Confirm normal page loads and navigation after SW update reload


Made with [Cursor](https://cursor.com)