### PR TITLE
Slim API responses by removing default nested linked objects

### DIFF
--- a/react/openapi.json
+++ b/react/openapi.json
@@ -278,7 +278,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserLinked"
+                  "$ref": "#/components/schemas/UserMe"
                 }
               }
             }
@@ -335,7 +335,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserLinked"
+                  "$ref": "#/components/schemas/UserMe"
                 }
               }
             }
@@ -382,7 +382,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserLinked"
+                  "$ref": "#/components/schemas/UserUnlinked"
                 }
               }
             }
@@ -436,7 +436,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserLinked"
+                  "$ref": "#/components/schemas/UserUnlinked"
                 }
               }
             }
@@ -497,7 +497,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UserLinked"
+                    "$ref": "#/components/schemas/UserUnlinked"
                   },
                   "title": "Response Read Users Parties Users Get"
                 }
@@ -547,7 +547,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserLinked"
+                  "$ref": "#/components/schemas/UserUnlinked"
                 }
               }
             }
@@ -829,7 +829,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/GroupLinked"
+                    "$ref": "#/components/schemas/GroupSummary"
                   },
                   "title": "Response List Groups Parties Groups  Get"
                 }
@@ -2487,7 +2487,7 @@
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/SearchType",
-              "default": "dual"
+              "default": "keyword"
             }
           },
           {
@@ -2553,7 +2553,7 @@
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/SearchType",
-              "default": "dual"
+              "default": "keyword"
             }
           },
           {
@@ -2995,14 +2995,14 @@
         "properties": {
           "upcoming": {
             "items": {
-              "$ref": "#/components/schemas/PublicLetter"
+              "$ref": "#/components/schemas/MinimalLetter"
             },
             "type": "array",
             "title": "Upcoming"
           },
           "in_progress": {
             "items": {
-              "$ref": "#/components/schemas/PublicLetter"
+              "$ref": "#/components/schemas/MinimalLetter"
             },
             "type": "array",
             "title": "In Progress"
@@ -3022,7 +3022,26 @@
           "recently_completed"
         ],
         "title": "DashboardLetters",
-        "description": "Model for the letters dashboard view.\n\nGroups letters by their status for dashboard display.\n\nAttributes:\n    upcoming (list[PublicLetter]): Letters scheduled for the future\n    in_progress (list[PublicLetter]): Currently active letters\n    recently_completed (list[PublicLetter]): Recently finished letters"
+        "description": "Model for the letters dashboard view.\n\nGroups letters by their status for dashboard display. Upcoming and\nin-progress cards only need summary fields; recently completed cards\nmay show unanswered-question counts and include full question data.\n\nAttributes:\n    upcoming (list[MinimalLetter]): Letters scheduled for the future\n    in_progress (list[MinimalLetter]): Currently active letters\n    recently_completed (list[PublicLetter]): Recently finished letters"
+      },
+      "DefaultQuestion": {
+        "properties": {
+          "question_text": {
+            "type": "string",
+            "title": "Question Text"
+          },
+          "api_identifier": {
+            "type": "string",
+            "title": "Api Identifier"
+          }
+        },
+        "type": "object",
+        "required": [
+          "question_text",
+          "api_identifier"
+        ],
+        "title": "DefaultQuestion",
+        "description": "Schema representing a default question in the system.\n\nAttributes:\n    question_text (str): The text content of the default question\n    api_identifier (str): Unique API identifier for the default question"
       },
       "DocumentCreate": {
         "properties": {
@@ -3253,32 +3272,20 @@
             "type": "array",
             "title": "Members"
           },
-          "letters": {
-            "items": {
-              "$ref": "#/components/schemas/LetterUnlinked"
-            },
-            "type": "array",
-            "title": "Letters"
-          },
-          "schedule": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ScheduleUnlinked"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "admin": {
             "$ref": "#/components/schemas/UserUnlinked"
           },
           "default_questions": {
             "items": {
-              "$ref": "#/components/schemas/QuestionUnlinked"
+              "$ref": "#/components/schemas/DefaultQuestion"
             },
             "type": "array",
             "title": "Default Questions"
+          },
+          "letter_count": {
+            "type": "integer",
+            "title": "Letter Count",
+            "default": 0
           }
         },
         "type": "object",
@@ -3288,13 +3295,64 @@
           "created_at",
           "cycle_length",
           "members",
-          "letters",
-          "schedule",
           "admin",
           "default_questions"
         ],
         "title": "GroupLinked",
