### PR TITLE
feat(cloud): faster Cloud Agent bootstrap with Vite API proxy

### DIFF
--- a/.cursor/cloud-start.sh
+++ b/.cursor/cloud-start.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 COMPOSE=(sudo docker compose -f compose.core.yml -f compose.dev.yml --profile dev)
+MODE="${1:-all}"
 
 ensure_network() {
   if ! sudo docker network inspect ring-network >/dev/null 2>&1; then
@@ -23,7 +24,10 @@ ensure_env() {
     return
   fi
 
-  cat > .env <<'EOF'
+  if [[ -f .env.cloud.example ]]; then
+    cp .env.cloud.example .env
+  else
+    cat > .env <<'EOF'
 ENVIRONMENT=local
 API_PORT=8001
 CELERY_BROKER_URL=redis://redis:6379/0
@@ -31,11 +35,12 @@ CELERY_RESULT_BACKEND=redis://redis:6379/0
 SQLALCHEMY_DATABASE_URI=postgresql://ring-postgres:ring-postgres@db:5432/ring
 COCKROACH_DATABASE_URI=cockroachdb://ringcockroach:ringcockroach@cockroach:26257/ring?sslmode=require
 JWT_SIGNING_ALGORITHM=HS256
-VITE_API_URL=https://localhost
+VITE_API_URL=
 BACKEND_CORS_ORIGINS="https://localhost:5173 http://localhost:5173"
 SW_DEV=true
 VITE_MAINTENANCE_MODE=false
 EOF
+  fi
 
   {
     echo "JWT_SIGNING_KEY=$(openssl rand -hex 32)"
@@ -59,6 +64,18 @@ wait_for_cockroach() {
   return 1
 }
 
+wait_for_api() {
+  local attempt
+  for attempt in $(seq 1 60); do
+    if curl -sf "http://localhost:8001/api/v1/openapi.json" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "API did not become ready in time" >&2
+  return 1
+}
+
 enable_vector_index() {
   sudo docker exec ring-cockroach ./cockroach sql \
     --certs-dir=/root/.cockroach-certs \
@@ -67,19 +84,65 @@ enable_vector_index() {
     || true
 }
 
-ensure_network
-ensure_ssl
-if [[ -f certs/node.key ]]; then
-  chmod 600 certs/node.key
-fi
-ensure_env
+seed_test_user() {
+  bash dev_util/cloud-seed.sh
+}
 
-"${COMPOSE[@]}" up --build --detach
+print_ready_banner() {
+  local vite_note="${1:-}"
+  cat <<EOF
 
-wait_for_cockroach
-enable_vector_index
+=== Ring cloud ready ===
+  App:    http://localhost:5173
+  API:    http://localhost:8001/api/v1/docs
+  Nginx:  https://localhost/api/v1/docs
+  Login:  test@example.com / testpassword123
+  Health: bash dev_util/cloud-health.sh
+${vite_note}
+EOF
+}
 
-"${COMPOSE[@]}" exec -T -w /src/ring api alembic upgrade head
+run_bootstrap() {
+  ensure_network
+  ensure_ssl
+  if [[ -f certs/node.key ]]; then
+    chmod 600 certs/node.key
+  fi
+  ensure_env
 
-cd react
-exec pnpm run dev -- --host 0.0.0.0
+  "${COMPOSE[@]}" up --build --detach
+
+  wait_for_cockroach
+  enable_vector_index
+
+  "${COMPOSE[@]}" exec -T -w /src/ring api alembic upgrade head
+
+  wait_for_api
+  seed_test_user
+
+  print_ready_banner "  Vite:   starts in the vite terminal (pnpm run dev)"
+}
+
+run_vite() {
+  cd "$ROOT/react"
+  # Empty VITE_API_URL uses same-origin /api/v1 via the Vite dev proxy.
+  export VITE_API_URL="${VITE_API_URL:-}"
+  exec pnpm run dev -- --host 0.0.0.0
+}
+
+case "$MODE" in
+  --bootstrap-only)
+    run_bootstrap
+    ;;
+  --vite-only)
+    run_vite
+    ;;
+  all|"")
+    run_bootstrap
+    run_vite
+    ;;
+  *)
+    echo "Usage: $0 [--bootstrap-only | --vite-only | all]" >&2
+    exit 1
+    ;;
+esac

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -4,12 +4,12 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "install": "uv sync --group dev --group ai && cd react && pnpm install && test -f certs/node.key && chmod 600 certs/node.key || true",
-  "start": "sudo service docker start",
+  "install": "uv sync --group dev --group ai && cd react && pnpm install && (test -f localhost.crt || bash dev_util/ssl.sh) && (test -f certs/node.key && chmod 600 certs/node.key || true)",
+  "start": "sudo service docker start && bash .cursor/cloud-start.sh --bootstrap-only",
   "terminals": [
     {
-      "name": "ring",
-      "command": "bash .cursor/cloud-start.sh"
+      "name": "vite",
+      "command": "bash .cursor/cloud-start.sh --vite-only"
     }
   ]
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "install": "uv sync --group dev --group ai && cd react && pnpm install && (test -f localhost.crt || bash dev_util/ssl.sh) && (test -f certs/node.key && chmod 600 certs/node.key || true)",
+  "install": "uv sync --group dev --group ai && (cd react && pnpm install) && (test -f localhost.crt || bash dev_util/ssl.sh) && (test -f certs/node.key && chmod 600 certs/node.key || true)",
   "start": "sudo service docker start && bash .cursor/cloud-start.sh --bootstrap-only",
   "terminals": [
     {

--- a/.cursor/skills/ring-cloud-dev/SKILL.md
+++ b/.cursor/skills/ring-cloud-dev/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: ring-cloud-dev
+description: Bootstrap, health-check, and browser-test Ring in Cursor Cloud Agent VMs. Use when starting compose, Vite, seeding test users, running ring fe regen, or validating the app on the cloud desktop.
+---
+
+# Ring Cloud Dev
+
+Playbook for agents working in the **Cursor Cloud Agent VM** on this repo.
+
+## One-command bootstrap
+
+The environment `start` hook runs backend bootstrap; the `vite` terminal starts the
+frontend. To run manually:
+
+```bash
+bash .cursor/cloud-start.sh --bootstrap-only   # Docker, DB, seed user
+bash .cursor/cloud-start.sh --vite-only        # Vite on :5173
+# or both:
+bash .cursor/cloud-start.sh
+```
+
+## Ready state
+
+After bootstrap, grep for `=== Ring cloud ready ===` or run:
+
+```bash
+bash dev_util/cloud-health.sh
+```
+
+| Service | URL |
+|---------|-----|
+| App (Vite) | http://localhost:5173 |
+| API (direct) | http://localhost:8001/api/v1/docs |
+| API (nginx) | https://localhost/api/v1/docs |
+
+## Test login
+
+Seeded on bootstrap (idempotent):
+
+- Email: `test@example.com`
+- Password: `testpassword123`
+
+Re-seed manually: `bash dev_util/cloud-seed.sh`
+
+## API client from browser
+
+Vite proxies `/api/v1` → `http://localhost:8001`. Cloud `.env` uses **empty**
+`VITE_API_URL` (see `.env.cloud.example`). Do **not** set
+`VITE_API_URL=https://localhost` with HTTP Vite — browsers block mixed content
+and login fails silently.
+
+Local OrbStack dev may still use `VITE_API_URL=https://localhost` when hitting
+nginx TLS directly (no Vite proxy).
+
+## `ring fe regen`
+
+Requires the API container on `:8001`:
+
+```bash
+source .venv/bin/activate
+ring fe regen
+```
+
+## Raw compose (debugging only)
+
+```bash
+source .venv/bin/activate
+sudo docker compose -f compose.core.yml -f compose.dev.yml --profile dev up --build --detach
+sudo docker compose -f compose.core.yml -f compose.dev.yml --profile dev \
+  exec -w /src/ring api alembic upgrade head
+```
+
+Vector index (handled by `cloud-start.sh`, run manually if migrations fail):
+
+```bash
+sudo docker exec ring-cockroach ./cockroach sql \
+  --certs-dir=/root/.cockroach-certs -d ring \
+  -e "SET CLUSTER SETTING feature.vector_index.enabled = true;"
+```
+
+## `.env`
+
+Gitignored. Created from `.env.cloud.example` on first bootstrap. SSL:
+`bash dev_util/ssl.sh`; `chmod 600 certs/node.key`.
+
+## Browser testing
+
+1. Open http://localhost:5173/login
+2. Log in with the test account above
+3. Expect redirect to the dashboard with sidebar navigation
+
+Nginx at `https://localhost/` serves `react/dist` only (404 for SPA routes
+unless built). Use Vite for frontend testing.
+
+## Notebook / WebSocket note
+
+Collaborative notebook WebSockets may still use `VITE_API_URL` for `wss://`
+URLs. If notebook sync fails in cloud, set `VITE_API_URL=http://localhost:8001`
+for those code paths or test notebook features via nginx production build.

--- a/.env.cloud.example
+++ b/.env.cloud.example
@@ -1,0 +1,17 @@
+# Cloud Agent VM defaults — copied to .env by .cursor/cloud-start.sh when missing.
+# For Vite dev, leave VITE_API_URL empty: the dev server proxies /api/v1 to :8001.
+ENVIRONMENT=local
+API_PORT=8001
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_RESULT_BACKEND=redis://redis:6379/0
+SQLALCHEMY_DATABASE_URI=postgresql://ring-postgres:ring-postgres@db:5432/ring
+COCKROACH_DATABASE_URI=cockroachdb://ringcockroach:ringcockroach@cockroach:26257/ring?sslmode=require
+JWT_SIGNING_ALGORITHM=HS256
+VITE_API_URL=
+BACKEND_CORS_ORIGINS="https://localhost:5173 http://localhost:5173"
+SW_DEV=true
+VITE_MAINTENANCE_MODE=false
+# Append secrets when bootstrapping (see README or cloud-start.sh):
+# JWT_SIGNING_KEY=
+# LLM_SERVICE_API_KEY=
+# VAPID_PRIVATE_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ celerybeat.pid
 # Environments
 .env
 .env*
+!.env.cloud.example
 *.env
 .venv
 env/
@@ -188,3 +189,5 @@ node_modules/
 !.cursor/environment.json
 !.cursor/Dockerfile
 !.cursor/cloud-start.sh
+!.cursor/skills/
+!.cursor/skills/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,40 +114,18 @@ ring fe regen                 # refresh react/src/client/ from OpenAPI
 
 ### Cursor Cloud Agent VM
 
-In the Cloud Agent VM, `ring` is not always wired up the same way, and Docker
-requires `sudo`. Use the raw compose commands instead:
+Use the [**ring-cloud-dev** skill](.cursor/skills/ring-cloud-dev/SKILL.md).
+Bootstrap is automated via [`.cursor/cloud-start.sh`](.cursor/cloud-start.sh)
+and [`.cursor/environment.json`](.cursor/environment.json); copy
+[`.env.cloud.example`](.env.cloud.example) for cloud `.env` defaults.
 
 ```bash
-source .venv/bin/activate
-
-sudo docker compose -f compose.core.yml -f compose.dev.yml --profile dev \
-  up --build --detach
-
-sudo docker compose -f compose.core.yml -f compose.dev.yml --profile dev \
-  exec -w /src/ring api alembic upgrade head
-
-cd react && pnpm run dev
+bash .cursor/cloud-start.sh --bootstrap-only
+bash dev_util/cloud-health.sh
 ```
 
-**Vector index gotcha.** CockroachDB requires the vector index cluster setting
-to be enabled before migrations succeed. Run this once after the
-`ring-cockroach` container first starts:
-
-```bash
-sudo docker exec ring-cockroach ./cockroach sql \
-  --certs-dir=/root/.cockroach-certs -d ring \
-  -e "SET CLUSTER SETTING feature.vector_index.enabled = true;"
-```
-
-Other Cloud-specific notes:
-
-- `.env` is required at the repo root and is `.gitignore`d; keys are documented
-  in [README.md](README.md).
-- SSL certs come from `bash dev_util/ssl.sh` (`localhost.crt`/`localhost.key`
-  for Nginx, `certs/` for CockroachDB). `certs/node.key` must be `chmod 600`.
-
-A personal skill (`~/.cursor/skills/ring-cloud-dev/`) captures these commands
-in a form that auto-applies inside the Cloud VM.
+Do not hand-roll compose unless debugging — the start script handles network,
+SSL, vector index, migrations, and a test user seed.
 
 ## Quality gates
 
@@ -187,3 +165,4 @@ separate CockroachDB instance on port 8008. There is one pre-existing flake:
     changes
   - `ring-authz-checklist/` — permission-check patterns for new routes
   - `ring-split-pr/` — splitting backend + frontend work into separate PRs
+ - `ring-cloud-dev/` — Cursor Cloud VM bootstrap, health checks, browser testing

--- a/README.md
+++ b/README.md
@@ -112,7 +112,31 @@ API accessible and `localhost/api/v1/docs`
 ring fe dev
 ```
 
-Accessible at `https://localhost:5173`
+Accessible at http://localhost:5173 during Vite dev. The dev server proxies
+`/api/v1` to the API on port 8001, so `VITE_API_URL` can be left empty in
+`.env` (see `.env.cloud.example`). Production builds still use
+`VITE_API_URL=https://localhost` to reach nginx.
+
+### Cursor Cloud Agent
+
+Cloud VMs use [`.cursor/environment.json`](.cursor/environment.json): `install`
+pulls deps, `start` runs `bash .cursor/cloud-start.sh --bootstrap-only`, and a
+`vite` terminal runs the frontend.
+
+```bash
+bash .cursor/cloud-start.sh              # bootstrap + Vite (manual)
+bash dev_util/cloud-health.sh            # verify stack
+```
+
+| | URL |
+|---|---|
+| App | http://localhost:5173 |
+| API docs | http://localhost:8001/api/v1/docs |
+| Test login | `test@example.com` / `testpassword123` |
+
+Agent playbook: [`.cursor/skills/ring-cloud-dev/SKILL.md`](.cursor/skills/ring-cloud-dev/SKILL.md).
+Copy [`.env.cloud.example`](.env.cloud.example) to `.env` if bootstrap has not
+run yet.
 
 ### `ring` commands
 

--- a/dev_util/cloud-health.sh
+++ b/dev_util/cloud-health.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Exit 0 when Ring cloud dev stack is ready for browser testing.
+set -euo pipefail
+
+errors=0
+
+check() {
+  local label="$1"
+  shift
+  if "$@"; then
+    echo "OK  ${label}"
+  else
+    echo "FAIL ${label}" >&2
+    errors=$((errors + 1))
+  fi
+}
+
+check_cockroach() {
+  sudo docker exec ring-cockroach ./cockroach sql \
+    --certs-dir=/root/.cockroach-certs \
+    -d ring \
+    -e "SELECT 1" >/dev/null 2>&1
+}
+
+check_api() {
+  curl -sf "http://localhost:8001/api/v1/openapi.json" >/dev/null
+}
+
+check_vite() {
+  curl -sf "http://localhost:5173/" >/dev/null
+}
+
+check_nginx_api() {
+  curl -skf "https://localhost/api/v1/openapi.json" >/dev/null
+}
+
+check "CockroachDB" check_cockroach
+check "API :8001" check_api
+check "Vite :5173" check_vite
+check "Nginx API :443" check_nginx_api
+
+if [[ "$errors" -eq 0 ]]; then
+  echo "Ring cloud stack is healthy"
+  exit 0
+fi
+
+echo "${errors} check(s) failed" >&2
+exit 1

--- a/dev_util/cloud-seed.sh
+++ b/dev_util/cloud-seed.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Idempotent dev seed: test user for cloud/local browser testing.
+set -euo pipefail
+
+API_BASE="${1:-http://localhost:8001}"
+EMAIL="${CLOUD_TEST_EMAIL:-test@example.com}"
+PASSWORD="${CLOUD_TEST_PASSWORD:-testpassword123}"
+NAME="${CLOUD_TEST_NAME:-Test User}"
+
+response="$(curl -s -w "\n%{http_code}" -X POST "${API_BASE}/api/v1/parties/user" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"${NAME}\",\"email\":\"${EMAIL}\",\"password\":\"${PASSWORD}\"}")"
+
+body="${response%$'\n'*}"
+status="${response##*$'\n'}"
+
+case "$status" in
+  201)
+    echo "Seeded test user ${EMAIL}"
+    ;;
+  400)
+    if [[ "$body" == *"already registered"* ]]; then
+      echo "Test user ${EMAIL} already exists"
+    else
+      echo "Seed skipped (${status}): ${body}" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "Seed failed (${status}): ${body}" >&2
+    exit 1
+    ;;
+esac

