### PR TITLE
perf(search): slim result snippets and request-scoped enforcer cache

### DIFF
--- a/react/openapi.json
+++ b/react/openapi.json
@@ -2487,7 +2487,7 @@
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/SearchType",
-              "default": "dual"
+              "default": "keyword"
             }
           },
           {
@@ -2553,7 +2553,7 @@
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/SearchType",
-              "default": "dual"
+              "default": "keyword"
             }
           },
           {
@@ -4241,6 +4241,119 @@
         "title": "ScheduleUnlinked",
         "description": "Schema for schedule data with unlinked task relationships.\n\nThis schema extends the base Schedule schema and includes a list of tasks,\nusing the unlinked task schema to avoid circular references.\n\nAttributes:\n    tasks: List of tasks associated with this schedule"
       },
+      "SearchGroupSnippet": {
+        "properties": {
+          "api_identifier": {
+            "type": "string",
+            "title": "Api Identifier"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "member_count": {
+            "type": "integer",
+            "title": "Member Count"
+          },
+          "letter_count": {
+            "type": "integer",
+            "title": "Letter Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "api_identifier",
+          "name",
+          "member_count",
+          "letter_count"
+        ],
+        "title": "SearchGroupSnippet"
+      },
+      "SearchLetterSnippet": {
+        "properties": {
+          "api_identifier": {
+            "type": "string",
+            "title": "Api Identifier"
+          },
+          "number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number"
+          },
+          "group_name": {
+            "type": "string",
+            "title": "Group Name"
+          },
+          "participant_count": {
+            "type": "integer",
+            "title": "Participant Count"
+          },
+          "question_count": {
+            "type": "integer",
+            "title": "Question Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "api_identifier",
+          "number",
+          "group_name",
+          "participant_count",
+          "question_count"
+        ],
+        "title": "SearchLetterSnippet"
+      },
+      "SearchQuestionSnippet": {
+        "properties": {
+          "api_identifier": {
+            "type": "string",
+            "title": "Api Identifier"
+          },
+          "question_text": {
+            "type": "string",
+            "title": "Question Text"
+          },
+          "group_name": {
+            "type": "string",
+            "title": "Group Name"
+          },
+          "letter_api_identifier": {
+            "type": "string",
+            "title": "Letter Api Identifier"
+          },
+          "letter_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Letter Number"
+          },
+          "response_count": {
+            "type": "integer",
+            "title": "Response Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "api_identifier",
+          "question_text",
+          "group_name",
+          "letter_api_identifier",
+          "letter_number",
+          "response_count"
+        ],
+        "title": "SearchQuestionSnippet"
+      },
       "SearchResponse": {
         "properties": {
           "results": {
@@ -4262,24 +4375,84 @@
         ],
         "title": "SearchResponse"
       },
+      "SearchResponseSnippet": {
+        "properties": {
+          "api_identifier": {
+            "type": "string",
+            "title": "Api Identifier"
+          },
+          "response_text": {
+            "type": "string",
+            "title": "Response Text"
+          },
+          "question_text": {
+            "type": "string",
+            "title": "Question Text"
+          },
+          "letter_api_identifier": {
+            "type": "string",
+            "title": "Letter Api Identifier"
+          },
+          "letter_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Letter Number"
+          },
+          "group_name": {
+            "type": "string",
+            "title": "Group Name"
+          },
+          "participant_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Participant Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "api_identifier",
+          "response_text",
+          "question_text",
+          "letter_api_identifier",
+          "letter_number",
+          "group_name",
+          "participant_name"
+        ],
+        "title": "SearchResponseSnippet"
+      },
       "SearchResult": {
         "properties": {
           "model": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/UserLinked"
+                "$ref": "#/components/schemas/SearchUserSnippet"
               },
               {
-                "$ref": "#/components/schemas/GroupLinked"
+                "$ref": "#/components/schemas/SearchGroupSnippet"
               },
               {
-                "$ref": "#/components/schemas/QuestionLinked"
+                "$ref": "#/components/schemas/SearchQuestionSnippet"
               },
               {
-                "$ref": "#/components/schemas/ResponseLinked"
+                "$ref": "#/components/schemas/SearchResponseSnippet"
               },
               {
-                "$ref": "#/components/schemas/PublicLetter"
+                "$ref": "#/components/schemas/SearchLetterSnippet"
+              },
+              {
+                "$ref": "#/components/schemas/UnknownSearchResult"
               }
             ],
             "title": "Model"
@@ -4295,7 +4468,7 @@
           "type"
         ],
         "title": "SearchResult",
-        "description": "Search result model that can hold different types of models based on type field.\n\nAttributes:\n    model (Any): The model instance\n    type (str): The type of the model"
+        "description": "Search result with a slim payload tailored for the search UI."
       },
       "SearchType": {
         "type": "string",
@@ -4305,6 +4478,36 @@
           "dual"
         ],
         "title": "SearchType"