-        "description": "Group model with linked relationships.\n\nExtends the base Group model to include members, letters, and other related data.\n\nAttributes:\n    members (list[UserUnlinked]): Users who are members of the group\n    letters (list[LetterUnlinked]): Letters associated with the group\n    schedule (Optional[ScheduleUnlinked]): Group's schedule, if any\n    admin (UserUnlinked): The group administrator\n    default_questions (list[QuestionUnlinked]): Default questions for group letters"
+        "description": "Group detail model with membership and settings.\n\nOmits nested letters and schedule (fetch those via dedicated endpoints).\n\nAttributes:\n    members (list[UserUnlinked]): Users who are members of the group\n    admin (UserUnlinked): The group administrator\n    default_questions (list[DefaultQuestion]): Default questions for group letters\n    letter_count (int): Number of letters in the group"
+      },
+      "GroupSummary": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "api_identifier": {
+            "type": "string",
+            "title": "Api Identifier"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "cycle_length": {
+            "type": "integer",
+            "title": "Cycle Length"
+          },
+          "min_responder_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Responder Ratio"
+          },
+          "members": {
+            "items": {
+              "$ref": "#/components/schemas/UserUnlinked"
+            },
+            "type": "array",
+            "title": "Members"
+          },
+          "admin": {
+            "$ref": "#/components/schemas/UserUnlinked"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "api_identifier",
+          "created_at",
+          "cycle_length",
+          "members",
+          "admin"
+        ],
+        "title": "GroupSummary",
+        "description": "Group list item with membership info only.\n\nUsed for list endpoints where nested letters, schedule, and default\nquestions are not needed."
       },
       "GroupUnlinked": {
         "properties": {
@@ -4224,23 +4282,6 @@
         "title": "ScheduleLinked",
         "description": "Schedule model with linked relationships.\n\nExtends the base Schedule model to include the associated group and tasks.\n\nAttributes:\n    group (GroupUnlinked): The group this schedule belongs to\n    tasks (list[TaskUnlinked]): Tasks in the schedule"
       },
-      "ScheduleUnlinked": {
-        "properties": {
-          "tasks": {
-            "items": {
-              "$ref": "#/components/schemas/TaskUnlinked"
-            },
-            "type": "array",
-            "title": "Tasks"
-          }
-        },
-        "type": "object",
-        "required": [
-          "tasks"
-        ],
-        "title": "ScheduleUnlinked",
-        "description": "Schema for schedule data with unlinked task relationships.\n\nThis schema extends the base Schedule schema and includes a list of tasks,\nusing the unlinked task schema to avoid circular references.\n\nAttributes:\n    tasks: List of tasks associated with this schedule"
-      },
       "SearchResponse": {
         "properties": {
           "results": {
@@ -4476,13 +4517,6 @@
             },
             "type": "array",
             "title": "Groups"
-          },
-          "responses": {
-            "items": {
-              "$ref": "#/components/schemas/ResponseUnlinked"
-            },
-            "type": "array",
-            "title": "Responses"
           }
         },
         "type": "object",
@@ -4491,11 +4525,47 @@
           "name",
           "api_identifier",
           "admin",
-          "groups",
-          "responses"
+          "groups"
         ],
         "title": "UserLinked",
