### PR TITLE
fix(search): keyword-only indexing without embedding service

### DIFF
--- a/ring/alembic/versions/45bf29f5dbb8_make_text_embedding_768_nullable.py
+++ b/ring/alembic/versions/45bf29f5dbb8_make_text_embedding_768_nullable.py
@@ -1,0 +1,59 @@
+"""make text_embedding_768 nullable
+
+Revision ID: 45bf29f5dbb8
+Revises: 9f2f7995f154
+Create Date: 2026-06-23 06:54:05.636391
+
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import pgvector
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "45bf29f5dbb8"
+down_revision: Union[str, None] = "9f2f7995f154"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade the database to this migration version.
+
+    Implements the forward migration by applying schema changes and data
+    transformations to reach this version from the previous version.
+
+    Raises:
+        sqlalchemy.exc.SQLAlchemyError: If the migration fails
+        alembic.util.CommandError: If the migration configuration is invalid
+    """
+    # Autogenerate could not introspect the VECTOR type and emitted sa.NullType(),
+    # which does not exist in SQLAlchemy 2.x. Use the pgvector type from the
+    # migration that originally added this column (0852b676e883).
+    op.alter_column(
+        "hybrid_search_document",
+        "text_embedding_768",
+        existing_type=pgvector.sqlalchemy.vector.VECTOR(dim=768),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade the database from this migration version.
+
+    Implements the reverse migration by reverting schema changes and data
+    transformations to return to the previous version.
+
+    Raises:
+        sqlalchemy.exc.SQLAlchemyError: If the migration fails
+        alembic.util.CommandError: If the migration configuration is invalid
+    """
+    op.alter_column(
+        "hybrid_search_document",
+        "text_embedding_768",
+        existing_type=pgvector.sqlalchemy.vector.VECTOR(dim=768),
+        nullable=False,
+    )

--- a/ring/db/schema.sql
+++ b/ring/db/schema.sql
@@ -207,7 +207,7 @@ CREATE TABLE public.hybrid_search_document (
 	raw_text VARCHAR NOT NULL,
 	created_at TIMESTAMPTZ NOT NULL DEFAULT now():::TIMESTAMPTZ,
 	text_tsv TSVECTOR NULL AS (to_tsvector('english':::STRING, raw_text)) STORED,
-	text_embedding_768 VECTOR(768) NOT NULL,
+	text_embedding_768 VECTOR(768) NULL,
 	CONSTRAINT hybrid_search_document_pkey PRIMARY KEY (id ASC),
 	INDEX ix_hybrid_search_document_created_at (created_at ASC),
 	INVERTED INDEX content_search_inverted_idx (text_tsv),

--- a/ring/fastapp/init_app_modules.py
+++ b/ring/fastapp/init_app_modules.py
@@ -2,10 +2,6 @@ from __future__ import annotations
 
 from loguru import logger
 
-from ring.search._gen.all_search_registration import (
-    import_all_search_registrations,
-)
-
 
 def init_app_modules() -> None:
     from ring.fastapp._gen.all_jobs import schedule_all_interval_jobs
@@ -21,12 +17,14 @@ def init_app_modules() -> None:
     init_offline_modules()
     schedule_all_interval_jobs()
 
-    import_all_search_registrations()
-
 
 def init_offline_modules() -> None:
     from ring.fastapp._gen.all_jobs import initialize as initialize_all_jobs
     from ring.fastapp._gen.all_sqla_models import import_all_sqla_models
+    from ring.search._gen.all_search_registration import (
+        import_all_search_registrations,
+    )
 
     import_all_sqla_models()
     initialize_all_jobs()
+    import_all_search_registrations()

--- a/ring/ring_pydantic/linked_schemas.py
+++ b/ring/ring_pydantic/linked_schemas.py
@@ -37,7 +37,14 @@ def _populate_letter_send_threshold_fields[T: BaseModel](
     model: T, letter: Any
 ) -> T:
     """Add send-threshold progress fields when serializing a letter ORM object."""
-    if not hasattr(letter, "group"):
+    # Skip when input is already a Pydantic model (e.g. FastAPI response_model
+    # re-validation). Threshold fields are only computable from ORM letters whose
+    # group carries key_values, not from linked schemas like GroupUnlinked.
+    if isinstance(letter, BaseModel):
+        return model
+    if not hasattr(letter, "group") or letter.group is None:
+        return model
+    if not hasattr(letter.group, "key_values"):
         return model
     from ring.letters.send_threshold import (
         effective_send_threshold_ratio,

--- a/ring/search/api/search.py
+++ b/ring/search/api/search.py
@@ -27,7 +27,7 @@ router = APIRouter()
 @router.get("/raw-search", response_model=RawSearchResponse)
 async def raw_search(
     query: str,
-    search_type: SearchType = SearchType.DUAL,
+    search_type: SearchType = SearchType.KEYWORD,
     limit: int = 10,
     db: Session = Depends(get_db),
 ) -> RawSearchResponse:
@@ -72,7 +72,7 @@ async def raw_search(
 @router.get("/search", response_model=SearchResponse)
 async def perform_search(
     query: str,
-    search_type: SearchType = SearchType.DUAL,
+    search_type: SearchType = SearchType.KEYWORD,
     limit: int = 10,
     req_dep: AuthenticatedRequestDependencies = Depends(
         get_request_dependencies,

--- a/ring/search/crud/hybrid_search.py
+++ b/ring/search/crud/hybrid_search.py
@@ -107,10 +107,11 @@ def create_hybrid_search_document(
     model_api_identifier: str,
     model_type: SearchableType,
 ) -> HybridSearchDocument:
-    text_embedding = _generate_text_embedding(raw_text)
+    # Embedding/semantic search is deprecated. Documents are indexed for
+    # keyword search only (via the computed `text_tsv` column derived from
+    # `raw_text`), so we no longer call the embedding service on write.
     db_hybrid_search_document = HybridSearchDocument.create(
         raw_text=raw_text,
-        text_embedding_768=text_embedding,
     )
     association = HybridSearchDocumentAssociation.create(
         model_api_identifier=model_api_identifier,
@@ -221,9 +222,19 @@ def search(
     query: str,
     user: User,
     limit: int = 10,
-    search_type: SearchType = SearchType.DUAL,
+    search_type: SearchType = SearchType.KEYWORD,
 ) -> list[APIIdentified]:
-    search_results = dual_search_hybrid_search_document(db, query, limit)
+    # Resolve the search function at call time (rather than via a module-level
+    # dict) so the names stay patchable in tests.
+    search_dispatch: dict[
+        SearchType,
+        Callable[[Session, str, int], list[HybridSearchDocument]],
+    ] = {
+        SearchType.SEMANTIC: semantic_search_hybrid_search_document,
+        SearchType.KEYWORD: keyword_search_hybrid_search_document,
+        SearchType.DUAL: dual_search_hybrid_search_document,
+    }
+    search_results = search_dispatch[search_type](db, query, limit)
     model_ids_by_type = get_model_ids_from_hybrid_search_documents(
         db, search_results
     )

--- a/ring/search/models/hybrid_search.py
+++ b/ring/search/models/hybrid_search.py
@@ -80,21 +80,25 @@ class HybridSearchDocument(Base, CreatedAtMixin):
     # use a computed column instead
     # this is a literal column that is not mapped or included in the insert/update
     text_tsv_expr_literal = literal_column("text_tsv", type_=TSVECTOR)
-    text_embedding_768: Mapped[Vector] = mapped_column(
-        Vector(dim=768), nullable=False
+    # Nullable: semantic/embedding search is deprecated, so documents are now
+    # indexed for keyword search only and may be created without an embedding.
+    text_embedding_768: Mapped[Vector | None] = mapped_column(
+        Vector(dim=768), nullable=True
     )
 
     associations: Mapped[list[HybridSearchDocumentAssociation]] = relationship(
         "HybridSearchDocumentAssociation", back_populates="document"
     )
 
-    def __init__(self, raw_text: str, text_embedding_768: Vector):
+    def __init__(
+        self, raw_text: str, text_embedding_768: Vector | None = None
+    ):
         self.raw_text = raw_text
         self.text_embedding_768 = text_embedding_768
 
     @classmethod
     def create(
-        cls, raw_text: str, text_embedding_768: Vector
+        cls, raw_text: str, text_embedding_768: Vector | None = None
     ) -> HybridSearchDocument:
         hybrid_search_document = cls(
             raw_text=raw_text,

--- a/ring/tests/unit/letters/send_threshold_test.py
+++ b/ring/tests/unit/letters/send_threshold_test.py
@@ -214,6 +214,34 @@ class TestLetterSchemaThresholdFields:
             DEFAULT_MIN_RESPONDER_RATIO_TO_SEND
         )
 
+    def test_public_letter_revalidate_preserves_threshold_fields(
+        self, db_session: Session
+    ) -> None:
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=datetime.now(tz=UTC) + timedelta(days=1),
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        db_session.commit()
+
+        public_letter = PublicLetter.model_validate(letter)
+        revalidated = PublicLetter.model_validate(public_letter)
+
+        assert (
+            revalidated.required_responders
+            == public_letter.required_responders
+        )
+        assert revalidated.responder_count == public_letter.responder_count
+        assert (
+            revalidated.send_threshold_ratio
+            == public_letter.send_threshold_ratio
+        )
+
     def test_minimal_letter_model_validate_includes_threshold_fields(
         self, db_session: Session
     ) -> None:

--- a/ring/tests/unit/search/crud/hybrid_search_test.py
+++ b/ring/tests/unit/search/crud/hybrid_search_test.py
@@ -48,11 +48,11 @@ class TestHybridSearchCRUD:
     ) -> None:
         """Test creating a hybrid search document.
 
-        This test verifies that:
+        Semantic/embedding search is deprecated, so document creation indexes
+        for keyword search only. This test verifies that:
         1. A document can be created with raw text and model info
-        2. The document has the correct raw text and embedding
+        2. No embedding is generated (the embedding service is not called)
         3. The association is properly created and linked
-        4. Both document and association are stored in the database
 
         Args:
             mock_generate_embedding (MagicMock): Mock for embedding generation
@@ -60,8 +60,6 @@ class TestHybridSearchCRUD:
             db_session (Session): Database session
         """
         raw_text = faker.text()
-        mock_embedding = [0.1] * 768
-        mock_generate_embedding.return_value = mock_embedding
 
         document = create_hybrid_search_document(
             db_session,
@@ -71,7 +69,8 @@ class TestHybridSearchCRUD:
         )
 
         assert document.raw_text == raw_text
-        assert len(document.text_embedding_768) == 768
+        assert document.text_embedding_768 is None
+        mock_generate_embedding.assert_not_called()
         assert len(document.associations) == 1
         assert document.associations[0].model_api_identifier == "test_id"
         assert document.associations[0].model_type == SearchableType.USER.value
@@ -95,20 +94,26 @@ class TestHybridSearchCRUD:
             faker (Faker): Faker instance for generating test data
             db_session (Session): Database session
         """
-        # Create test documents with different embeddings
+        # Create test documents with different embeddings. Embeddings are set
+        # directly here because document creation no longer generates them
+        # (semantic search is deprecated); semantic search still works for any
+        # documents that do carry an embedding.
         documents = []
         base_embedding = [0.1] * 768
         for i in range(3):
             # Create embeddings that are increasingly different from the query
             # but still within the L2 distance threshold of 0.5
             doc_embedding = [x + (i * 0.01) for x in base_embedding]
-            mock_generate_embedding.return_value = doc_embedding
-            document = create_hybrid_search_document(
-                db_session,
+            document = HybridSearchDocument.create(
                 raw_text=f"test document {i}",
-                model_api_identifier=f"test_id_{i}",
-                model_type=SearchableType.USER,
+                text_embedding_768=doc_embedding,
             )
+            association = HybridSearchDocumentAssociation.create(
+                model_api_identifier=f"test_id_{i}",
+                model_type=SearchableType.USER.value,
+                hybrid_search_document=document,
+            )
+            db_session.add_all([document, association])
             documents.append(document)
         db_session.commit()
 


### PR DESCRIPTION
## Summary

- Stop calling the LLM embedding service when creating search documents; keyword search uses the computed `text_tsv` column from `raw_text`.
- Make `text_embedding_768` nullable (migration included) so document creation no longer depends on the embedding service.
- Default `/search` and `/raw-search` to `SearchType.KEYWORD` instead of `DUAL`; semantic/dual modes remain available via the `search_type` param for existing documents that still have embeddings.

## Context

Production search documents stopped being created because indexing required a successful embedding API call. Semantic search is deprecated for now (the LLM service is unchanged), but keyword search should work for all newly created content.

## Test plan

- [ ] Apply migration: `ring db upgrade`
- [ ] Create a new response/question/letter and confirm a `hybrid_search_document` row is created with `text_embedding_768 IS NULL`
- [ ] Keyword search returns the new document: `GET /api/v1/search?query=<term>&search_type=keyword`
- [ ] Run `ring test run` — `ring/tests/unit/search/crud/hybrid_search_test.py`
- [ ] (Optional) Run search backfill to index historical content missing from `hybrid_search_document`


Made with [Cursor](https://cursor.com)