--- a/react/src/main.tsx
+++ b/react/src/main.tsx
@@ -42,8 +42,9 @@ const updateSW = registerSW({
 /**/
 
 /* vite Config */
+const apiOrigin = import.meta.env.VITE_API_URL ?? ""
 client.setConfig({
-  baseURL: `${import.meta.env.VITE_API_URL}/api/v1`,
+  baseURL: apiOrigin ? `${apiOrigin}/api/v1` : "/api/v1",
   auth: async () => {
     return localStorage.getItem("access_token") || ""
   },

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -88,4 +88,14 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    host: "0.0.0.0",
+    port: 5173,
+    proxy: {
+      "/api/v1": {
+        target: "http://localhost:8001",
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves Cursor Cloud Agent startup so agents land in a testable state without hand-rolling compose, fighting mixed-content login failures, or guessing URLs.

- **`environment.json`**: `start` runs full backend bootstrap; `vite` terminal starts the frontend; **install** wraps `pnpm install` in a subshell so SSL/cert steps run from repo root (fixes VM startup `exit 127`)
- **`cloud-start.sh`**: split `--bootstrap-only` / `--vite-only`; waits for API; seeds test user; prints ready banner
- **`dev_util/cloud-health.sh`** and **`dev_util/cloud-seed.sh`**: verify stack / idempotent test account
- **`.env.cloud.example`**: empty `VITE_API_URL` for proxy-based dev
- **Vite proxy**: `/api/v1` → `:8001`; `main.tsx` uses `/api/v1` when `VITE_API_URL` is empty
- **`ring-cloud-dev` skill**: agent playbook replacing duplicated AGENTS.md compose steps
- **README / AGENTS.md**: cloud section with URLs and skill pointer

## Test login

- `test@example.com` / `testpassword123` (seeded on bootstrap)

## Testing

- `bash dev_util/cloud-health.sh` — all checks pass
- Login via Vite proxy at `http://localhost:5173/api/v1/login/access-token`
- Browser login → dashboard verified
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eab78b1f-8542-42d5-b172-9f9e2c1458e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eab78b1f-8542-42d5-b172-9f9e2c1458e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