+      },
+      "SearchUserSnippet": {
+        "properties": {
+          "api_identifier": {
+            "type": "string",
+            "title": "Api Identifier"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "group_count": {
+            "type": "integer",
+            "title": "Group Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "api_identifier",
+          "name",
+          "group_count"
+        ],
+        "title": "SearchUserSnippet"
       },
       "SingleGroupKeyValueUpdate": {
         "properties": {
@@ -4427,6 +4630,19 @@
         ],
         "title": "Token",
         "description": "Authentication token schema.\n\nRepresents the structure of an authentication token response.\n\nAttributes:\n    access_token (str): The JWT access token string\n    token_type (str): The type of token (e.g., \"bearer\")"
+      },
+      "UnknownSearchResult": {
+        "properties": {
+          "model": {
+            "title": "Model"
+          }
+        },
+        "type": "object",
+        "required": [
+          "model"
+        ],
+        "title": "UnknownSearchResult",
+        "description": "Search result model for unknown types.\n\nAttributes:\n    type (str): Type of the model\n    model (Any): The model instance"
       },
       "UserCreate": {
         "properties": {

--- a/react/src/client/types.gen.ts
+++ b/react/src/client/types.gen.ts
@@ -633,24 +633,60 @@ export type ScheduleUnlinked = {
     tasks: Array<TaskUnlinked>;
 };
 
+export type SearchGroupSnippet = {
+    api_identifier: string;
+    name: string;
+    member_count: number;
+    letter_count: number;
+};
+
+export type SearchLetterSnippet = {
+    api_identifier: string;
+    number: number | null;
+    group_name: string;
+    participant_count: number;
+    question_count: number;
+};
+
+export type SearchQuestionSnippet = {
+    api_identifier: string;
+    question_text: string;
+    group_name: string;
+    letter_api_identifier: string;
+    letter_number: number | null;
+    response_count: number;
+};
+
 export type SearchResponse = {
     results: Array<SearchResult>;
     total: number;
 };
 
+export type SearchResponseSnippet = {
+    api_identifier: string;
+    response_text: string;
+    question_text: string;
+    letter_api_identifier: string;
+    letter_number: number | null;
+    group_name: string;
+    participant_name: string | null;
+};
+
 /**
- * Search result model that can hold different types of models based on type field.
- *
- * Attributes:
- * model (Any): The model instance
- * type (str): The type of the model
+ * Search result with a slim payload tailored for the search UI.
  */
 export type SearchResult = {
-    model: UserLinked | GroupLinked | QuestionLinked | ResponseLinked | PublicLetter;
+    model: SearchUserSnippet | SearchGroupSnippet | SearchQuestionSnippet | SearchResponseSnippet | SearchLetterSnippet | UnknownSearchResult;
     type: string;
 };
 
 export type SearchType = 'semantic' | 'keyword' | 'dual';
+
+export type SearchUserSnippet = {
+    api_identifier: string;
+    name: string | null;
+    group_count: number;
+};
 
 /**
  * Schema for updating a single group key-value pair.
@@ -726,6 +762,17 @@ export type TaskUnlinked = {
 export type Token = {
     access_token: string;
     token_type: string;
+};
+
+/**
+ * Search result model for unknown types.
+ *
+ * Attributes:
+ * type (str): Type of the model
+ * model (Any): The model instance
+ */
+export type UnknownSearchResult = {
+    model: unknown;
 };
 
 /**

--- a/react/src/components/Common/SearchResultRow.tsx
+++ b/react/src/components/Common/SearchResultRow.tsx
@@ -2,28 +2,29 @@ import { Badge } from "@/components/ui/badge"
 import { TableCell, TableRow } from "@/components/ui/table"
 import { Link } from "@tanstack/react-router"
 import type {
-  GroupLinked,
-  LetterUnlinked,
-  PublicLetter,
-  QuestionLinked,
-  ResponseLinked,
+  SearchGroupSnippet,
+  SearchLetterSnippet,
+  SearchQuestionSnippet,
+  SearchResponseSnippet,
   SearchResult,
-  UserLinked,
+  SearchUserSnippet,
 } from "../../client"
 
 interface SearchResultRowProps {
   result: SearchResult
 }
 
-function ResponseSearchResultRow({ result }: { result: SearchResult }) {
-  const model = result.model as ResponseLinked
-
+function ResponseSearchResultRow({
+  model,
+}: {
+  model: SearchResponseSnippet
+}) {
   return (
     <TableRow className="cursor-pointer">
       <TableCell>
         <Link
           to="/loops/$loopId"
-          params={{ loopId: model.letter?.api_identifier ?? "" }}
+          params={{ loopId: model.letter_api_identifier }}
           style={{ textDecoration: "none" }}
         >
           <div className="flex flex-col gap-2">
@@ -32,16 +33,14 @@ function ResponseSearchResultRow({ result }: { result: SearchResult }) {
                 Response
               </Badge>
               <span className="font-medium">
-                {model.group?.name} - Letter {model.letter?.number}
+                {model.group_name} - Letter {model.letter_number}
               </span>
             </div>
             <div className="flex gap-2 items-center">
-              <span className="font-medium">
-                Q: {model.question.question_text}
-              </span>
+              <span className="font-medium">Q: {model.question_text}</span>
             </div>
             <div className="flex gap-2 items-center">
-              <span className="font-medium">by {model.participant.name}</span>
+              <span className="font-medium">by {model.participant_name}</span>
             </div>
             <p className="text-sm text-muted-foreground line-clamp-2">
               {model.response_text}
@@ -53,9 +52,7 @@ function ResponseSearchResultRow({ result }: { result: SearchResult }) {
   )
 }
 
-function UserSearchResultRow({ result }: { result: SearchResult }) {
-  const model = result.model as UserLinked
-
+function UserSearchResultRow({ model }: { model: SearchUserSnippet }) {
   return (
     <TableRow className="cursor-pointer">
       <TableCell>
@@ -67,7 +64,7 @@ function UserSearchResultRow({ result }: { result: SearchResult }) {
             <span className="font-medium">{model.name}</span>
           </div>
           <p className="text-sm text-muted-foreground">
-            Member of {model.groups.length} groups
+            Member of {model.group_count} groups
           </p>
         </div>
       </TableCell>
@@ -75,9 +72,7 @@ function UserSearchResultRow({ result }: { result: SearchResult }) {
   )
 }
 
-function GroupSearchResultRow({ result }: { result: SearchResult }) {
-  const model = result.model as GroupLinked
-
+function GroupSearchResultRow({ model }: { model: SearchGroupSnippet }) {
   return (
     <TableRow className="cursor-pointer">
       <TableCell>
@@ -94,7 +89,7 @@ function GroupSearchResultRow({ result }: { result: SearchResult }) {
               <span className="font-medium">{model.name}</span>
             </div>
             <p className="text-sm text-muted-foreground">
-              {model.members.length} members • {model.letters.length} letters
+              {model.member_count} members • {model.letter_count} letters
             </p>
           </div>
         </Link>
@@ -103,16 +98,17 @@ function GroupSearchResultRow({ result }: { result: SearchResult }) {
   )
 }
 
-function QuestionSearchResultRow({ result }: { result: SearchResult }) {
-  const model = result.model as QuestionLinked
-  const letter = model.letter as LetterUnlinked
-
+function QuestionSearchResultRow({
+  model,
+}: {
+  model: SearchQuestionSnippet
+}) {
   return (
     <TableRow className="cursor-pointer">
       <TableCell>
         <Link
           to="/loops/$loopId"
-          params={{ loopId: letter.api_identifier }}
+          params={{ loopId: model.letter_api_identifier }}
           style={{ textDecoration: "none" }}
         >
           <div className="flex flex-col gap-2">
@@ -121,14 +117,14 @@ function QuestionSearchResultRow({ result }: { result: SearchResult }) {
                 Question
               </Badge>
               <span className="font-medium">
-                {model.group.name} - Letter {letter.number}
+                {model.group_name} - Letter {model.letter_number}
               </span>
             </div>
             <p className="text-sm text-muted-foreground line-clamp-2">
               {model.question_text}
             </p>
             <p className="text-sm text-muted-foreground/70">
-              {model.responses.length} responses
+              {model.response_count} responses
             </p>
           </div>
         </Link>
@@ -137,9 +133,7 @@ function QuestionSearchResultRow({ result }: { result: SearchResult }) {
   )
 }
 
-function LetterSearchResultRow({ result }: { result: SearchResult }) {
-  const model = result.model as PublicLetter
-
+function LetterSearchResultRow({ model }: { model: SearchLetterSnippet }) {
   return (
     <TableRow className="cursor-pointer">
       <TableCell>
@@ -154,12 +148,12 @@ function LetterSearchResultRow({ result }: { result: SearchResult }) {
                 Letter
               </Badge>
               <span className="font-medium">
-                {model.group.name} - Letter {model.number}
+                {model.group_name} - Letter {model.number}
               </span>
             </div>
             <p className="text-sm text-muted-foreground">
-              {model.participants.length} participants •{" "}
-              {model.questions.length} questions
+              {model.participant_count} participants • {model.question_count}{" "}
+              questions
             </p>
           </div>
         </Link>
@@ -173,9 +167,9 @@ function DefaultSearchResultRow({ result }: { result: SearchResult }) {
     <TableRow className="cursor-pointer">
       <TableCell>
         <div className="flex flex-col gap-1">
-          <span className="font-medium">{result.model.api_identifier}</span>
+          <span className="font-medium">{result.type}</span>
           <Badge className="w-fit bg-blue-500 text-white hover:bg-blue-600">
-            {result.type.replace("Linked", "")}
+            Search result
           </Badge>
         </div>
       </TableCell>
@@ -185,16 +179,24 @@ function DefaultSearchResultRow({ result }: { result: SearchResult }) {
 
 export function SearchResultRow({ result }: SearchResultRowProps) {
   switch (result.type) {
-    case "ResponseLinked":
-      return <ResponseSearchResultRow result={result} />
-    case "UserLinked":
-      return <UserSearchResultRow result={result} />
-    case "GroupLinked":
-      return <GroupSearchResultRow result={result} />
-    case "QuestionLinked":
-      return <QuestionSearchResultRow result={result} />
-    case "PublicLetter":
-      return <LetterSearchResultRow result={result} />
+    case "SearchResponseSnippet":
+      return (
+        <ResponseSearchResultRow
+          model={result.model as SearchResponseSnippet}
+        />
+      )
+    case "SearchUserSnippet":
+      return <UserSearchResultRow model={result.model as SearchUserSnippet} />
+    case "SearchGroupSnippet":
+      return <GroupSearchResultRow model={result.model as SearchGroupSnippet} />
+    case "SearchQuestionSnippet":
+      return (
+        <QuestionSearchResultRow
+          model={result.model as SearchQuestionSnippet}
+        />
+      )
+    case "SearchLetterSnippet":
+      return <LetterSearchResultRow model={result.model as SearchLetterSnippet} />
     default:
       return <DefaultSearchResultRow result={result} />
   }

--- a/react/src/routes/_layout/search.tsx
+++ b/react/src/routes/_layout/search.tsx
@@ -78,9 +78,13 @@ function SearchContent() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {searchResults.results.map((result: SearchResult) => (
+              {searchResults.results.map((result: SearchResult, index) => (
                 <SearchResultRow
-                  key={result.model.api_identifier}
+                  key={
+                    "api_identifier" in result.model
+                      ? `${result.type}:${result.model.api_identifier}`
+                      : `${result.type}:${index}`
+                  }
                   result={result}
                 />
               ))}

--- a/ring/authz/authz.py
+++ b/ring/authz/authz.py
@@ -55,9 +55,11 @@ def filter_to_authorized(
     user: User,
     action: Action,
     resources: Sequence[APIIdentified],
+    enforcer: Enforcer | None = None,
 ) -> Sequence[APIIdentified]:
     """Filter a sequence of resources to only include those that the user has permission to perform an action on."""
-    enforcer = build_stateless_enforcer(db, user.api_identifier)
+    if enforcer is None:
+        enforcer = build_stateless_enforcer(db, user.api_identifier)
     return [
         resource
         for resource in resources

--- a/ring/fastapp/dependencies.py
+++ b/ring/fastapp/dependencies.py
@@ -7,7 +7,7 @@ FastAPI's dependency injection system to provide these dependencies to route han
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import boto3
@@ -16,12 +16,14 @@ from fastapi import Depends, HTTPException, WebSocket, status
 from loguru import logger
 from mypy_boto3_s3 import S3Client
 
+from ring.authz.enforcer import build_stateless_enforcer
 from ring.parties.crud import user as user_crud
 from ring.parties.models.user_model import User
 from ring.security import decode_token, oauth2_scheme
 from ring.sqlalchemy_base import get_db
 
 if TYPE_CHECKING:
+    from casbin import Enforcer
     from sqlalchemy.orm import Session
 
 
@@ -51,6 +53,15 @@ class AuthenticatedRequestDependencies(RequestDependenciesBase):
     """
 
     current_user: User
+    _enforcer: Enforcer | None = field(default=None, init=False, repr=False)
+
+    def get_enforcer(self) -> Enforcer:
+        """Return a request-scoped Casbin enforcer, building it once if needed."""
+        if self._enforcer is None:
+            self._enforcer = build_stateless_enforcer(
+                self.db, self.current_user.api_identifier
+            )
+        return self._enforcer
 
 
 async def get_current_user(

--- a/ring/ring_pydantic/linked_schemas.py
+++ b/ring/ring_pydantic/linked_schemas.py
@@ -29,6 +29,13 @@ from ring.parties.schemas.group import Group, GroupUnlinked
 from ring.parties.schemas.invite import Invite
 from ring.parties.schemas.user import User, UserUnlinked
 from ring.s3.schemas.image import WithImageMixin
+from ring.search.schemas.search_snippets import (
+    SearchGroupSnippet,
+    SearchLetterSnippet,
+    SearchQuestionSnippet,
+    SearchResponseSnippet,
+    SearchUserSnippet,
+)
 from ring.tasks.schemas.schedule import Schedule, ScheduleUnlinked
 from ring.tasks.schemas.task import TaskUnlinked
 
@@ -325,36 +332,17 @@ class UnknownSearchResult(BaseModel):
 
 
 class SearchResult(BaseModel):
-    """Search result model that can hold different types of models based on type field.
-
-    Attributes:
-        model (Any): The model instance
-        type (str): The type of the model
-    """
+    """Search result with a slim payload tailored for the search UI."""
 
     model: (
-        UserLinked
-        | GroupLinked
-        | QuestionLinked
-        | ResponseLinked
-        | PublicLetter
-        # | UnknownSearchResult
+        SearchUserSnippet
+        | SearchGroupSnippet
+        | SearchQuestionSnippet
+        | SearchResponseSnippet
+        | SearchLetterSnippet
+        | UnknownSearchResult
     )
     type: str
-
-    @classmethod
-    def from_model(cls, model: Any) -> "SearchResult":
-        """Create a SearchResult from a model instance.
-
-        Args:
-            model: Any model instance that has a PYDANTIC_MODEL attribute
-        """
-        if not hasattr(model, "PYDANTIC_MODEL"):
-            return UnknownSearchResult(model=model)
-
-        # Convert SQLAlchemy model to Pydantic model using PYDANTIC_MODEL
-        pydantic_model = model.PYDANTIC_MODEL.model_validate(model)
-        return cls(model=pydantic_model, type=model.PYDANTIC_MODEL.__name__)
 
 
 class SearchResponse(BaseModel):

--- a/ring/search/api/search.py
+++ b/ring/search/api/search.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from casbin import Enforcer
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
@@ -8,13 +9,14 @@ from ring.fastapp.dependencies import (
     get_db,
     get_request_dependencies,
 )
-from ring.ring_pydantic.linked_schemas import SearchResponse, SearchResult
+from ring.ring_pydantic.linked_schemas import SearchResponse
 from ring.search.crud.hybrid_search import (
     dual_search_hybrid_search_document,
     keyword_search_hybrid_search_document,
     search,
     semantic_search_hybrid_search_document,
 )
+from ring.search.crud.search_serialization import build_search_results
 from ring.search.schemas.search import (
     RawSearchResponse,
     RawSearchResult,
@@ -84,8 +86,9 @@ async def perform_search(
         user=req_dep.current_user,
         limit=limit,
         search_type=search_type,
+        enforcer=req_dep.get_enforcer(),
     )
     return SearchResponse(
-        results=[SearchResult.from_model(result) for result in results],
+        results=build_search_results(req_dep.db, results),
         total=len(results),
     )

--- a/ring/search/crud/hybrid_search.py
+++ b/ring/search/crud/hybrid_search.py
@@ -6,6 +6,7 @@ from enum import Enum
 from functools import wraps
 from typing import Callable
 
+from casbin import Enforcer
 from llm_service import (
     ApiClient,
     EmbeddingRequest,
@@ -223,6 +224,7 @@ def search(
     user: User,
     limit: int = 10,
     search_type: SearchType = SearchType.KEYWORD,
+    enforcer: Enforcer | None = None,
 ) -> list[APIIdentified]:
     # Resolve the search function at call time (rather than via a module-level
     # dict) so the names stay patchable in tests.
@@ -244,6 +246,6 @@ def search(
             hydrate_results(db, model_type, model_api_identifiers)
         )
     hydrated_results = filter_to_authorized(
-        db, user, Action.READ, hydrated_results
+        db, user, Action.READ, hydrated_results, enforcer=enforcer
     )
     return hydrated_results

--- a/ring/search/crud/search_serialization.py
+++ b/ring/search/crud/search_serialization.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Sequence
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from ring.api_identifier.api_identified_model import APIIdentified
+from ring.letters.models.letter_model import Letter, letter_to_user_assocation
+from ring.letters.models.question_model import Question
+from ring.letters.models.response_model import Response
+from ring.parties.models.group_model import Group
+from ring.parties.models.user_group_assocation import user_group_association
+from ring.parties.models.user_model import User
+from ring.ring_pydantic.linked_schemas import SearchResult
+from ring.search.schemas.search_snippets import (
+    SearchGroupSnippet,
+    SearchLetterSnippet,
+    SearchQuestionSnippet,
+    SearchResponseSnippet,
+    SearchUserSnippet,
+)
+
+
+def build_search_results(
+    db: Session, models: Sequence[APIIdentified]
+) -> list[SearchResult]:
+    """Build slim search API payloads without loading full linked graphs."""
+    if not models:
+        return []
+
+    by_class: dict[type[APIIdentified], list[APIIdentified]] = defaultdict(
+        list
+    )
+    for model in models:
+        by_class[type(model)].append(model)
+
+    snippet_by_api_id: dict[str, SearchResult] = {}
+
+    if users := by_class.get(User):
+        _add_user_snippets(db, users, snippet_by_api_id)
+    if groups := by_class.get(Group):
+        _add_group_snippets(db, groups, snippet_by_api_id)
+    if questions := by_class.get(Question):
+        _add_question_snippets(db, questions, snippet_by_api_id)
+    if responses := by_class.get(Response):
+        _add_response_snippets(db, responses, snippet_by_api_id)
+    if letters := by_class.get(Letter):
+        _add_letter_snippets(db, letters, snippet_by_api_id)
+
+    results: list[SearchResult] = []
+    for model in models:
+        result = snippet_by_api_id.get(model.api_identifier)
+        if result is not None:
+            results.append(result)
+    return results
+
+
+def _add_user_snippets(
+    db: Session,
+    users: Sequence[User],
+    snippet_by_api_id: dict[str, SearchResult],
+) -> None:
+    user_ids = [user.id for user in users]
+    group_counts = dict(
+        db.execute(
+            select(
+                user_group_association.c.user_id,
+                func.count(),
+            )
+            .where(user_group_association.c.user_id.in_(user_ids))
+            .group_by(user_group_association.c.user_id)
+        ).all()
+    )
+    for user in users:
+        snippet_by_api_id[user.api_identifier] = SearchResult(
+            model=SearchUserSnippet(
+                api_identifier=user.api_identifier,
+                name=user.name,
+                group_count=group_counts.get(user.id, 0),
+            ),
+            type=SearchUserSnippet.__name__,
+        )
+
+
+def _add_group_snippets(
+    db: Session,
+    groups: Sequence[Group],
+    snippet_by_api_id: dict[str, SearchResult],
+) -> None:
+    group_ids = [group.id for group in groups]
+    member_counts = dict(
+        db.execute(
+            select(
+                user_group_association.c.group_id,
+                func.count(),
+            )
+            .where(user_group_association.c.group_id.in_(group_ids))
+            .group_by(user_group_association.c.group_id)
+        ).all()
+    )
+    letter_counts = dict(
+        db.execute(
+            select(Letter.group_id, func.count())
+            .where(Letter.group_id.in_(group_ids))
+            .group_by(Letter.group_id)
+        ).all()
+    )
+    for group in groups:
+        snippet_by_api_id[group.api_identifier] = SearchResult(
+            model=SearchGroupSnippet(
+                api_identifier=group.api_identifier,
+                name=group.name,
+                member_count=member_counts.get(group.id, 0),
+                letter_count=letter_counts.get(group.id, 0),
+            ),
+            type=SearchGroupSnippet.__name__,
+        )
+
+
+def _add_question_snippets(
+    db: Session,
+    questions: Sequence[Question],
+    snippet_by_api_id: dict[str, SearchResult],
+) -> None:
+    question_api_ids = [question.api_identifier for question in questions]
+    rows = db.execute(
+        select(
+            Question.api_identifier,
+            Question.question_text,
+            Letter.api_identifier,
+            Letter.number,
+            Group.name,
+            func.count(Response.id),
+        )
+        .join(Letter, Question.letter_id == Letter.id)
+        .join(Group, Letter.group_id == Group.id)
+        .outerjoin(Response, Response.question_id == Question.id)
+        .where(Question.api_identifier.in_(question_api_ids))
+        .group_by(
+            Question.id,
+            Question.api_identifier,
+            Question.question_text,
+            Letter.api_identifier,
+            Letter.number,
+            Group.name,
+        )
+    ).all()
+    for (
+        api_identifier,
+        question_text,
+        letter_api_identifier,
+        letter_number,
+        group_name,
+        response_count,
+    ) in rows:
+        snippet_by_api_id[api_identifier] = SearchResult(
+            model=SearchQuestionSnippet(
+                api_identifier=api_identifier,
+                question_text=question_text,
+                group_name=group_name,
+                letter_api_identifier=letter_api_identifier,
+                letter_number=letter_number,
+                response_count=response_count,
+            ),
+            type=SearchQuestionSnippet.__name__,
+        )
+
+
+def _add_response_snippets(
+    db: Session,
+    responses: Sequence[Response],
+    snippet_by_api_id: dict[str, SearchResult],
+) -> None:
+    response_api_ids = [response.api_identifier for response in responses]
+    rows = db.execute(
+        select(
+            Response.api_identifier,
+            Response.response_text,
+            Question.question_text,
+            Letter.api_identifier,
+            Letter.number,
+            Group.name,
+            User.name,
+        )
+        .join(Question, Response.question_id == Question.id)
+        .join(Letter, Question.letter_id == Letter.id)
+        .join(Group, Letter.group_id == Group.id)
+        .join(User, Response.participant_id == User.id)
+        .where(Response.api_identifier.in_(response_api_ids))
+    ).all()
+    for (
+        api_identifier,
+        response_text,
+        question_text,
+        letter_api_identifier,
+        letter_number,
+        group_name,
+        participant_name,
+    ) in rows:
+        snippet_by_api_id[api_identifier] = SearchResult(
+            model=SearchResponseSnippet(
+                api_identifier=api_identifier,
+                response_text=response_text,
+                question_text=question_text,
+                letter_api_identifier=letter_api_identifier,
+                letter_number=letter_number,
+                group_name=group_name,
+                participant_name=participant_name,
+            ),
+            type=SearchResponseSnippet.__name__,
+        )
+
+
+def _add_letter_snippets(
+    db: Session,
+    letters: Sequence[Letter],
+    snippet_by_api_id: dict[str, SearchResult],
+) -> None:
+    letter_ids = [letter.id for letter in letters]
+    participant_counts = dict(
+        db.execute(
+            select(
+                letter_to_user_assocation.c.letter_id,
+                func.count(),
+            )
+            .where(letter_to_user_assocation.c.letter_id.in_(letter_ids))
+            .group_by(letter_to_user_assocation.c.letter_id)
+        ).all()
+    )
+    question_counts = dict(
+        db.execute(
+            select(Question.letter_id, func.count())
+            .where(Question.letter_id.in_(letter_ids))
+            .group_by(Question.letter_id)
+        ).all()
+    )
+    rows = db.execute(
+        select(Letter.id, Letter.api_identifier, Letter.number, Group.name)
+        .join(Group, Letter.group_id == Group.id)
+        .where(Letter.id.in_(letter_ids))
+    ).all()
+    for letter_id, api_identifier, number, group_name in rows:
+        snippet_by_api_id[api_identifier] = SearchResult(
+            model=SearchLetterSnippet(
+                api_identifier=api_identifier,
+                number=number,
+                group_name=group_name,
+                participant_count=participant_counts.get(letter_id, 0),
+                question_count=question_counts.get(letter_id, 0),
+            ),
+            type=SearchLetterSnippet.__name__,
+        )

--- a/ring/search/schemas/search_snippets.py
+++ b/ring/search/schemas/search_snippets.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class SearchUserSnippet(BaseModel):
+    api_identifier: str
+    name: str | None
+    group_count: int
+
+
+class SearchGroupSnippet(BaseModel):
+    api_identifier: str
+    name: str
+    member_count: int
+    letter_count: int
+
+
+class SearchQuestionSnippet(BaseModel):
+    api_identifier: str
+    question_text: str
+    group_name: str
+    letter_api_identifier: str
+    letter_number: int | None
+    response_count: int
+
+
+class SearchResponseSnippet(BaseModel):
+    api_identifier: str
+    response_text: str
+    question_text: str
+    letter_api_identifier: str
+    letter_number: int | None
+    group_name: str
+    participant_name: str | None
+
+
+class SearchLetterSnippet(BaseModel):
+    api_identifier: str
+    number: int | None
+    group_name: str
+    participant_count: int
+    question_count: int

--- a/ring/tests/unit/search/api/search_test.py
+++ b/ring/tests/unit/search/api/search_test.py
@@ -13,12 +13,13 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from ring.parties.models.user_model import User
-from ring.ring_pydantic.linked_schemas import SearchResponse, SearchResult
+from ring.ring_pydantic.linked_schemas import SearchResponse
 from ring.search.crud.hybrid_search import (
     HybridSearchDocument,
     HybridSearchDocumentAssociation,
     SearchableType,
 )
+from ring.search.crud.search_serialization import build_search_results
 from ring.tests.factories.parties.group_factory import GroupFactory
 from ring.tests.factories.parties.user_factory import UserFactory
 from ring.tests.lib.utils import (
@@ -170,7 +171,7 @@ class TestSearchAPI:
         assert len(data["results"]) == 2
         assert_pydantic_schema_json_dump_equivalent_to_response_dict(
             SearchResponse(
-                results=[SearchResult.from_model(user) for user in users[:2]],
+                results=build_search_results(db_session, users[:2]),
                 total=2,
             ),
             data,

--- a/ring/tests/unit/search/crud/hybrid_search_test.py
+++ b/ring/tests/unit/search/crud/hybrid_search_test.py
@@ -258,5 +258,5 @@ class TestHybridSearchCRUD:
         mock_get_model_ids.assert_called_once_with(db_session, mock_documents)
         mock_hydrate.assert_called_once()
         mock_filter_authorized.assert_called_once_with(
-            db_session, user, Action.READ, mock_hydrated
+            db_session, user, Action.READ, mock_hydrated, enforcer=None
         )

--- a/ring/tests/unit/search/crud/search_serialization_test.py
+++ b/ring/tests/unit/search/crud/search_serialization_test.py
@@ -1,0 +1,52 @@
+"""Tests for slim search result serialization."""
+
+from __future__ import annotations
+
+from sqlalchemy import event
+from sqlalchemy.orm import Session
+
+from ring.search.crud.search_serialization import build_search_results
+from ring.search.schemas.search_snippets import SearchUserSnippet
+from ring.tests.factories.parties.group_factory import GroupFactory
+from ring.tests.factories.parties.user_factory import UserFactory
+
+
+class TestSearchSerialization:
+    def test_build_user_snippets_uses_count_query_not_relationship_load(
+        self, db_session: Session
+    ) -> None:
+        user = UserFactory.create()
+        group = GroupFactory.create()
+        group.members.append(user)
+        db_session.commit()
+
+        query_count = 0
+
+        def count_queries(
+            conn, cursor, statement, parameters, context, executemany
+        ) -> None:
+            nonlocal query_count
+            query_count += 1
+
+        event.listen(
+            db_session.get_bind(),
+            "before_cursor_execute",
+            count_queries,
+        )
+        try:
+            results = build_search_results(db_session, [user])
+        finally:
+            event.remove(
+                db_session.get_bind(),
+                "before_cursor_execute",
+                count_queries,
+            )
+
+        assert len(results) == 1
+        assert results[0].type == SearchUserSnippet.__name__
+        snippet = results[0].model
+        assert isinstance(snippet, SearchUserSnippet)
+        assert snippet.api_identifier == user.api_identifier
+        assert snippet.name == user.name
+        assert snippet.group_count == 1
+        assert query_count <= 2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses search latency (10+ second requests) with two targeted fixes:

**P0 — Slim search result payloads**
- Add `SearchUserSnippet`, `SearchGroupSnippet`, `SearchQuestionSnippet`, `SearchResponseSnippet`, and `SearchLetterSnippet` schemas with only the fields the search UI needs.
- Replace `SearchResult.from_model()` (which validated full `UserLinked` / `GroupLinked` / `PublicLetter` graphs and triggered N+1 lazy loads) with `build_search_results()`, which uses batched count/join queries per result type.

**P1 — Request-scoped enforcer cache**
- Add `AuthenticatedRequestDependencies.get_enforcer()` to build the Casbin enforcer once per HTTP request.
- Pass the cached enforcer into `filter_to_authorized()` from the search path so auth filtering does not rebuild policy state on every call.

## API change

`/search/search` now returns snippet types in `SearchResult.model` (e.g. `SearchUserSnippet` with `group_count` instead of `UserLinked` with a full `groups` array). The `type` discriminator field uses the snippet class names.

## Testing

- `ring check lint`
- `pytest -k search` (15 passed)
- `cd react && npx tsc --noEmit`
- Manual API smoke: `GET /search/search?query=test` returns snippet-shaped JSON
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f69a2f49-fdd0-41cc-8614-f08e485b5c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f69a2f49-fdd0-41cc-8614-f08e485b5c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