-        "description": "User model with linked relationships.\n\nExtends the base User model to include related groups and responses.\n\nAttributes:\n    groups (list[GroupUnlinked]): Groups the user is a member of\n    responses (list[ResponseUnlinked]): User's responses to questions"
+        "description": "User model with linked relationships for search and admin views.\n\nAttributes:\n    groups (list[GroupUnlinked]): Groups the user is a member of"
+      },
+      "UserMe": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "api_identifier": {
+            "type": "string",
+            "title": "Api Identifier"
+          },
+          "admin": {
+            "type": "boolean",
+            "title": "Admin"
+          },
+          "groups": {
+            "items": {
+              "$ref": "#/components/schemas/GroupUnlinked"
+            },
+            "type": "array",
+            "title": "Groups"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "name",
+          "api_identifier",
+          "admin",
+          "groups"
+        ],
+        "title": "UserMe",
+        "description": "Current-user profile with group memberships only.\n\nLighter than UserLinked: includes group ids/names for navigation but omits\nthe user's full response history."
       },
       "UserUnlinked": {
         "properties": {

--- a/react/src/client/types.gen.ts
+++ b/react/src/client/types.gen.ts
@@ -57,17 +57,31 @@ export type CompletionResponse = {
 /**
  * Model for the letters dashboard view.
  *
- * Groups letters by their status for dashboard display.
+ * Groups letters by their status for dashboard display. Upcoming and
+ * in-progress cards only need summary fields; recently completed cards
+ * may show unanswered-question counts and include full question data.
  *
  * Attributes:
- * upcoming (list[PublicLetter]): Letters scheduled for the future
- * in_progress (list[PublicLetter]): Currently active letters
+ * upcoming (list[MinimalLetter]): Letters scheduled for the future
+ * in_progress (list[MinimalLetter]): Currently active letters
  * recently_completed (list[PublicLetter]): Recently finished letters
  */
 export type DashboardLetters = {
-    upcoming: Array<PublicLetter>;
-    in_progress: Array<PublicLetter>;
+    upcoming: Array<MinimalLetter>;
+    in_progress: Array<MinimalLetter>;
     recently_completed: Array<PublicLetter>;
+};
+
+/**
+ * Schema representing a default question in the system.
+ *
+ * Attributes:
+ * question_text (str): The text content of the default question
+ * api_identifier (str): Unique API identifier for the default question
+ */
+export type DefaultQuestion = {
+    question_text: string;
+    api_identifier: string;
 };
 
 /**
@@ -192,16 +206,15 @@ export type GroupKeyValueBase = {
 };
 
 /**
- * Group model with linked relationships.
+ * Group detail model with membership and settings.
  *
- * Extends the base Group model to include members, letters, and other related data.
+ * Omits nested letters and schedule (fetch those via dedicated endpoints).
  *
  * Attributes:
  * members (list[UserUnlinked]): Users who are members of the group
- * letters (list[LetterUnlinked]): Letters associated with the group
- * schedule (Optional[ScheduleUnlinked]): Group's schedule, if any
  * admin (UserUnlinked): The group administrator
- * default_questions (list[QuestionUnlinked]): Default questions for group letters
+ * default_questions (list[DefaultQuestion]): Default questions for group letters
+ * letter_count (int): Number of letters in the group
  */
 export type GroupLinked = {
     name: string;
@@ -210,10 +223,25 @@ export type GroupLinked = {
     cycle_length: number;
     min_responder_ratio?: number | null;
     members: Array<UserUnlinked>;
-    letters: Array<LetterUnlinked>;
-    schedule: ScheduleUnlinked | null;
     admin: UserUnlinked;
-    default_questions: Array<QuestionUnlinked>;
+    default_questions: Array<DefaultQuestion>;
+    letter_count?: number;
+};
+
+/**
+ * Group list item with membership info only.
+ *
+ * Used for list endpoints where nested letters, schedule, and default
+ * questions are not needed.
+ */
+export type GroupSummary = {
+    name: string;
+    api_identifier: string;
+    created_at: string;
+    cycle_length: number;
+    min_responder_ratio?: number | null;
+    members: Array<UserUnlinked>;
+    admin: UserUnlinked;
 };
 
 /**
@@ -620,19 +648,6 @@ export type ScheduleLinked = {
     tasks: Array<TaskUnlinked>;
 };
 
-/**
- * Schema for schedule data with unlinked task relationships.
- *
- * This schema extends the base Schedule schema and includes a list of tasks,
- * using the unlinked task schema to avoid circular references.
- *
- * Attributes:
- * tasks: List of tasks associated with this schedule
- */
-export type ScheduleUnlinked = {
-    tasks: Array<TaskUnlinked>;
-};
-
 export type SearchResponse = {
     results: Array<SearchResult>;
     total: number;
@@ -743,13 +758,10 @@ export type UserCreate = {
 };
 
 /**
- * User model with linked relationships.
- *
- * Extends the base User model to include related groups and responses.
+ * User model with linked relationships for search and admin views.
  *
  * Attributes:
  * groups (list[GroupUnlinked]): Groups the user is a member of
- * responses (list[ResponseUnlinked]): User's responses to questions
  */
 export type UserLinked = {
     email: string;
@@ -757,7 +769,20 @@ export type UserLinked = {
     api_identifier: string;
     admin: boolean;
     groups: Array<GroupUnlinked>;
-    responses: Array<ResponseUnlinked>;
+};
+
+/**
+ * Current-user profile with group memberships only.
+ *
+ * Lighter than UserLinked: includes group ids/names for navigation but omits
+ * the user's full response history.
+ */
+export type UserMe = {
+    email: string;
+    name: string;
+    api_identifier: string;
+    admin: boolean;
+    groups: Array<GroupUnlinked>;
 };
 
 /**
@@ -978,7 +1003,7 @@ export type ReadUserMePartiesMeGetResponses = {
     /**
      * Successful Response
      */
-    200: UserLinked;
+    200: UserMe;
 };
 
 export type ReadUserMePartiesMeGetResponse = ReadUserMePartiesMeGetResponses[keyof ReadUserMePartiesMeGetResponses];
@@ -1003,7 +1028,7 @@ export type UpdateUserMePartiesMePatchResponses = {
     /**
      * Successful Response
      */
-    200: UserLinked;
+    200: UserMe;
 };
 
 export type UpdateUserMePartiesMePatchResponse = UpdateUserMePartiesMePatchResponses[keyof UpdateUserMePartiesMePatchResponses];
@@ -1028,7 +1053,7 @@ export type CreateUserPartiesUserPostResponses = {
     /**
      * Successful Response
      */
-    201: UserLinked;
+    201: UserUnlinked;
 };
 
 export type CreateUserPartiesUserPostResponse = CreateUserPartiesUserPostResponses[keyof CreateUserPartiesUserPostResponses];
@@ -1055,7 +1080,7 @@ export type RegisterUserPartiesRegisterTokenPostResponses = {
     /**
      * Successful Response
      */
-    200: UserLinked;
+    200: UserUnlinked;
 };
 
 export type RegisterUserPartiesRegisterTokenPostResponse = RegisterUserPartiesRegisterTokenPostResponses[keyof RegisterUserPartiesRegisterTokenPostResponses];
@@ -1083,7 +1108,7 @@ export type ReadUsersPartiesUsersGetResponses = {
     /**
      * Successful Response
      */
-    200: Array<UserLinked>;
+    200: Array<UserUnlinked>;
 };
 
 export type ReadUsersPartiesUsersGetResponse = ReadUsersPartiesUsersGetResponses[keyof ReadUsersPartiesUsersGetResponses];
@@ -1110,7 +1135,7 @@ export type ReadUserByIdPartiesUserUserApiIdGetResponses = {
     /**
      * Successful Response
      */
-    200: UserLinked;
+    200: UserUnlinked;
 };
 
 export type ReadUserByIdPartiesUserUserApiIdGetResponse = ReadUserByIdPartiesUserUserApiIdGetResponses[keyof ReadUserByIdPartiesUserUserApiIdGetResponses];
@@ -1264,7 +1289,7 @@ export type ListGroupsPartiesGroupsGetResponses = {
     /**
      * Successful Response
      */
-    200: Array<GroupLinked>;
+    200: Array<GroupSummary>;
 };
 
 export type ListGroupsPartiesGroupsGetResponse = ListGroupsPartiesGroupsGetResponses[keyof ListGroupsPartiesGroupsGetResponses];

--- a/react/src/components/Common/ActionsMenu.tsx
+++ b/react/src/components/Common/ActionsMenu.tsx
@@ -16,7 +16,7 @@ import {
 import { useState } from "react"
 
 import { useNavigate } from "@tanstack/react-router"
-import type { GroupLinked, UserLinked } from "../../client"
+import type { GroupLinked, GroupSummary, UserLinked, UserMe, UserUnlinked } from "../../client"
 import EditUser from "../Admin/EditUser"
 import ImpersonateUser from "../Admin/ImpersonateUser"
 import AddMembers from "../Groups/AddMembers"
@@ -25,7 +25,7 @@ import Delete from "./DeleteAlert"
 
 interface ActionsMenuProps {
   type: string
-  value: GroupLinked | UserLinked
+  value: GroupLinked | GroupSummary | UserLinked | UserMe | UserUnlinked
   disabled?: boolean
 }
 

--- a/react/src/components/Common/SearchResultRow.tsx
+++ b/react/src/components/Common/SearchResultRow.tsx
@@ -94,7 +94,7 @@ function GroupSearchResultRow({ result }: { result: SearchResult }) {
               <span className="font-medium">{model.name}</span>
             </div>
             <p className="text-sm text-muted-foreground">
-              {model.members.length} members • {model.letters.length} letters
+              {model.members.length} members • {model.letter_count ?? 0} letters
             </p>
           </div>
         </Link>

--- a/react/src/routes/_layout/admin.tsx
+++ b/react/src/routes/_layout/admin.tsx
@@ -12,7 +12,7 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { Suspense } from "react"
-import type { UserLinked } from "../../client"
+import type { UserMe } from "../../client"
 import { readUsersPartiesUsersGetOptions } from "../../client/@tanstack/react-query.gen"
 import ActionsMenu from "../../components/Common/ActionsMenu"
 import Navbar from "../../components/Common/Navbar"
@@ -28,7 +28,7 @@ export const Route = createFileRoute("/_layout/admin")({
 })
 
 const MembersTableBody = () => {
-  const currentUser = Route.useLoaderData<UserLinked>()
+  const currentUser = Route.useLoaderData<UserMe>()
 
   const { data: users } = useSuspenseQuery({
     ...readUsersPartiesUsersGetOptions(),

--- a/react/src/routes/_layout/groups.tsx
+++ b/react/src/routes/_layout/groups.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/table"
 import { Suspense } from "react"
 import { ErrorBoundary } from "react-error-boundary"
-import type { UserLinked } from "../../client"
+import type { UserMe } from "../../client"
 import { listGroupsPartiesGroupsGetOptions } from "../../client/@tanstack/react-query.gen"
 import ActionsMenu from "../../components/Common/ActionsMenu"
 import Navbar from "../../components/Common/Navbar"
@@ -28,7 +28,7 @@ export const Route = createFileRoute("/_layout/groups")({
 })
 
 function GroupTableBody() {
-  const currentUser = Route.useLoaderData<UserLinked>()
+  const currentUser = Route.useLoaderData<UserMe>()
   const { data: groups } = useSuspenseQuery({
     ...listGroupsPartiesGroupsGetOptions({
       query: { user_api_id: currentUser?.api_identifier },

--- a/ring/letters/schemas/default_question.py
+++ b/ring/letters/schemas/default_question.py
@@ -13,17 +13,17 @@ class DefaultQuestionBase(BaseModel):
     """Base schema for default question-related operations.
 
     Attributes:
-        question (str): The text content of the default question
+        question_text (str): The text content of the default question
     """
 
-    question: str
+    question_text: str
 
 
 class DefaultQuestion(DefaultQuestionBase):
     """Schema representing a default question in the system.
 
     Attributes:
-        question (str): The text content of the default question
+        question_text (str): The text content of the default question
         api_identifier (str): Unique API identifier for the default question
     """
 

--- a/ring/parties/api/group.py
+++ b/ring/parties/api/group.py
@@ -26,14 +26,17 @@ from ring.parties.schemas.group import (
     GroupUpdate,
     ReplaceDefaultQuestions,
 )
-from ring.ring_pydantic import GroupLinked as GroupSchema
+from ring.ring_pydantic import GroupLinked as GroupDetailSchema
+from ring.ring_pydantic.linked_schemas import GroupSummary
 from ring.tasks.schemas.schedule import ScheduleSendParam
 
 router = APIRouter()
 
 
 @router.post(
-    "/group", response_model=GroupSchema, status_code=status.HTTP_201_CREATED
+    "/group",
+    response_model=GroupDetailSchema,
+    status_code=status.HTTP_201_CREATED,
 )
 async def create_group(
     group: GroupCreate,
@@ -60,7 +63,7 @@ async def create_group(
     return db_group
 
 
-@router.get("/groups/", response_model=Sequence[GroupSchema])
+@router.get("/groups/", response_model=Sequence[GroupSummary])
 async def list_groups(
     user_api_id: str,
     skip: int = 0,
@@ -89,7 +92,7 @@ async def list_groups(
     return groups
 
 
-@router.get("/group/{group_api_id}", response_model=GroupSchema)
+@router.get("/group/{group_api_id}", response_model=GroupDetailSchema)
 async def read_group(
     group_api_id: str,
     req_dep: AuthenticatedRequestDependencies = Depends(
@@ -123,7 +126,7 @@ async def read_group(
 
 @router.post(
     "/group/{group_api_id}:add_member/{user_api_id}",
-    response_model=GroupSchema,
+    response_model=GroupDetailSchema,
 )
 async def add_user_to_group(
     group_api_id: str,
@@ -154,7 +157,7 @@ async def add_user_to_group(
 
 @router.post(
     "/group/{group_api_id}:remove_member/{user_api_id}",
-    response_model=GroupSchema,
+    response_model=GroupDetailSchema,
 )
 async def remove_user_from_group(
     group_api_id: str,
@@ -211,7 +214,7 @@ async def remove_user_from_group(
 
 @router.patch(
     "/group/{group_api_id}",
-    response_model=GroupSchema,
+    response_model=GroupDetailSchema,
 )
 async def update_group(
     group_api_id: str,
@@ -275,7 +278,7 @@ async def update_group(
 
 @router.post(
     "/group/{group_api_id}:add_members",
-    response_model=GroupSchema,
+    response_model=GroupDetailSchema,
 )
 async def add_members(
     group_api_id: str,
@@ -336,7 +339,7 @@ async def add_members(
 
 @router.post(
     "/group/{group_api_id}:replace_default_questions",
-    response_model=GroupSchema,
+    response_model=GroupDetailSchema,
 )
 async def replace_group_default_questions(
     group_api_id: str,

--- a/ring/parties/api/user.py
+++ b/ring/parties/api/user.py
@@ -30,13 +30,13 @@ from ring.parties.schemas.user import (
     UserUpdate,
     UserUpdatePassword,
 )
-from ring.ring_pydantic import UserLinked as UserSchema
 from ring.ring_pydantic.core import ResponseMessage
+from ring.ring_pydantic.linked_schemas import UserMe, UserUnlinked
 
 router = APIRouter()
 
 
-@router.get("/me", response_model=UserSchema)
+@router.get("/me", response_model=UserMe)
 async def read_user_me(
     req_dep: AuthenticatedRequestDependencies = Depends(
         get_request_dependencies,
@@ -54,7 +54,7 @@ async def read_user_me(
 
 
 @router.post(
-    "/user", response_model=UserSchema, deprecated=True, status_code=201
+    "/user", response_model=UserUnlinked, deprecated=True, status_code=201
 )
 async def create_user(
     user: UserCreate,
@@ -90,7 +90,7 @@ async def create_user(
     return db_user
 
 
-@router.post("/register/{token}", response_model=UserSchema)
+@router.post("/register/{token}", response_model=UserUnlinked)
 async def register_user(
     token: str,
     user: UserCreate,
@@ -137,7 +137,7 @@ async def register_user(
     return db_user
 
 
-@router.get("/users", response_model=Sequence[UserSchema])
+@router.get("/users", response_model=Sequence[UserUnlinked])
 async def read_users(
     skip: int = 0,
     limit: int = 100,
@@ -159,7 +159,7 @@ async def read_users(
     return users
 
 
-@router.get("/user/{user_api_id}", response_model=UserSchema)
+@router.get("/user/{user_api_id}", response_model=UserUnlinked)
 async def read_user_by_id(
     user_api_id: str,
     req_dep: AuthenticatedRequestDependencies = Depends(
@@ -188,7 +188,7 @@ async def read_user_by_id(
 
 @router.patch(
     "/me",
-    response_model=UserSchema,
+    response_model=UserMe,
 )
 async def update_user_me(
     current_user_update_data: UserUpdate,

--- a/ring/ring_pydantic/__init__.py
+++ b/ring/ring_pydantic/__init__.py
@@ -13,11 +13,13 @@ from __future__ import annotations
 from .linked_schemas import *
 
 GroupLinked.model_rebuild()
+GroupSummary.model_rebuild()
 LetterLinked.model_rebuild()
 PublicLetter.model_rebuild()
 QuestionLinked.model_rebuild()
 # ResponseLinked.model_rebuild()
 UserLinked.model_rebuild()
+UserMe.model_rebuild()
 ScheduleUnlinked.model_rebuild()
 InviteLinked.model_rebuild()
 # SubscriptionLinked.model_rebuild()

--- a/ring/ring_pydantic/linked_schemas.py
+++ b/ring/ring_pydantic/linked_schemas.py
@@ -21,6 +21,7 @@ from pydantic import (
     validator,
 )
 
+from ring.letters.schemas.default_question import DefaultQuestion
 from ring.letters.schemas.letter import Letter, LetterUnlinked
 from ring.letters.schemas.question import Question, QuestionUnlinked
 from ring.letters.schemas.response import Response, ResponseUnlinked
@@ -31,6 +32,15 @@ from ring.parties.schemas.user import User, UserUnlinked
 from ring.s3.schemas.image import WithImageMixin
 from ring.tasks.schemas.schedule import Schedule, ScheduleUnlinked
 from ring.tasks.schemas.task import TaskUnlinked
+
+
+def _populate_group_letter_count[T: BaseModel](model: T, group: Any) -> T:
+    """Add letter_count when serializing a group ORM object."""
+    if isinstance(group, BaseModel):
+        return model
+    if not hasattr(group, "letters"):
+        return model
+    return model.model_copy(update={"letter_count": len(group.letters)})
 
 
 def _populate_letter_send_threshold_fields[T: BaseModel](
@@ -63,38 +73,63 @@ def _populate_letter_send_threshold_fields[T: BaseModel](
     )
 
 
-class UserLinked(User):
-    """User model with linked relationships.
+class UserMe(User):
+    """Current-user profile with group memberships only.
 
-    Extends the base User model to include related groups and responses.
-
-    Attributes:
-        groups (list[GroupUnlinked]): Groups the user is a member of
-        responses (list[ResponseUnlinked]): User's responses to questions
+    Lighter than UserLinked: includes group ids/names for navigation but omits
+    the user's full response history.
     """
 
     groups: list["GroupUnlinked"]
-    responses: list["ResponseUnlinked"]
 
 
-class GroupLinked(Group):
-    """Group model with linked relationships.
-
-    Extends the base Group model to include members, letters, and other related data.
+class UserLinked(UserMe):
+    """User model with linked relationships for search and admin views.
 
     Attributes:
-        members (list[UserUnlinked]): Users who are members of the group
-        letters (list[LetterUnlinked]): Letters associated with the group
-        schedule (Optional[ScheduleUnlinked]): Group's schedule, if any
-        admin (UserUnlinked): The group administrator
-        default_questions (list[QuestionUnlinked]): Default questions for group letters
+        groups (list[GroupUnlinked]): Groups the user is a member of
+    """
+
+    pass
+
+
+class GroupSummary(Group):
+    """Group list item with membership info only.
+
+    Used for list endpoints where nested letters, schedule, and default
+    questions are not needed.
     """
 
     members: list["UserUnlinked"]
-    letters: list["LetterUnlinked"]
-    schedule: Optional["ScheduleUnlinked"]
     admin: "UserUnlinked"
-    default_questions: list["QuestionUnlinked"]
+
+
+class GroupLinked(Group):
+    """Group detail model with membership and settings.
+
+    Omits nested letters and schedule (fetch those via dedicated endpoints).
+
+    Attributes:
+        members (list[UserUnlinked]): Users who are members of the group
+        admin (UserUnlinked): The group administrator
+        default_questions (list[DefaultQuestion]): Default questions for group letters
+        letter_count (int): Number of letters in the group
+    """
+
+    members: list["UserUnlinked"]
+    admin: "UserUnlinked"
+    default_questions: list[DefaultQuestion]
+    letter_count: int = 0
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def populate_letter_count(
+        cls,
+        data: Any,
+        handler: ModelWrapValidatorHandler[Self],
+    ) -> Self:
+        model = handler(data)
+        return _populate_group_letter_count(model, data)
 
 
 class ScheduleLinked(Schedule):
@@ -198,16 +233,18 @@ class PublicLetter(Letter):
 class DashboardLetters(BaseModel):
     """Model for the letters dashboard view.
 
-    Groups letters by their status for dashboard display.
+    Groups letters by their status for dashboard display. Upcoming and
+    in-progress cards only need summary fields; recently completed cards
+    may show unanswered-question counts and include full question data.
 
     Attributes:
-        upcoming (list[PublicLetter]): Letters scheduled for the future
-        in_progress (list[PublicLetter]): Currently active letters
+        upcoming (list[MinimalLetter]): Letters scheduled for the future
+        in_progress (list[MinimalLetter]): Currently active letters
         recently_completed (list[PublicLetter]): Recently finished letters
     """
 
-    upcoming: list[PublicLetter]
-    in_progress: list[PublicLetter]
+    upcoming: list[MinimalLetter]
+    in_progress: list[MinimalLetter]
     recently_completed: list[PublicLetter]
 
 

--- a/ring/tests/unit/letters/api/letter_test.py
+++ b/ring/tests/unit/letters/api/letter_test.py
@@ -257,11 +257,15 @@ class TestLetterAPI:
         data = response.json()
         assert len(data["upcoming"]) == 1
         assert_pydantic_model_json_dump_equivalent_to_response_dict(
-            letters[0], data["upcoming"][0]
+            letters[0],
+            data["upcoming"][0],
+            override_pydantic_model=MinimalLetter,
         )
         assert len(data["in_progress"]) == 1
         assert_pydantic_model_json_dump_equivalent_to_response_dict(
-            letters[1], data["in_progress"][0]
+            letters[1],
+            data["in_progress"][0],
+            override_pydantic_model=MinimalLetter,
         )
         assert len(data["recently_completed"]) == 1
         assert_pydantic_model_json_dump_equivalent_to_response_dict(

--- a/ring/tests/unit/parties/api/group_test.py
+++ b/ring/tests/unit/parties/api/group_test.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from ring.parties.models.group_model import Group
 from ring.parties.models.user_model import User
+from ring.ring_pydantic.linked_schemas import GroupSummary
 from ring.tests.factories.parties.group_factory import GroupFactory
 from ring.tests.factories.parties.user_factory import UserFactory
 from ring.tests.lib.utils import (
@@ -145,6 +146,7 @@ class TestGroupApi:
         assert_pydantic_models_json_dump_in_response_dict(
             admin_groups + member_groups,
             data,
+            override_pydantic_model=GroupSummary,
         )
 
     def test_read_group(

--- a/ring/tests/unit/parties/api/user_test.py
+++ b/ring/tests/unit/parties/api/user_test.py
@@ -14,6 +14,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from ring.parties.models.user_model import User
+from ring.ring_pydantic.linked_schemas import UserUnlinked
 from ring.tests.factories.parties.group_factory import GroupFactory
 from ring.tests.factories.parties.invite_factory import InviteFactory
 from ring.tests.factories.parties.one_time_token_factory import (
@@ -381,7 +382,9 @@ class TestUserAPI:
         data = resp.json()
         assert len(data) == 11  # 10 users + current user
         assert_pydantic_models_json_dump_in_response_dict(
-            users + group_users + [current_user], data
+            users + group_users + [current_user],
+            data,
+            override_pydantic_model=UserUnlinked,
         )
 
     def test_read_user_by_id(
@@ -407,7 +410,9 @@ class TestUserAPI:
         resp = authenticated_client.get(f"/parties/user/{user.api_identifier}")
         assert resp.status_code == 200
         data = resp.json()
-        assert_pydantic_model_json_dump_equivalent_to_response_dict(user, data)
+        assert_pydantic_model_json_dump_equivalent_to_response_dict(
+            user, data, override_pydantic_model=UserUnlinked
+        )
 
     def test_read_user_by_id_not_found(
         self,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Several high-traffic endpoints were serializing full linked schema graphs by default (`GroupLinked` with all letters + schedule, `UserLinked` with full response history, `PublicLetter` on dashboard lists). This inflated JSON payloads and slowed page loads.

## Solution

Introduce purpose-built response shapes and use them on list/auth endpoints:

| Endpoint | Before | After |
|----------|--------|-------|
| `GET /parties/me` | `UserLinked` (groups + all responses) | `UserMe` (groups only) |
| `GET /parties/groups/` | `GroupLinked` (letters, schedule, default questions) | `GroupSummary` (members + admin) |
| `GET /parties/group/{id}` | `GroupLinked` with nested letters/schedule | Slim `GroupLinked` (settings fields + `letter_count`) |
| `GET /letters/letters:dashboard` upcoming/in_progress | `PublicLetter` (questions + responses) | `MinimalLetter` |

Representative payload sizes (20 letters, 50 responses):

- Group list item: **4778 → 397 bytes** (~92% smaller)
- Group detail: **4778 → 740 bytes** (~85% smaller)
- `/me`: **14685 → 230 bytes** (~98% smaller)

Letters and schedules remain available via existing dedicated endpoints (`/letters/`, `/schedule/{group_api_id}`).

## Frontend

- Regenerated OpenAPI client
- Updated search result row to use `letter_count`
- Widened `ActionsMenu` value types for new shapes

## Testing

![Groups page loads quickly](https://cursor.com/artifacts/c/art-203fa07f-0c7f-48b8-9066-e0608f4f4dfe)

- Manual: logged in, navigated to Groups — API calls ~8–11ms, page loads instantly
- `npx tsc --noEmit` passes
- API tests: group, user, letter suites pass (48 tests)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53af77e9-f81b-4a03-aca3-cf21b3e5eb60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53af77e9-f81b-4a03-aca3-cf21b3e5eb60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

