### PR TITLE
Add search filters by group/responder and time-based sorting

### DIFF
--- a/react/openapi.json
+++ b/react/openapi.json
@@ -12,9 +12,7 @@
   "paths": {
     "/login/access-token": {
       "post": {
-        "tags": [
-          "login"
-        ],
+        "tags": ["login"],
         "summary": "Login Access Token",
         "description": "Authenticate user and generate access token.\n\nValidates user credentials and generates a JWT access token for authenticated sessions.\n\nArgs:\n    form_data (OAuth2PasswordRequestForm): OAuth2 password request form containing username and password\n    req_dep (RequestDependenciesBase): Request dependencies including database session\n\nReturns:\n    Token: JWT access token with bearer type\n\nRaises:\n    HTTPException: 400 if credentials are invalid",
         "operationId": "login_access_token_login_access_token_post",
@@ -54,9 +52,7 @@
     },
     "/impersonate-user-token": {
       "post": {
-        "tags": [
-          "login"
-        ],
+        "tags": ["login"],
         "summary": "Impersonate User Token",
         "operationId": "impersonate_user_token_impersonate_user_token_post",
         "security": [
@@ -101,9 +97,7 @@
     },
     "/login/test-token": {
       "post": {
-        "tags": [
-          "login"
-        ],
+        "tags": ["login"],
         "summary": "Test Token",
         "description": "Test endpoint for validating access tokens.\n\nThis endpoint is deprecated and will be removed in future versions.\n\nRaises:\n    NotImplementedError: Always raises this error as the endpoint is deprecated",
         "operationId": "test_token_login_test_token_post",
@@ -125,9 +119,7 @@
     },
     "/reset-password:request/{email}": {
       "post": {
-        "tags": [
-          "login"
-        ],
+        "tags": ["login"],
         "summary": "Reset Password Request",
         "description": "Initiate password reset process for a user.\n\nGenerates a one-time token and sends a password reset email to the user.\n\nArgs:\n    email (str): User's email address\n    req_dep (RequestDependenciesBase): Request dependencies including database session\n\nReturns:\n    ResponseMessage: Confirmation message of email sent\n\nRaises:\n    HTTPException: 400 if user with email doesn't exist",
         "operationId": "reset_password_request_reset_password_request__email__post",
@@ -168,9 +160,7 @@
     },
     "/reset-password/{token}": {
       "post": {
-        "tags": [
-          "login"
-        ],
+        "tags": ["login"],
         "summary": "Reset Password",
         "description": "Reset user's password using a valid reset token.\n\nValidates the reset token and updates the user's password if token is valid.\n\nArgs:\n    token (str): Password reset token\n    new_password_data (NewPassword): New password data\n    req_dep (RequestDependenciesBase): Request dependencies including database session\n\nReturns:\n    ResponseMessage: Confirmation message of password update\n\nRaises:\n    HTTPException: 400 if token is invalid, expired, or already used",
         "operationId": "reset_password_reset_password__token__post",
@@ -221,9 +211,7 @@
     },
     "/password-recovery-html-content/{email}": {
       "post": {
-        "tags": [
-          "login"
-        ],
+        "tags": ["login"],
         "summary": "Recover Password Html Content",
         "description": "Generate HTML content for password recovery email.\n\nThis endpoint is deprecated and will be removed in future versions.\n\nArgs:\n    email (str): User's email address\n\nRaises:\n    NotImplementedError: Always raises this error as the endpoint is deprecated",
         "operationId": "recover_password_html_content_password_recovery_html_content__email__post",
@@ -266,9 +254,7 @@
     },
     "/parties/me": {
       "get": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Read User Me",
         "description": "Get the current authenticated user's information.\n\nArgs:\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    User: Current user's information",
         "operationId": "read_user_me_parties_me_get",
@@ -291,9 +277,7 @@
         ]
       },
       "delete": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Delete User Me",
         "description": "Delete current user (deprecated).\n\nNote:\n    This endpoint is not implemented and is deprecated.",
         "operationId": "delete_user_me_parties_me_delete",
@@ -313,9 +297,7 @@
         "deprecated": true
       },
       "patch": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Update User Me",
         "description": "Update current user's information.\n\nArgs:\n    current_user_update_data (UserUpdate): User update parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    User: Updated user information\n\nRaises:\n    HTTPException: If new email is already registered by another user",
         "operationId": "update_user_me_parties_me_patch",
@@ -360,9 +342,7 @@
     },
     "/parties/user": {
       "post": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Create User",
         "description": "Create a new user (deprecated).\n\nArgs:\n    user (UserCreate): User creation parameters\n    req_dep (RequestDependenciesBase): Request dependencies\n\nReturns:\n    User: Created user\n\nRaises:\n    HTTPException: If email is already registered\n\nNote:\n    This endpoint is deprecated. Use /register/{token} instead.",
         "operationId": "create_user_parties_user_post",
@@ -403,9 +383,7 @@
     },
     "/parties/register/{token}": {
       "post": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Register User",
         "description": "Register a new user with an invite token.\n\nArgs:\n    token (str): Invite token\n    user (UserCreate): User creation parameters\n    req_dep (RequestDependenciesBase): Request dependencies\n\nReturns:\n    User: Created user\n\nRaises:\n    HTTPException: If token is invalid, expired, already used, or email mismatch",
         "operationId": "register_user_parties_register__token__post",
@@ -456,9 +434,7 @@
     },
     "/parties/users": {
       "get": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Read Users",
         "description": "Get a list of users with pagination.\n\nArgs:\n    skip (int, optional): Number of records to skip. Defaults to 0.\n    limit (int, optional): Maximum number of records to return. Defaults to 100.\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Sequence[User]: List of users",
         "operationId": "read_users_parties_users_get",
@@ -519,9 +495,7 @@
     },
     "/parties/user/{user_api_id}": {
       "get": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Read User By Id",
         "description": "Get a user by their API identifier.\n\nArgs:\n    user_api_id (str): API identifier of the user\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    User: User information\n\nRaises:\n    HTTPException: If user not found",
         "operationId": "read_user_by_id_parties_user__user_api_id__get",
@@ -567,9 +541,7 @@
     },
     "/parties/me/password": {
       "patch": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Update Password Me",
         "description": "Update current user's password.\n\nArgs:\n    update_password_data (UserUpdatePassword): Password update parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    ResponseMessage: Success message\n\nRaises:\n    HTTPException: If current password is incorrect or new password is same as current",
         "operationId": "update_password_me_parties_me_password_patch",
@@ -614,9 +586,7 @@
     },
     "/parties/{user_api_id}/admin": {
       "patch": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Update User Admin",
         "description": "Update a user's admin status.\n\nArgs:\n    user_api_id (str): API identifier of the user to update\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    ResponseMessage: Success message\n\nRaises:\n    HTTPException: If user is not an admin",
         "operationId": "update_user_admin_parties__user_api_id__admin_patch",
@@ -662,9 +632,7 @@
     },
     "/parties/signup": {
       "post": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Signup",
         "description": "Sign up a new user without invitation (deprecated).\n\nNote:\n    This endpoint is not implemented and is deprecated.",
         "operationId": "signup_parties_signup_post",
@@ -686,9 +654,7 @@
     },
     "/parties/{user_id}": {
       "delete": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Delete User",
         "description": "Delete any user (deprecated).\n\nNote:\n    This endpoint is not implemented and is deprecated.",
         "operationId": "delete_user_parties__user_id__delete",
@@ -708,9 +674,7 @@
         "deprecated": true
       },
       "patch": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Update User",
         "description": "Update any user (deprecated).\n\nNote:\n    This endpoint is not implemented and is deprecated.",
         "operationId": "update_user_parties__user_id__patch",
@@ -732,9 +696,7 @@
     },
     "/parties/group": {
       "post": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Create Group",
         "description": "Create a new group.\n\nArgs:\n    group (GroupCreate): Group creation parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Created group\n\nRaises:\n    HTTPException: If group creation fails",
         "operationId": "create_group_parties_group_post",
@@ -779,9 +741,7 @@
     },
     "/parties/groups/": {
       "get": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "List Groups",
         "description": "List all groups a user is a member of.\n\nArgs:\n    user_api_id (str): API identifier of the user\n    skip (int, optional): Number of records to skip. Defaults to 0.\n    limit (int, optional): Maximum number of records to return. Defaults to 100.\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Sequence[Group]: List of groups",
         "operationId": "list_groups_parties_groups__get",
@@ -851,9 +811,7 @@
     },
     "/parties/group/{group_api_id}": {
       "get": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Read Group",
         "description": "Get details of a specific group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Group details\n\nRaises:\n    HTTPException: If group not found or user is not a member",
         "operationId": "read_group_parties_group__group_api_id__get",
@@ -897,9 +855,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Update Group",
         "description": "Update group information.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    group (GroupUpdate): Group update parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Updated group\n\nRaises:\n    HTTPException: If no updates provided, user not authorized, or invalid cycle length",
         "operationId": "update_group_parties_group__group_api_id__patch",
@@ -955,9 +911,7 @@
     },
     "/parties/group/{group_api_id}:add_member/{user_api_id}": {
       "post": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Add User To Group",
         "description": "Add a user to a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    user_api_id (str): API identifier of the user to add\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Updated group\n\nRaises:\n    HTTPException: If group or user not found",
         "operationId": "add_user_to_group_parties_group__group_api_id__add_member__user_api_id__post",
@@ -1012,9 +966,7 @@
     },
     "/parties/group/{group_api_id}:remove_member/{user_api_id}": {
       "post": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Remove User From Group",
         "description": "Remove a user from a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    user_api_id (str): API identifier of the user to remove\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Updated group\n\nRaises:\n    HTTPException: If group not found, user not authorized, or invalid operation",
         "operationId": "remove_user_from_group_parties_group__group_api_id__remove_member__user_api_id__post",
@@ -1069,9 +1021,7 @@
     },
     "/parties/group/{group_api_id}:add_members": {
       "post": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Add Members",
         "description": "Add multiple members to a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    add_members (AddMembers): List of email addresses to invite\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Updated group\n\nNote:\n    - Existing users will be added directly to the group\n    - Non-registered users will receive email invitations\n    - New members are automatically added to in-progress and upcoming letters",
         "operationId": "add_members_parties_group__group_api_id__add_members_post",
@@ -1127,9 +1077,7 @@
     },
     "/parties/group/{group_api_id}:replace_default_questions": {
       "post": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Replace Group Default Questions",
         "description": "Replace a group's default questions.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    default_questions (ReplaceDefaultQuestions): New list of default questions\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Group: Updated group\n\nRaises:\n    HTTPException: If group not found or user not authorized",
         "operationId": "replace_group_default_questions_parties_group__group_api_id__replace_default_questions_post",
@@ -1185,9 +1133,7 @@
     },
     "/parties/group/{group_api_id}/key-value": {
       "get": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Read Group Key Values",
         "description": "Get all key-value pairs for a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    GroupKeyValue: Dictionary of all key-value pairs\n\nRaises:\n    HTTPException: If group not found or user is not a member",
         "operationId": "read_group_key_values_parties_group__group_api_id__key_value_get",
@@ -1231,9 +1177,7 @@
         }
       },
       "put": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Full Replace Group Key Values",
         "description": "Replace all key-value pairs for a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    updates (GroupKeyValue): New key-value pairs\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    GroupKeyValue: Updated key-value pairs\n\nRaises:\n    HTTPException: If group not found or user is not a member",
         "operationId": "full_replace_group_key_values_parties_group__group_api_id__key_value_put",
@@ -1289,9 +1233,7 @@
     },
     "/parties/group/{group_api_id}/key-value/{key}": {
       "get": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Read Group Key Value",
         "description": "Get a specific key-value pair for a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    key (str): Key to retrieve\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    GroupKeyValueBase: Key-value pair\n\nRaises:\n    HTTPException: If group not found or user is not a member",
         "operationId": "read_group_key_value_parties_group__group_api_id__key_value__key__get",
@@ -1346,9 +1288,7 @@
     },
     "/parties/group/{group_api_id}/key-value:update": {
       "post": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Upsert Group Key Value",
         "description": "Update or delete a single key-value pair for a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    update (SingleGroupKeyValueUpdate): Update operation details\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    GroupKeyValueBase: Updated key-value pair\n\nRaises:\n    HTTPException: If group not found or user is not a member",
         "operationId": "upsert_group_key_value_parties_group__group_api_id__key_value_update_post",
@@ -1404,9 +1344,7 @@
     },
     "/parties/group/{group_api_id}/key-value:bulk-update": {
       "post": {
-        "tags": [
-          "parties"
-        ],
+        "tags": ["parties"],
         "summary": "Bulk Update Group Key Values",
         "description": "Update or delete multiple key-value pairs for a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    updates (BulkGroupKeyValueUpdate): List of update operations\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    GroupKeyValue: All key-value pairs after updates\n\nRaises:\n    HTTPException: If group not found or user is not a member",
         "operationId": "bulk_update_group_key_values_parties_group__group_api_id__key_value_bulk_update_post",
@@ -1462,9 +1400,7 @@
     },
     "/letters/letter": {
       "post": {
-        "tags": [
-          "letters"
-        ],
+        "tags": ["letters"],
         "summary": "Add Next Letter",
         "description": "Create a new letter for a group.\n\nCreates a new letter with default questions if there are no letters\ncurrently in progress or upcoming for the group.\n\nArgs:\n    letter (LetterCreate): Letter creation parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Letter: Newly created letter\n\nRaises:\n    ValueError: If there is already a letter in progress or upcoming",
         "operationId": "add_next_letter_letters_letter_post",
@@ -1509,9 +1445,7 @@
     },
     "/letters/letter:{letter_type}": {
       "post": {
-        "tags": [
-          "letters"
-        ],
+        "tags": ["letters"],
         "summary": "Add Next Letter",
         "operationId": "add_next_letter_letters_letter__letter_type__post",
         "security": [
@@ -1565,9 +1499,7 @@
     },
     "/letters/letters/": {
       "get": {
-        "tags": [
-          "letters"
-        ],
+        "tags": ["letters"],
         "summary": "List Letters",
         "description": "List letters for a specific group.\n\nRetrieves a paginated list of letters belonging to the specified group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    skip (int, optional): Number of records to skip for pagination. Defaults to 0.\n    limit (int, optional): Maximum number of records to return. Defaults to 100.\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Sequence[Letter]: List of letters",
         "operationId": "list_letters_letters_letters__get",
@@ -1653,9 +1585,7 @@
     },
     "/letters/letter/{letter_api_id}": {
       "get": {
-        "tags": [
-          "letters"
-        ],
+        "tags": ["letters"],
         "summary": "Read Letter",
         "description": "Retrieve a specific letter by its API identifier.\n\nArgs:\n    letter_api_id (str): API identifier of the letter\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Letter: The requested letter\n\nRaises:\n    IDNotFoundException: If letter with given API ID is not found",
         "operationId": "read_letter_letters_letter__letter_api_id__get",
@@ -1701,9 +1631,7 @@
     },
     "/letters/letters:dashboard": {
       "get": {
-        "tags": [
-          "letters"
-        ],
+        "tags": ["letters"],
         "summary": "List Dashboard Letters",
         "description": "List letters for the dashboard view.\n\nRetrieves letters that are upcoming, in progress, or recently completed\n(within the last 8 days) for the current user.\n\nArgs:\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    dict[str, list[Letter]]: Dictionary containing categorized letters",
         "operationId": "list_dashboard_letters_letters_letters_dashboard_get",
@@ -1728,9 +1656,7 @@
     },
     "/letters/letter/{letter_api_id}:edit_letter": {
       "post": {
-        "tags": [
-          "letters"
-        ],
+        "tags": ["letters"],
         "summary": "Edit Letter",
         "description": "Update a letter's details.\n\nUpdates the send time of a letter. For upcoming letters, ensures the new\nsend time is after any in-progress letter's send time.\n\nArgs:\n    letter_api_id (str): API identifier of the letter to edit\n    letter (LetterUpdate): Updated letter details\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Letter: Updated letter\n\nRaises:\n    AssertionError: If new send time violates timing constraints\n    IDNotFoundException: If letter with given API ID is not found",
         "operationId": "edit_letter_letters_letter__letter_api_id__edit_letter_post",
@@ -1786,9 +1712,7 @@
     },
     "/letters/letter/{letter_api_id}:add_question": {
       "post": {
-        "tags": [
-          "letters"
-        ],
+        "tags": ["letters"],
         "summary": "Add Question",
         "description": "Add a new question to a letter.\n\nCreates and adds a new question to the specified letter. The question can\noptionally be associated with an author.\n\n:param letter_api_id: API identifier of the letter\n:type letter_api_id: str\n:param question: Question creation parameters\n:type question: QuestionCreate\n:param req_dep: Request dependencies including database session and auth\n:type req_dep: AuthenticatedRequestDependencies\n:raises IDNotFoundException: If letter or author with given API ID is not found\n:return: Updated letter with the new question\n:rtype: Letter",
         "operationId": "add_question_letters_letter__letter_api_id__add_question_post",
@@ -1844,9 +1768,7 @@
     },
     "/letters/letter/{letter_api_id}:generate_question": {
       "post": {
-        "tags": [
-          "letters"
-        ],
+        "tags": ["letters"],
         "summary": "Generate Question",
         "description": "Generate a question using LLM without saving it.",
         "operationId": "generate_question_letters_letter__letter_api_id__generate_question_post",
@@ -1902,9 +1824,7 @@
     },
     "/schedule/schedule/{group_api_id}": {
       "get": {
-        "tags": [
-          "schedule"
-        ],
+        "tags": ["schedule"],
         "summary": "Get Schedule For Group",
         "description": "Get a group's schedule by its API identifier.\n\nArgs:\n    group_api_id: API identifier of the group\n    req_dep: Request dependencies including database session\n\nReturns:\n    Schedule: The group's schedule with its associated tasks\n\nRaises:\n    HTTPException: If the group is not found or user lacks permission",
         "operationId": "get_schedule_for_group_schedule_schedule__group_api_id__get",
@@ -1950,9 +1870,7 @@
     },
     "/questions/question/{question_api_id}:upsert_response": {
       "post": {
-        "tags": [
-          "questions"
-        ],
+        "tags": ["questions"],
         "summary": "Upsert Response",
         "description": "Create or update a response to a question.\n\nIf a response already exists (identified by api_identifier or participant),\nupdates it. Otherwise, creates a new response.\n\nArgs:\n    question_api_id (str): API identifier of the question\n    response (ResponseUpsert): Response creation/update parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Question: Updated question with the new/updated response\n\nRaises:\n    IDNotFoundException: If question or response with given API ID is not found",
         "operationId": "upsert_response_questions_question__question_api_id__upsert_response_post",
@@ -2008,9 +1926,7 @@
     },
     "/questions/question/{question_api_id}:upload_image": {
       "post": {
-        "tags": [
-          "questions"
-        ],
+        "tags": ["questions"],
         "summary": "Upload Image",
         "description": "Upload an image as part of a response to a question.\n\nCreates a new response if one doesn't exist for the current user,\nthen attaches the uploaded image to it.\n\nArgs:\n    question_api_id (str): API identifier of the question\n    response_image (UploadFile): Image file to upload\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Question: Updated question with the response containing the new image\n\nRaises:\n    IDNotFoundException: If question with given API ID is not found",
         "operationId": "upload_image_questions_question__question_api_id__upload_image_post",
@@ -2066,9 +1982,7 @@
     },
     "/questions/question/{question_api_id}": {
       "delete": {
-        "tags": [
-          "questions"
-        ],
+        "tags": ["questions"],
         "summary": "Delete Question",
         "description": "Delete a question.\n\nOnly the question author or group admin can delete a question.\nQuestions with responses cannot be deleted.\n\nArgs:\n    question_api_id (str): API identifier of the question to delete\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nRaises:\n    HTTPException: If question not found, user not authorized, or question has responses",
         "operationId": "delete_question_questions_question__question_api_id__delete",
@@ -2107,9 +2021,7 @@
     },
     "/responses/response/{response_api_id}:edit_response": {
       "post": {
-        "tags": [
-          "responses"
-        ],
+        "tags": ["responses"],
         "summary": "Edit Response",
         "description": "Update the text content of a response.\n\nArgs:\n    response_api_id (str): API identifier of the response to edit\n    response (ResponseCreateBase): Updated response content\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Response: Updated response\n\nRaises:\n    IDNotFoundException: If response with given API ID is not found",
         "operationId": "edit_response_responses_response__response_api_id__edit_response_post",
@@ -2165,9 +2077,7 @@
     },
     "/responses/response/{response_api_id}:upload_image": {
       "post": {
-        "tags": [
-          "responses"
-        ],
+        "tags": ["responses"],
         "summary": "Upload Image",
         "description": "Upload images to attach to a response.\n\nThis endpoint is deprecated. Use the question-level image upload endpoint instead.\n\nArgs:\n    response_api_id (str): API identifier of the response\n    response_images (list[UploadFile]): List of image files to upload\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Response: Updated response with attached images\n\nRaises:\n    IDNotFoundException: If response with given API ID is not found",
         "operationId": "upload_image_responses_response__response_api_id__upload_image_post",
@@ -2224,9 +2134,7 @@
     },
     "/responses/response/{response_api_id}:delete_image": {
       "delete": {
-        "tags": [
-          "responses"
-        ],
+        "tags": ["responses"],
         "summary": "Delete Image",
         "description": "Delete an image from a response.\n\nRemoves the image association and deletes the Image model row.\nThe S3 file is not deleted to avoid data loss.\n\nArgs:\n    response_api_id (str): API identifier of the response\n    s3_url (str): S3 URL of the image to delete\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Response: Updated response without the deleted image\n\nRaises:\n    IDNotFoundException: If response with given API ID is not found\n    ValueError: If image is not found in the response",
         "operationId": "delete_image_responses_response__response_api_id__delete_image_delete",
@@ -2281,9 +2189,7 @@
     },
     "/invites/": {
       "post": {
-        "tags": [
-          "invites"
-        ],
+        "tags": ["invites"],
         "summary": "Create Invite",
         "description": "Create a new invite for a user to join a group.\n\nArgs:\n    invite (InviteCreate): Invite creation parameters including email and group_api_id\n    req_dep (AuthenticatedRequestDependencies): Request dependencies\n\nReturns:\n    Invite: Created invite\n\nRaises:\n    HTTPException: If email is already invited, already registered, or group not found",
         "operationId": "create_invite_invites__post",
@@ -2328,9 +2234,7 @@
     },
     "/invites/token/{token}": {
       "get": {
-        "tags": [
-          "invites"
-        ],
+        "tags": ["invites"],
         "summary": "Validate Token",
         "description": "Validate an invite token and return the associated invite.\n\nArgs:\n    token (str): The invite token to validate\n    req_dep (RequestDependenciesBase): Request dependencies\n\nReturns:\n    Invite: The invite associated with the token\n\nRaises:\n    HTTPException: If token is invalid, expired, or already used",
         "operationId": "validate_token_invites_token__token__get",
@@ -2371,9 +2275,7 @@
     },
     "/notifications/subscription": {
       "post": {
-        "tags": [
-          "notifications"
-        ],
+        "tags": ["notifications"],
         "summary": "Post Subscription",
         "description": "Create a new web push notification subscription.\n\nCreates a subscription for the authenticated user to receive web push\nnotifications. If a subscription with the same endpoint already exists,\nreturns a message indicating this instead of creating a duplicate.\n\nArgs:\n    subscription (SubscriptionCreate): Subscription details including endpoint and keys\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session\n\nReturns:\n    ResponseMessage: Message indicating success or existing subscription\n\nRaises:\n    HTTPException: If user is not authenticated",
         "operationId": "post_subscription_notifications_subscription_post",
@@ -2418,9 +2320,7 @@
     },
     "/llm/completion": {
       "post": {
-        "tags": [
-          "llm"
-        ],
+        "tags": ["llm"],
         "summary": "Generate Completion",
         "description": "Generate a completion for the given request.\n\nGenerates a completion for the given request.\n\nArgs:\n    completion_request (CompletionRequest): Completion request details\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session\n\nReturns:\n    CompletionResponse: Completion response details\n\nRaises:\n    HTTPException: If user is not authenticated",
         "operationId": "generate_completion_llm_completion_post",
@@ -2465,11 +2365,9 @@
     },
     "/search/raw-search": {
       "get": {
-        "tags": [
-          "search"
-        ],
+        "tags": ["search"],
         "summary": "Raw Search",
-        "description": "Search the search table for a given query.\n\nArgs:\n    query: The search query string\n    search_type: Type of search to perform (semantic, keyword, or dual)\n    limit: Maximum number of results to return\n    db: Database session\n\nReturns:\n    RawSearchResponse containing matching results and total count",
+        "description": "Search the search table for a given query.\n\nArgs:\n    query: The search query string\n    search_type: Type of search to perform (semantic, keyword, or dual)\n    limit: Maximum number of results to return\n    group_api_id: Optional group filter\n    participant_api_id: Optional responder filter (responses only)\n    sort: Result ordering\n    db: Database session\n\nReturns:\n    RawSearchResponse containing matching results and total count",
         "operationId": "raw_search_search_raw_search_get",
         "parameters": [
           {
@@ -2487,7 +2385,7 @@
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/SearchType",
-              "default": "dual"
+              "default": "keyword"
             }
           },
           {
@@ -2498,6 +2396,47 @@
               "type": "integer",
               "default": 10,
               "title": "Limit"
+            }
+          },
+          {
+            "name": "group_api_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Group Api Id"
+            }
+          },
+          {
+            "name": "participant_api_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Participant Api Id"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/SearchSort",
+              "default": "relevance"
             }
           }
         ],
@@ -2527,9 +2466,7 @@
     },
     "/search/search": {
       "get": {
-        "tags": [
-          "search"
-        ],
+        "tags": ["search"],
         "summary": "Perform Search",
         "operationId": "perform_search_search_search_get",
         "security": [
@@ -2553,7 +2490,7 @@
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/SearchType",
-              "default": "dual"
+              "default": "keyword"
             }
           },
           {
@@ -2564,6 +2501,47 @@
               "type": "integer",
               "default": 10,
               "title": "Limit"
+            }
+          },
+          {
+            "name": "group_api_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Group Api Id"
+            }
+          },
+          {
+            "name": "participant_api_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Participant Api Id"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/SearchSort",
+              "default": "relevance"
             }
           }
         ],
@@ -2593,9 +2571,7 @@
     },
     "/notebook/documents": {
       "post": {
-        "tags": [
-          "notebook"
-        ],
+        "tags": ["notebook"],
         "summary": "Create Document Endpoint",
         "description": "Create a new document.\n\nArgs:\n    document (DocumentCreate): Document creation parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Document: Newly created document",
         "operationId": "create_document_endpoint_notebook_documents_post",
@@ -2638,9 +2614,7 @@
         }
       },
       "get": {
-        "tags": [
-          "notebook"
-        ],
+        "tags": ["notebook"],
         "summary": "List Documents",
         "description": "List documents for a group.\n\nArgs:\n    group_api_id (str): API identifier of the group\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    List[Document]: List of documents",
         "operationId": "list_documents_notebook_documents_get",
@@ -2690,9 +2664,7 @@
     },
     "/notebook/documents/{document_api_id}": {
       "get": {
-        "tags": [
-          "notebook"
-        ],
+        "tags": ["notebook"],
         "summary": "Get Document Endpoint",
         "description": "Get a document by its API identifier.\n\nArgs:\n    document_api_id (str): API identifier of the document\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Document: The requested document\n\nRaises:\n    IDNotFoundException: If document with given API ID is not found",
         "operationId": "get_document_endpoint_notebook_documents__document_api_id__get",
@@ -2736,9 +2708,7 @@
         }
       },
       "put": {
-        "tags": [
-          "notebook"
-        ],
+        "tags": ["notebook"],
         "summary": "Update Document Endpoint",
         "description": "Update a document.\n\nArgs:\n    document_api_id (str): API identifier of the document\n    document_update (DocumentUpdate): Document update parameters\n    req_dep (AuthenticatedRequestDependencies): Request dependencies including database session and auth\n\nReturns:\n    Document: Updated document\n\nRaises:\n    IDNotFoundException: If document with given API ID is not found",
         "operationId": "update_document_endpoint_notebook_documents__document_api_id__put",
@@ -2852,9 +2822,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "member_emails"
-        ],
+        "required": ["member_emails"],
         "title": "AddMembers",
         "description": "Schema for adding members to a group.\n\nAttributes:\n    member_emails (list[str]): List of email addresses to invite"
       },
@@ -2909,10 +2877,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "username",
-          "password"
-        ],
+        "required": ["username", "password"],
         "title": "Body_login_access_token_login_access_token_post"
       },
       "Body_upload_image_questions_question__question_api_id__upload_image_post": {
@@ -2924,9 +2889,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "response_image"
-        ],
+        "required": ["response_image"],
         "title": "Body_upload_image_questions_question__question_api_id__upload_image_post"
       },
       "Body_upload_image_responses_response__response_api_id__upload_image_post": {
@@ -2941,9 +2904,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "response_images"
-        ],
+        "required": ["response_images"],
         "title": "Body_upload_image_responses_response__response_api_id__upload_image_post"
       },
       "BulkGroupKeyValueUpdate": {
@@ -2959,9 +2920,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "updates"
-        ],
+        "required": ["updates"],
         "title": "BulkGroupKeyValueUpdate",
         "description": "Schema for bulk updating multiple key-value pairs.\n\nThis model allows multiple key-value operations to be performed in a single request.\nEach update in the list can be either a 'set' or 'delete' operation.\n\nAttributes:\n    updates (list[SingleGroupKeyValueUpdate]): List of update operations to perform\n\nNote:\n    At least one update operation must be provided"
       },
@@ -2973,9 +2932,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "prompt"
-        ],
+        "required": ["prompt"],
         "title": "CompletionRequest"
       },
       "CompletionResponse": {
@@ -2986,9 +2943,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "text"
-        ],
+        "required": ["text"],
         "title": "CompletionResponse"
       },
       "DashboardLetters": {
@@ -3016,11 +2971,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "upcoming",
-          "in_progress",
-          "recently_completed"
-        ],
+        "required": ["upcoming", "in_progress", "recently_completed"],
         "title": "DashboardLetters",
         "description": "Model for the letters dashboard view.\n\nGroups letters by their status for dashboard display.\n\nAttributes:\n    upcoming (list[PublicLetter]): Letters scheduled for the future\n    in_progress (list[PublicLetter]): Currently active letters\n    recently_completed (list[PublicLetter]): Recently finished letters"
       },
@@ -3043,11 +2994,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "content",
-          "group_api_id"
-        ],
+        "required": ["name", "content", "group_api_id"],
         "title": "DocumentCreate",
         "description": "Schema for creating a new document."
       },
@@ -3143,9 +3090,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "prompt"
-        ],
+        "required": ["prompt"],
         "title": "GenerateQuestionRequest"
       },
       "GenerateQuestionResponse": {
@@ -3156,9 +3101,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "generated_text"
-        ],
+        "required": ["generated_text"],
         "title": "GenerateQuestionResponse"
       },
       "GroupCreate": {
@@ -3173,10 +3116,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "admin_api_identifier"
-        ],
+        "required": ["name", "admin_api_identifier"],
         "title": "GroupCreate",
         "description": "Schema for creating a new group.\n\nAttributes:\n    name (str): Name of the group (inherited from GroupBase)\n    admin_api_identifier (str): API identifier of the user who will be admin"
       },
@@ -3190,9 +3130,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "key_values"
-        ],
+        "required": ["key_values"],
         "title": "GroupKeyValue",
         "description": "Schema for group key-value responses.\n\nThis model represents the complete key-value store for a group, containing\nall key-value pairs in a dictionary format.\n\nAttributes:\n    key_values (dict[str, Any]): Dictionary containing all key-value pairs for the group"
       },
@@ -3209,10 +3147,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "key",
-          "value"
-        ],
+        "required": ["key", "value"],
         "title": "GroupKeyValueBase",
         "description": "Base schema for group key-value operations.\n\nThis is the base model that defines the fundamental structure of a key-value pair.\nIt is used as a building block for other key-value related schemas.\n\nAttributes:\n    key (str): The key identifier for the value\n    value (Any): The value associated with the key, can be any JSON-serializable type"
       },
@@ -3328,12 +3263,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "api_identifier",
-          "created_at",
-          "cycle_length"
-        ],
+        "required": ["name", "api_identifier", "created_at", "cycle_length"],
         "title": "GroupUnlinked",
         "description": "Schema for groups without linked relationships.\n\nInherits all fields from Group but excludes relationship data."
       },
@@ -3401,10 +3331,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "s3_url",
-          "media_type"
-        ],
+        "required": ["s3_url", "media_type"],
         "title": "Image",
         "description": "Schema for image data.\n\nRepresents an image stored in S3 with its media type.\n\nAttributes:\n    s3_url (str): S3 key/path for the image\n    media_type (MediaType): Type of media (image/video)"
       },
@@ -3420,10 +3347,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "email",
-          "group_api_id"
-        ],
+        "required": ["email", "group_api_id"],
         "title": "InviteCreate",
         "description": "Schema for creating a new invite.\n\nAttributes:\n    email (str): Email address of the invitee (inherited from InviteBase)\n    group_api_id (str): API identifier of the group to invite to"
       },
@@ -3498,29 +3422,19 @@
           }
         },
         "type": "object",
-        "required": [
-          "group_api_identifier",
-          "send_at"
-        ],
+        "required": ["group_api_identifier", "send_at"],
         "title": "LetterCreate",
         "description": "Schema for creating a new letter.\n\nAttributes:\n    group_api_identifier (str): API identifier of the group to create the letter for\n    send_at (AwareDatetime): Scheduled time to send the letter"
       },
       "LetterStatus": {
         "type": "string",
-        "enum": [
-          "UPCOMING",
-          "IN_PROGRESS",
-          "SENT"
-        ],
+        "enum": ["UPCOMING", "IN_PROGRESS", "SENT"],
         "title": "LetterStatus",
         "description": "Enumeration of possible letter statuses.\nRepresents the different states a letter can be in within the system:\n- UPCOMING: Letter is scheduled but not yet active\n- IN_PROGRESS: Letter is currently active and accepting responses\n- SENT: Letter has been completed and sent"
       },
       "LetterType": {
         "type": "string",
-        "enum": [
-          "CYCLIC",
-          "ADHOC"
-        ],
+        "enum": ["CYCLIC", "ADHOC"],
         "title": "LetterType",
         "description": ""
       },
@@ -3622,10 +3536,7 @@
       },
       "MediaType": {
         "type": "string",
-        "enum": [
-          "image",
-          "video"
-        ],
+        "enum": ["image", "video"],
         "title": "MediaType",
         "description": "Enumeration of supported media types.\n\nAttributes:\n    IMAGE: Image files (e.g., jpg, png)\n    VIDEO: Video files"
       },
@@ -3726,9 +3637,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "new_password"
-        ],
+        "required": ["new_password"],
         "title": "NewPassword",
         "description": "Schema for setting a new password (e.g., after reset).\n\nAttributes:\n    new_password (str): User's new password"
       },
@@ -3900,10 +3809,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "question_text",
-          "author_api_id"
-        ],
+        "required": ["question_text", "author_api_id"],
         "title": "QuestionCreate",
         "description": "Schema for creating a new question.\n\nAttributes:\n    question_text (str): The text content of the question\n    author_api_id (str | None): API identifier of the question's author, optional"
       },
@@ -3965,11 +3871,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "question_text",
-          "api_identifier",
-          "created_at"
-        ],
+        "required": ["question_text", "api_identifier", "created_at"],
         "title": "QuestionUnlinked",
         "description": "Schema for question without linked relationships.\n\nInherits all fields from Question but excludes relationship data."
       },
@@ -3988,10 +3890,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "results",
-          "total"
-        ],
+        "required": ["results", "total"],
         "title": "RawSearchResponse"
       },
       "RawSearchResult": {
@@ -4002,9 +3901,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "raw_text"
-        ],
+        "required": ["raw_text"],
         "title": "RawSearchResult"
       },
       "ReplaceDefaultQuestions": {
@@ -4018,9 +3915,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "questions"
-        ],
+        "required": ["questions"],
         "title": "ReplaceDefaultQuestions",
         "description": "Schema for replacing a group's default questions.\n\nAttributes:\n    questions (list[str]): New list of default questions"
       },
@@ -4032,9 +3927,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "response_text"
-        ],
+        "required": ["response_text"],
         "title": "ResponseCreateBase",
         "description": "Base schema for response creation operations.\n\nInherits response_text field from ResponseBase."
       },
@@ -4097,9 +3990,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "title": "ResponseMessage",
         "description": "Standard response message model.\n\nUsed for API endpoints that return a simple message response.\n\nAttributes:\n    message (str): The response message text"
       },
@@ -4120,11 +4011,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "response_text",
-          "api_identifier",
-          "created_at"
-        ],
+        "required": ["response_text", "api_identifier", "created_at"],
         "title": "ResponseUnlinked",
         "description": "Schema for response without linked relationships.\n\nInherits all fields from Response but excludes relationship data."
       },
@@ -4158,9 +4045,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "response_text"
-        ],
+        "required": ["response_text"],
         "title": "ResponseUpsert",
         "description": "Schema for creating or updating a response.\n\nAttributes:\n    response_text (str): The text content of the response\n    participant_api_identifier (Optional[str]): API identifier of the participant, optional\n    api_identifier (Optional[str]): API identifier of an existing response, optional"
       },
@@ -4217,10 +4102,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "group",
-          "tasks"
-        ],
+        "required": ["group", "tasks"],
         "title": "ScheduleLinked",
         "description": "Schedule model with linked relationships.\n\nExtends the base Schedule model to include the associated group and tasks.\n\nAttributes:\n    group (GroupUnlinked): The group this schedule belongs to\n    tasks (list[TaskUnlinked]): Tasks in the schedule"
       },
@@ -4235,9 +4117,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "tasks"
-        ],
+        "required": ["tasks"],
         "title": "ScheduleUnlinked",
         "description": "Schema for schedule data with unlinked task relationships.\n\nThis schema extends the base Schedule schema and includes a list of tasks,\nusing the unlinked task schema to avoid circular references.\n\nAttributes:\n    tasks: List of tasks associated with this schedule"
       },
@@ -4256,10 +4136,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "results",
-          "total"
-        ],
+        "required": ["results", "total"],
         "title": "SearchResponse"
       },
       "SearchResult": {
@@ -4290,20 +4167,18 @@
           }
         },
         "type": "object",
-        "required": [
-          "model",
-          "type"
-        ],
+        "required": ["model", "type"],
         "title": "SearchResult",
         "description": "Search result model that can hold different types of models based on type field.\n\nAttributes:\n    model (Any): The model instance\n    type (str): The type of the model"
       },
+      "SearchSort": {
+        "type": "string",
+        "enum": ["relevance", "created_at_desc", "created_at_asc"],
+        "title": "SearchSort"
+      },
       "SearchType": {
         "type": "string",
-        "enum": [
-          "semantic",
-          "keyword",
-          "dual"
-        ],
+        "enum": ["semantic", "keyword", "dual"],
         "title": "SearchType"
       },
       "SingleGroupKeyValueUpdate": {
@@ -4325,19 +4200,13 @@
           },
           "operation": {
             "type": "string",
-            "enum": [
-              "set",
-              "delete"
-            ],
+            "enum": ["set", "delete"],
             "title": "Operation",
             "description": "Operation to perform: 'set' to update/create, 'delete' to remove"
           }
         },
         "type": "object",
-        "required": [
-          "key",
-          "operation"
-        ],
+        "required": ["key", "operation"],
         "title": "SingleGroupKeyValueUpdate",
         "description": "Schema for updating a single group key-value pair.\n\nThis model extends GroupKeyValueBase to include an operation field that specifies\nwhether to set or delete the key-value pair.\n\nAttributes:\n    key (str): The key identifier to update\n    value (Any | None): The value to set (required for 'set' operation, ignored for 'delete')\n    operation (Literal[\"set\", \"delete\"]): The operation to perform on the key-value pair\n\nNote:\n    For 'delete' operations, the value field is ignored"
       },
@@ -4370,11 +4239,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "endpoint",
-          "keys",
-          "user_api_identifier"
-        ],
+        "required": ["endpoint", "keys", "user_api_identifier"],
         "title": "SubscriptionCreate",
         "description": "Schema for creating a new subscription.\n\nInherits endpoint and keys from SubscriptionBase and adds user identification.\n\nAttributes:\n    endpoint (str): Push notification endpoint URL\n    keys (dict[str, str | float | bool]): Dictionary containing encryption keys and auth info\n    user_api_identifier (str): API identifier of the user to subscribe"
       },
@@ -4400,12 +4265,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "type",
-          "status",
-          "execute_at",
-          "arguments"
-        ],
+        "required": ["type", "status", "execute_at", "arguments"],
         "title": "TaskUnlinked",
         "description": "Schema for task data without linked relationships.\n\nThis schema extends the base Task schema but excludes any linked relationships,\nuseful for nested serialization to avoid circular references."
       },
@@ -4421,10 +4281,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "access_token",
-          "token_type"
-        ],
+        "required": ["access_token", "token_type"],
         "title": "Token",
         "description": "Authentication token schema.\n\nRepresents the structure of an authentication token response.\n\nAttributes:\n    access_token (str): The JWT access token string\n    token_type (str): The type of token (e.g., \"bearer\")"
       },
@@ -4444,11 +4301,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "email",
-          "name",
-          "password"
-        ],
+        "required": ["email", "name", "password"],
         "title": "UserCreate",
         "description": "Schema for creating a new user.\n\nAttributes:\n    email (str): User's email address (inherited from UserBase)\n    name (str): User's display name (inherited from UserBase)\n    password (str): User's password (will be hashed)"
       },
@@ -4517,12 +4370,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "email",
-          "name",
-          "api_identifier",
-          "admin"
-        ],
+        "required": ["email", "name", "api_identifier", "admin"],
         "title": "UserUnlinked",
         "description": "Schema for users without linked relationships.\n\nInherits all fields from User but excludes relationship data."
       },
@@ -4567,10 +4415,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "current_password",
-          "new_password"
-        ],
+        "required": ["current_password", "new_password"],
         "title": "UserUpdatePassword",
         "description": "Schema for updating a user's password.\n\nAttributes:\n    current_password (str): User's current password\n    new_password (str): User's new password"
       },
@@ -4600,11 +4445,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
+        "required": ["loc", "msg", "type"],
         "title": "ValidationError"
       }
     },

--- a/react/src/client/sdk.gen.ts
+++ b/react/src/client/sdk.gen.ts
@@ -1392,6 +1392,9 @@ export const generateCompletionLlmCompletionPost = <ThrowOnError extends boolean
  * query: The search query string
  * search_type: Type of search to perform (semantic, keyword, or dual)
  * limit: Maximum number of results to return
+ * group_api_id: Optional group filter
+ * participant_api_id: Optional responder filter (responses only)
+ * sort: Result ordering
  * db: Database session
  *
  * Returns:

--- a/react/src/client/types.gen.ts
+++ b/react/src/client/types.gen.ts
@@ -650,6 +650,8 @@ export type SearchResult = {
     type: string;
 };
 
+export type SearchSort = 'relevance' | 'created_at_desc' | 'created_at_asc';
+
 export type SearchType = 'semantic' | 'keyword' | 'dual';
 
 /**
@@ -2075,6 +2077,9 @@ export type RawSearchSearchRawSearchGetData = {
         query: string;
         search_type?: SearchType;
         limit?: number;
+        group_api_id?: string | null;
+        participant_api_id?: string | null;
+        sort?: SearchSort;
     };
     url: '/search/raw-search';
 };
@@ -2104,6 +2109,9 @@ export type PerformSearchSearchSearchGetData = {
         query: string;
         search_type?: SearchType;
         limit?: number;
+        group_api_id?: string | null;
+        participant_api_id?: string | null;
+        sort?: SearchSort;
     };
     url: '/search/search';
 };

--- a/react/src/components/Common/SearchFilters.tsx
+++ b/react/src/components/Common/SearchFilters.tsx
@@ -1,0 +1,124 @@
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { ChevronDown } from "lucide-react"
+
+import type { GroupUnlinked, SearchSort, UserUnlinked } from "../../client"
+
+type SearchFiltersProps = {
+  groups: GroupUnlinked[]
+  members: UserUnlinked[]
+  groupApiId?: string
+  participantApiId?: string
+  sort: SearchSort
+  onGroupChange: (groupApiId?: string) => void
+  onParticipantChange: (participantApiId?: string) => void
+  onSortChange: (sort: SearchSort) => void
+}
+
+const SORT_LABELS: Record<SearchSort, string> = {
+  relevance: "Relevance",
+  created_at_desc: "Newest first",
+  created_at_asc: "Oldest first",
+}
+
+export function SearchFilters({
+  groups,
+  members,
+  groupApiId,
+  participantApiId,
+  sort,
+  onGroupChange,
+  onParticipantChange,
+  onSortChange,
+}: SearchFiltersProps) {
+  const selectedGroup = groups.find(
+    (group) => group.api_identifier === groupApiId,
+  )
+  const selectedParticipant = members.find(
+    (member) => member.api_identifier === participantApiId,
+  )
+
+  return (
+    <div className="flex flex-wrap gap-3 px-4 pb-4">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" className="min-w-40 justify-between">
+            {selectedGroup?.name ?? "All groups"}
+            <ChevronDown className="h-4 w-4 opacity-60" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-56">
+          <DropdownMenuItem
+            onClick={() => {
+              onGroupChange(undefined)
+              onParticipantChange(undefined)
+            }}
+          >
+            All groups
+          </DropdownMenuItem>
+          {groups.map((group) => (
+            <DropdownMenuItem
+              key={group.api_identifier}
+              onClick={() => {
+                onGroupChange(group.api_identifier)
+                onParticipantChange(undefined)
+              }}
+            >
+              {group.name}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            className="min-w-40 justify-between"
+            disabled={!groupApiId}
+          >
+            {selectedParticipant?.name ?? "All responders"}
+            <ChevronDown className="h-4 w-4 opacity-60" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-56">
+          <DropdownMenuItem onClick={() => onParticipantChange(undefined)}>
+            All responders
+          </DropdownMenuItem>
+          {members.map((member) => (
+            <DropdownMenuItem
+              key={member.api_identifier}
+              onClick={() => onParticipantChange(member.api_identifier)}
+            >
+              {member.name}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" className="min-w-40 justify-between">
+            {SORT_LABELS[sort]}
+            <ChevronDown className="h-4 w-4 opacity-60" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-56">
+          {(Object.keys(SORT_LABELS) as SearchSort[]).map((sortOption) => (
+            <DropdownMenuItem
+              key={sortOption}
+              onClick={() => onSortChange(sortOption)}
+            >
+              {SORT_LABELS[sortOption]}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/react/src/components/Common/SearchResultRow.tsx
+++ b/react/src/components/Common/SearchResultRow.tsx
@@ -13,9 +13,27 @@ import type {
 
 interface SearchResultRowProps {
   result: SearchResult
+  showTimestamp?: boolean
 }
 
-function ResponseSearchResultRow({ result }: { result: SearchResult }) {
+function formatTimestamp(value?: string) {
+  if (!value) return null
+  return new Date(value).toLocaleString()
+}
+
+function TimestampLine({ value }: { value?: string }) {
+  const formatted = formatTimestamp(value)
+  if (!formatted) return null
+  return <p className="text-xs text-muted-foreground">{formatted}</p>
+}
+
+function ResponseSearchResultRow({
+  result,
+  showTimestamp,
+}: {
+  result: SearchResult
+  showTimestamp?: boolean
+}) {
   const model = result.model as ResponseLinked
 
   return (
@@ -46,6 +64,7 @@ function ResponseSearchResultRow({ result }: { result: SearchResult }) {
             <p className="text-sm text-muted-foreground line-clamp-2">
               {model.response_text}
             </p>
+            {showTimestamp ? <TimestampLine value={model.created_at} /> : null}
           </div>
         </Link>
       </TableCell>
@@ -75,7 +94,13 @@ function UserSearchResultRow({ result }: { result: SearchResult }) {
   )
 }
 
-function GroupSearchResultRow({ result }: { result: SearchResult }) {
+function GroupSearchResultRow({
+  result,
+  showTimestamp,
+}: {
+  result: SearchResult
+  showTimestamp?: boolean
+}) {
   const model = result.model as GroupLinked
 
   return (
@@ -96,6 +121,7 @@ function GroupSearchResultRow({ result }: { result: SearchResult }) {
             <p className="text-sm text-muted-foreground">
               {model.members.length} members • {model.letters.length} letters
             </p>
+            {showTimestamp ? <TimestampLine value={model.created_at} /> : null}
           </div>
         </Link>
       </TableCell>
@@ -103,7 +129,13 @@ function GroupSearchResultRow({ result }: { result: SearchResult }) {
   )
 }
 
-function QuestionSearchResultRow({ result }: { result: SearchResult }) {
+function QuestionSearchResultRow({
+  result,
+  showTimestamp,
+}: {
+  result: SearchResult
+  showTimestamp?: boolean
+}) {
   const model = result.model as QuestionLinked
   const letter = model.letter as LetterUnlinked
 
@@ -130,6 +162,7 @@ function QuestionSearchResultRow({ result }: { result: SearchResult }) {
             <p className="text-sm text-muted-foreground/70">
               {model.responses.length} responses
             </p>
+            {showTimestamp ? <TimestampLine value={model.created_at} /> : null}
           </div>
         </Link>
       </TableCell>
@@ -137,7 +170,13 @@ function QuestionSearchResultRow({ result }: { result: SearchResult }) {
   )
 }
 
-function LetterSearchResultRow({ result }: { result: SearchResult }) {
+function LetterSearchResultRow({
+  result,
+  showTimestamp,
+}: {
+  result: SearchResult
+  showTimestamp?: boolean
+}) {
   const model = result.model as PublicLetter
 
   return (
@@ -161,6 +200,7 @@ function LetterSearchResultRow({ result }: { result: SearchResult }) {
               {model.participants.length} participants •{" "}
               {model.questions.length} questions
             </p>
+            {showTimestamp ? <TimestampLine value={model.created_at} /> : null}
           </div>
         </Link>
       </TableCell>
@@ -183,18 +223,35 @@ function DefaultSearchResultRow({ result }: { result: SearchResult }) {
   )
 }
 
-export function SearchResultRow({ result }: SearchResultRowProps) {
+export function SearchResultRow({
+  result,
+  showTimestamp = false,
+}: SearchResultRowProps) {
   switch (result.type) {
     case "ResponseLinked":
-      return <ResponseSearchResultRow result={result} />
+      return (
+        <ResponseSearchResultRow
+          result={result}
+          showTimestamp={showTimestamp}
+        />
+      )
     case "UserLinked":
       return <UserSearchResultRow result={result} />
     case "GroupLinked":
-      return <GroupSearchResultRow result={result} />
+      return (
+        <GroupSearchResultRow result={result} showTimestamp={showTimestamp} />
+      )
     case "QuestionLinked":
-      return <QuestionSearchResultRow result={result} />
+      return (
+        <QuestionSearchResultRow
+          result={result}
+          showTimestamp={showTimestamp}
+        />
+      )
     case "PublicLetter":
-      return <LetterSearchResultRow result={result} />
+      return (
+        <LetterSearchResultRow result={result} showTimestamp={showTimestamp} />
+      )
     default:
       return <DefaultSearchResultRow result={result} />
   }

--- a/react/src/routes/_layout/search.tsx
+++ b/react/src/routes/_layout/search.tsx
@@ -11,9 +11,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { useQuery } from "@tanstack/react-query"
-import type { SearchResult } from "../../client"
-import { performSearchSearchSearchGetOptions } from "../../client/@tanstack/react-query.gen"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import type { SearchSort, UserLinked } from "../../client"
+import {
+  performSearchSearchSearchGetOptions,
+  readGroupPartiesGroupGroupApiIdGetOptions,
+  readUserMePartiesMeGetQueryKey,
+} from "../../client/@tanstack/react-query.gen"
+import { SearchFilters } from "../../components/Common/SearchFilters"
 import { SearchResultRow } from "../../components/Common/SearchResultRow"
 
 export const Route = createFileRoute("/_layout/search")({
@@ -21,23 +26,53 @@ export const Route = createFileRoute("/_layout/search")({
 })
 
 function SearchContent() {
-  const [searchQuery, setSearchQuery] = useState("")
-  const [isSearching, setIsSearching] = useState(false)
+  const queryClient = useQueryClient()
+  const currentUser = queryClient.getQueryData<UserLinked>(
+    readUserMePartiesMeGetQueryKey(),
+  )
+  const groups = currentUser?.groups ?? []
 
-  const { data: searchResults, refetch } = useQuery({
+  const [searchQuery, setSearchQuery] = useState("")
+  const [submittedQuery, setSubmittedQuery] = useState<string | null>(null)
+  const [groupApiId, setGroupApiId] = useState<string | undefined>()
+  const [participantApiId, setParticipantApiId] = useState<string | undefined>()
+  const [sort, setSort] = useState<SearchSort>("relevance")
+
+  const { data: selectedGroup } = useQuery({
+    ...readGroupPartiesGroupGroupApiIdGetOptions({
+      path: { group_api_id: groupApiId ?? "" },
+    }),
+    enabled: Boolean(groupApiId),
+  })
+
+  const {
+    data: searchResults,
+    isFetching,
+    refetch,
+  } = useQuery({
     ...performSearchSearchSearchGetOptions({
       query: {
-        query: searchQuery,
+        query: submittedQuery ?? "",
+        group_api_id: groupApiId ?? null,
+        participant_api_id: participantApiId ?? null,
+        sort,
+        limit: 25,
       },
     }),
-    enabled: false,
+    enabled: Boolean(submittedQuery?.trim()),
   })
 
   const handleSearch = async () => {
     if (!searchQuery.trim()) return
-    setIsSearching(true)
-    await refetch()
+    if (submittedQuery === searchQuery) {
+      await refetch()
+      return
+    }
+    setSubmittedQuery(searchQuery)
   }
+
+  const showTimestamp = sort !== "relevance"
+  const hasSearched = submittedQuery !== null
 
   return (
     <div className="w-full">
@@ -54,38 +89,71 @@ function SearchContent() {
             onChange={(e) => setSearchQuery(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
-                handleSearch()
+                void handleSearch()
               }
             }}
           />
           <Button
             variant="ghost"
             size="icon"
-            onClick={handleSearch}
+            onClick={() => void handleSearch()}
             className="absolute right-1 top-1/2 -translate-y-1/2"
+            disabled={isFetching}
           >
-            <SearchIcon className="h-5 w-5" />
+            {isFetching ? (
+              <Loader2 className="h-5 w-5 animate-spin" />
+            ) : (
+              <SearchIcon className="h-5 w-5" />
+            )}
           </Button>
         </div>
       </div>
 
-      {isSearching && searchResults && (
+      <SearchFilters
+        groups={groups}
+        members={selectedGroup?.members ?? []}
+        groupApiId={groupApiId}
+        participantApiId={participantApiId}
+        sort={sort}
+        onGroupChange={setGroupApiId}
+        onParticipantChange={setParticipantApiId}
+        onSortChange={setSort}
+      />
+
+      {hasSearched && (
         <div className="px-4 overflow-auto">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Result</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {searchResults.results.map((result: SearchResult) => (
-                <SearchResultRow
-                  key={result.model.api_identifier}
-                  result={result}
-                />
-              ))}
-            </TableBody>
-          </Table>
+          {isFetching && !searchResults ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin" />
+            </div>
+          ) : searchResults && searchResults.results.length > 0 ? (
+            <>
+              <p className="text-sm text-muted-foreground pb-4">
+                {searchResults.total} result
+                {searchResults.total === 1 ? "" : "s"}
+              </p>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Result</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {searchResults.results.map((result) => (
+                    <SearchResultRow
+                      key={`${result.type}-${result.model.api_identifier}`}
+                      result={result}
+                      showTimestamp={showTimestamp}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground py-8 text-center">
+              No results found.
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/ring/alembic/versions/f36847c5bb55_add_search_association_filter_metadata.py
+++ b/ring/alembic/versions/f36847c5bb55_add_search_association_filter_metadata.py
@@ -1,0 +1,196 @@
+"""add search association filter metadata
+
+Revision ID: f36847c5bb55
+Revises: 45bf29f5dbb8
+Create Date: 2026-06-23 08:09:02.472390
+
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f36847c5bb55"
+down_revision: Union[str, None] = "45bf29f5dbb8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE hybrid_search_document_association
+        ADD COLUMN IF NOT EXISTS group_api_id VARCHAR
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE hybrid_search_document_association
+        ADD COLUMN IF NOT EXISTS participant_api_id VARCHAR
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE hybrid_search_document_association
+        ADD COLUMN IF NOT EXISTS entity_created_at TIMESTAMPTZ
+        """
+    )
+
+    op.execute(
+        """
+        UPDATE hybrid_search_document_association AS a
+        SET entity_created_at = r.created_at
+        FROM response AS r
+        WHERE a.model_type = 'response'
+          AND a.model_api_identifier = r.api_identifier
+        """
+    )
+    op.execute(
+        """
+        UPDATE hybrid_search_document_association AS a
+        SET entity_created_at = q.created_at
+        FROM question AS q
+        WHERE a.model_type = 'question'
+          AND a.model_api_identifier = q.api_identifier
+        """
+    )
+    op.execute(
+        """
+        UPDATE hybrid_search_document_association AS a
+        SET entity_created_at = l.created_at
+        FROM letter AS l
+        WHERE a.model_type = 'letter'
+          AND a.model_api_identifier = l.api_identifier
+        """
+    )
+    op.execute(
+        """
+        UPDATE hybrid_search_document_association AS a
+        SET entity_created_at = g.created_at
+        FROM "group" AS g
+        WHERE a.model_type = 'group'
+          AND a.model_api_identifier = g.api_identifier
+        """
+    )
+    op.execute(
+        """
+        UPDATE hybrid_search_document_association AS a
+        SET entity_created_at = u.created_at
+        FROM "user" AS u
+        WHERE a.model_type = 'user'
+          AND a.model_api_identifier = u.api_identifier
+        """
+    )
+    op.execute(
+        """
+        UPDATE hybrid_search_document_association AS a
+        SET entity_created_at = d.created_at
+        FROM hybrid_search_document AS d
+        WHERE a.hybrid_search_document_id = d.id
+          AND a.entity_created_at IS NULL
+        """
+    )
+
+    op.execute(
+        """
+        UPDATE hybrid_search_document_association AS a
+        SET group_api_id = g.api_identifier
+        FROM response AS r
+        JOIN question AS q ON r.question_id = q.id
+        JOIN letter AS l ON q.letter_id = l.id
+        JOIN "group" AS g ON l.group_id = g.id
+        WHERE a.model_type = 'response'
+          AND a.model_api_identifier = r.api_identifier
+        """
+    )
+    op.execute(
+        """
+        UPDATE hybrid_search_document_association AS a
+        SET group_api_id = g.api_identifier
+        FROM question AS q
+        JOIN letter AS l ON q.letter_id = l.id
+        JOIN "group" AS g ON l.group_id = g.id
+        WHERE a.model_type = 'question'
+          AND a.model_api_identifier = q.api_identifier
+        """
+    )
+    op.execute(
+        """
+        UPDATE hybrid_search_document_association AS a
+        SET group_api_id = g.api_identifier
+        FROM letter AS l
+        JOIN "group" AS g ON l.group_id = g.id
+        WHERE a.model_type = 'letter'
+          AND a.model_api_identifier = l.api_identifier
+        """
+    )
+    op.execute(
+        """
+        UPDATE hybrid_search_document_association AS a
+        SET group_api_id = g.api_identifier
+        FROM "group" AS g
+        WHERE a.model_type = 'group'
+          AND a.model_api_identifier = g.api_identifier
+        """
+    )
+    op.execute(
+        """
+        UPDATE hybrid_search_document_association AS a
+        SET participant_api_id = u.api_identifier
+        FROM response AS r
+        JOIN "user" AS u ON r.participant_id = u.id
+        WHERE a.model_type = 'response'
+          AND a.model_api_identifier = r.api_identifier
+        """
+    )
+
+    op.alter_column(
+        "hybrid_search_document_association",
+        "entity_created_at",
+        existing_type=sa.DateTime(timezone=True),
+        nullable=False,
+    )
+
+    op.create_index(
+        op.f("ix_hybrid_search_document_association_entity_created_at"),
+        "hybrid_search_document_association",
+        ["entity_created_at"],
+        unique=False,
+        if_not_exists=True,
+    )
+    op.create_index(
+        op.f("ix_hybrid_search_document_association_group_api_id"),
+        "hybrid_search_document_association",
+        ["group_api_id"],
+        unique=False,
+        if_not_exists=True,
+    )
+    op.create_index(
+        op.f("ix_hybrid_search_document_association_participant_api_id"),
+        "hybrid_search_document_association",
+        ["participant_api_id"],
+        unique=False,
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_hybrid_search_document_association_participant_api_id"),
+        table_name="hybrid_search_document_association",
+    )
+    op.drop_index(
+        op.f("ix_hybrid_search_document_association_group_api_id"),
+        table_name="hybrid_search_document_association",
+    )
+    op.drop_index(
+        op.f("ix_hybrid_search_document_association_entity_created_at"),
+        table_name="hybrid_search_document_association",
+    )
+    op.drop_column("hybrid_search_document_association", "entity_created_at")
+    op.drop_column("hybrid_search_document_association", "participant_api_id")
+    op.drop_column("hybrid_search_document_association", "group_api_id")

--- a/ring/db/schema.sql
+++ b/ring/db/schema.sql
@@ -218,8 +218,14 @@ CREATE TABLE public.hybrid_search_document_association (
 	hybrid_search_document_id INT8 NOT NULL,
 	model_api_identifier VARCHAR NOT NULL,
 	model_type VARCHAR NOT NULL,
+	group_api_id VARCHAR NULL,
+	participant_api_id VARCHAR NULL,
+	entity_created_at TIMESTAMPTZ NOT NULL,
 	CONSTRAINT hybrid_search_document_association_pkey PRIMARY KEY (id ASC),
-	UNIQUE INDEX uq_model_api_identifier_model_type (model_api_identifier ASC, model_type ASC)
+	UNIQUE INDEX uq_model_api_identifier_model_type (model_api_identifier ASC, model_type ASC),
+	INDEX ix_hybrid_search_document_association_entity_created_at (entity_created_at ASC),
+	INDEX ix_hybrid_search_document_association_group_api_id (group_api_id ASC),
+	INDEX ix_hybrid_search_document_association_participant_api_id (participant_api_id ASC)
 );
 CREATE TABLE public.documents (
 	id INT8 NOT NULL DEFAULT unique_rowid(),

--- a/ring/letters/crud/letter.py
+++ b/ring/letters/crud/letter.py
@@ -594,5 +594,10 @@ def create_letter_search_document(
     )
     raw_text = f"{letter.group.name} {question_texts} {participant_names}"
     return create_hybrid_search_document(
-        db, raw_text, letter.api_identifier, SearchableType.LETTER
+        db,
+        raw_text,
+        letter.api_identifier,
+        SearchableType.LETTER,
+        entity_created_at=letter.created_at,
+        group_api_id=letter.group.api_identifier,
     )

--- a/ring/letters/crud/question.py
+++ b/ring/letters/crud/question.py
@@ -235,5 +235,10 @@ def create_question_search_document(
     author_name = question.author.name if question.author else ""
     raw_text = f"{question.question_text} {author_name}"
     return create_hybrid_search_document(
-        db, raw_text, question.api_identifier, SearchableType.QUESTION
+        db,
+        raw_text,
+        question.api_identifier,
+        SearchableType.QUESTION,
+        entity_created_at=question.created_at,
+        group_api_id=question.letter.group.api_identifier,
     )

--- a/ring/letters/crud/response.py
+++ b/ring/letters/crud/response.py
@@ -201,7 +201,13 @@ def create_response_search_document(
     """
     raw_text = f"{response.response_text} {response.participant.name}"
     return create_hybrid_search_document(
-        db, raw_text, response.api_identifier, SearchableType.RESPONSE
+        db,
+        raw_text,
+        response.api_identifier,
+        SearchableType.RESPONSE,
+        entity_created_at=response.created_at,
+        group_api_id=response.question.letter.group.api_identifier,
+        participant_api_id=response.participant.api_identifier,
     )
 
 

--- a/ring/parties/crud/group.py
+++ b/ring/parties/crud/group.py
@@ -233,5 +233,10 @@ def create_group_search_document(
     )
     raw_text = f"{group.name} {member_names} {key_values}"
     return create_hybrid_search_document(
-        db, raw_text, group.api_identifier, SearchableType.GROUP
+        db,
+        raw_text,
+        group.api_identifier,
+        SearchableType.GROUP,
+        entity_created_at=group.created_at,
+        group_api_id=group.api_identifier,
     )

--- a/ring/parties/crud/user.py
+++ b/ring/parties/crud/user.py
@@ -103,7 +103,11 @@ def create_user_search_document(
     """
     raw_text = f"{user.name} {user.email}"
     return create_hybrid_search_document(
-        db, raw_text, user.api_identifier, SearchableType.USER
+        db,
+        raw_text,
+        user.api_identifier,
+        SearchableType.USER,
+        entity_created_at=user.created_at,
     )
 
 

--- a/ring/scripts/search/backfill.py
+++ b/ring/scripts/search/backfill.py
@@ -43,6 +43,11 @@ def run_script(
 ) -> None:
     """Backfill search documents for specified types.
 
+    When ``replace_existing`` is True, associations are recreated with filter and
+    sort metadata (``group_api_id``, ``participant_api_id``, ``entity_created_at``)
+    via each type's search registrar. Run with ``dry_run=False`` on production
+    after deploying the search filter migration.
+
     Args:
         searchable_types (list[SearchableType] | None): Types to backfill. If None, backfills all types.
         replace_existing (bool): Whether to replace existing documents

--- a/ring/search/api/search.py
+++ b/ring/search/api/search.py
@@ -18,6 +18,7 @@ from ring.search.crud.hybrid_search import (
 from ring.search.schemas.search import (
     RawSearchResponse,
     RawSearchResult,
+    SearchSort,
     SearchType,
 )
 
@@ -29,6 +30,9 @@ async def raw_search(
     query: str,
     search_type: SearchType = SearchType.KEYWORD,
     limit: int = 10,
+    group_api_id: str | None = None,
+    participant_api_id: str | None = None,
+    sort: SearchSort = SearchSort.RELEVANCE,
     db: Session = Depends(get_db),
 ) -> RawSearchResponse:
     """
@@ -38,6 +42,9 @@ async def raw_search(
         query: The search query string
         search_type: Type of search to perform (semantic, keyword, or dual)
         limit: Maximum number of results to return
+        group_api_id: Optional group filter
+        participant_api_id: Optional responder filter (responses only)
+        sort: Result ordering
         db: Database session
 
     Returns:
@@ -61,7 +68,14 @@ async def raw_search(
         )
 
     search_func = search_functions[search_type]
-    results = search_func(db=db, query=query, limit=limit)
+    results = search_func(
+        db=db,
+        query=query,
+        limit=limit,
+        group_api_id=group_api_id,
+        participant_api_id=participant_api_id,
+        sort=sort,
+    )
 
     return RawSearchResponse(
         results=[RawSearchResult.model_validate(result) for result in results],
@@ -74,6 +88,9 @@ async def perform_search(
     query: str,
     search_type: SearchType = SearchType.KEYWORD,
     limit: int = 10,
+    group_api_id: str | None = None,
+    participant_api_id: str | None = None,
+    sort: SearchSort = SearchSort.RELEVANCE,
     req_dep: AuthenticatedRequestDependencies = Depends(
         get_request_dependencies,
     ),
@@ -84,6 +101,9 @@ async def perform_search(
         user=req_dep.current_user,
         limit=limit,
         search_type=search_type,
+        group_api_id=group_api_id,
+        participant_api_id=participant_api_id,
+        sort=sort,
     )
     return SearchResponse(
         results=[SearchResult.from_model(result) for result in results],

--- a/ring/search/crud/hybrid_search.py
+++ b/ring/search/crud/hybrid_search.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 from functools import wraps
 from typing import Callable
@@ -12,8 +13,8 @@ from llm_service import (
     EmbeddingsApi,
 )
 from loguru import logger
-from sqlalchemy import func, or_, select
-from sqlalchemy.orm import Session
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.orm import Query, Session
 
 from ring.api_identifier.api_identified_model import APIIdentified
 from ring.api_identifier.util import get_models
@@ -27,7 +28,9 @@ from ring.search.models.hybrid_search import (
     HybridSearchDocumentAssociation,
     SearchableType,
 )
-from ring.search.schemas.search import SearchType
+from ring.search.schemas.search import SearchSort, SearchType
+
+SearchHit = tuple[SearchableType, str]
 
 
 @dataclass
@@ -106,6 +109,9 @@ def create_hybrid_search_document(
     raw_text: str,
     model_api_identifier: str,
     model_type: SearchableType,
+    entity_created_at: datetime,
+    group_api_id: str | None = None,
+    participant_api_id: str | None = None,
 ) -> HybridSearchDocument:
     # Embedding/semantic search is deprecated. Documents are indexed for
     # keyword search only (via the computed `text_tsv` column derived from
@@ -117,73 +123,286 @@ def create_hybrid_search_document(
         model_api_identifier=model_api_identifier,
         model_type=model_type.value,
         hybrid_search_document=db_hybrid_search_document,
+        entity_created_at=entity_created_at,
+        group_api_id=group_api_id,
+        participant_api_id=participant_api_id,
     )
     db.add_all([db_hybrid_search_document, association])
     return db_hybrid_search_document
 
 
-def semantic_search_hybrid_search_document(
-    db: Session, query: str, limit: int = 10
-) -> list[HybridSearchDocument]:
-    text_embedding = _generate_text_embedding(query)
-    return (
-        db.query(HybridSearchDocument)
-        .filter(
-            HybridSearchDocument.text_embedding_768.l2_distance(text_embedding)
-            < 0.5
+def _apply_search_filters(
+    query: Query,
+    group_api_id: str | None,
+    participant_api_id: str | None,
+) -> Query:
+    if participant_api_id:
+        query = query.filter(
+            HybridSearchDocumentAssociation.model_type
+            == SearchableType.RESPONSE.value,
+            HybridSearchDocumentAssociation.participant_api_id
+            == participant_api_id,
         )
-        .order_by(
-            HybridSearchDocument.text_embedding_768.l2_distance(text_embedding)
+    if group_api_id:
+        query = query.filter(
+            or_(
+                HybridSearchDocumentAssociation.group_api_id == group_api_id,
+                and_(
+                    HybridSearchDocumentAssociation.model_type
+                    == SearchableType.GROUP.value,
+                    HybridSearchDocumentAssociation.model_api_identifier
+                    == group_api_id,
+                ),
+            )
         )
-        .limit(limit)
-        .all()
+    return query
+
+
+def _apply_search_sort(
+    query: Query,
+    sort: SearchSort,
+    ts_rank: object,
+) -> Query:
+    if sort == SearchSort.CREATED_AT_DESC:
+        return query.order_by(
+            HybridSearchDocumentAssociation.entity_created_at.desc(),
+            ts_rank.desc(),
+        )
+    if sort == SearchSort.CREATED_AT_ASC:
+        return query.order_by(
+            HybridSearchDocumentAssociation.entity_created_at.asc(),
+            ts_rank.desc(),
+        )
+    return query.order_by(ts_rank.desc())
+
+
+def _document_search_base_query(db: Session) -> Query:
+    return db.query(HybridSearchDocument).join(
+        HybridSearchDocumentAssociation,
+        HybridSearchDocumentAssociation.hybrid_search_document_id
+        == HybridSearchDocument.id,
     )
+
+
+def _hits_from_rows(rows: list) -> list[SearchHit]:
+    hits: list[SearchHit] = []
+    for row in rows:
+        association = row[1]
+        hits.append(
+            (
+                SearchableType(association.model_type),
+                association.model_api_identifier,
+            )
+        )
+    return hits
+
+
+def _documents_from_rows(rows: list) -> list[HybridSearchDocument]:
+    documents: list[HybridSearchDocument] = []
+    for row in rows:
+        if isinstance(row, HybridSearchDocument):
+            documents.append(row)
+        else:
+            documents.append(row[0])
+    return documents
 
 
 def keyword_search_hybrid_search_document(
-    db: Session, query: str, limit: int = 10
+    db: Session,
+    query: str,
+    limit: int = 10,
+    group_api_id: str | None = None,
+    participant_api_id: str | None = None,
+    sort: SearchSort = SearchSort.RELEVANCE,
 ) -> list[HybridSearchDocument]:
     tsquery = func.plainto_tsquery("english", query)
-    return (
-        db.query(HybridSearchDocument)
-        .filter(HybridSearchDocument.text_tsv_expr_literal.op("@@")(tsquery))
-        .order_by(
-            func.ts_rank(
-                HybridSearchDocument.text_tsv_expr_literal, tsquery
-            ).desc()
-        )
-        .limit(limit)
-        .all()
+    ts_rank = func.ts_rank(HybridSearchDocument.text_tsv_expr_literal, tsquery)
+    search_query = _document_search_base_query(db).filter(
+        HybridSearchDocument.text_tsv_expr_literal.op("@@")(tsquery)
     )
+    search_query = _apply_search_filters(
+        search_query, group_api_id, participant_api_id
+    )
+    search_query = _apply_search_sort(search_query, sort, ts_rank)
+    rows = search_query.limit(limit).all()
+    return _documents_from_rows(rows)
+
+
+def keyword_search_hits(
+    db: Session,
+    query: str,
+    limit: int = 10,
+    group_api_id: str | None = None,
+    participant_api_id: str | None = None,
+    sort: SearchSort = SearchSort.RELEVANCE,
+) -> list[SearchHit]:
+    tsquery = func.plainto_tsquery("english", query)
+    ts_rank = func.ts_rank(HybridSearchDocument.text_tsv_expr_literal, tsquery)
+    search_query = (
+        _document_search_base_query(db)
+        .add_columns(HybridSearchDocumentAssociation)
+        .filter(HybridSearchDocument.text_tsv_expr_literal.op("@@")(tsquery))
+    )
+    search_query = _apply_search_filters(
+        search_query, group_api_id, participant_api_id
+    )
+    search_query = _apply_search_sort(search_query, sort, ts_rank)
+    rows = search_query.limit(limit).all()
+    return _hits_from_rows(rows)
+
+
+def semantic_search_hybrid_search_document(
+    db: Session,
+    query: str,
+    limit: int = 10,
+    group_api_id: str | None = None,
+    participant_api_id: str | None = None,
+    sort: SearchSort = SearchSort.RELEVANCE,
+) -> list[HybridSearchDocument]:
+    text_embedding = _generate_text_embedding(query)
+    distance = HybridSearchDocument.text_embedding_768.l2_distance(
+        text_embedding
+    )
+    search_query = _document_search_base_query(db).filter(distance < 0.5)
+    search_query = _apply_search_filters(
+        search_query, group_api_id, participant_api_id
+    )
+    if sort == SearchSort.CREATED_AT_DESC:
+        search_query = search_query.order_by(
+            HybridSearchDocumentAssociation.entity_created_at.desc(),
+            distance,
+        )
+    elif sort == SearchSort.CREATED_AT_ASC:
+        search_query = search_query.order_by(
+            HybridSearchDocumentAssociation.entity_created_at.asc(),
+            distance,
+        )
+    else:
+        search_query = search_query.order_by(distance)
+    rows = search_query.limit(limit).all()
+    return _documents_from_rows(rows)
+
+
+def semantic_search_hits(
+    db: Session,
+    query: str,
+    limit: int = 10,
+    group_api_id: str | None = None,
+    participant_api_id: str | None = None,
+    sort: SearchSort = SearchSort.RELEVANCE,
+) -> list[SearchHit]:
+    text_embedding = _generate_text_embedding(query)
+    distance = HybridSearchDocument.text_embedding_768.l2_distance(
+        text_embedding
+    )
+    search_query = (
+        _document_search_base_query(db)
+        .add_columns(HybridSearchDocumentAssociation)
+        .filter(distance < 0.5)
+    )
+    search_query = _apply_search_filters(
+        search_query, group_api_id, participant_api_id
+    )
+    if sort == SearchSort.CREATED_AT_DESC:
+        search_query = search_query.order_by(
+            HybridSearchDocumentAssociation.entity_created_at.desc(),
+            distance,
+        )
+    elif sort == SearchSort.CREATED_AT_ASC:
+        search_query = search_query.order_by(
+            HybridSearchDocumentAssociation.entity_created_at.asc(),
+            distance,
+        )
+    else:
+        search_query = search_query.order_by(distance)
+    rows = search_query.limit(limit).all()
+    return _hits_from_rows(rows)
 
 
 def dual_search_hybrid_search_document(
-    db: Session, query: str, limit: int = 10
+    db: Session,
+    query: str,
+    limit: int = 10,
+    group_api_id: str | None = None,
+    participant_api_id: str | None = None,
+    sort: SearchSort = SearchSort.RELEVANCE,
 ) -> list[HybridSearchDocument]:
     text_embedding = _generate_text_embedding(query)
     tsquery = func.plainto_tsquery("english", query)
-    return (
-        db.query(HybridSearchDocument)
+    distance = HybridSearchDocument.text_embedding_768.l2_distance(
+        text_embedding
+    )
+    ts_rank = func.ts_rank(HybridSearchDocument.text_tsv_expr_literal, tsquery)
+    search_query = _document_search_base_query(db).filter(
+        or_(
+            distance < 0.5,
+            HybridSearchDocument.text_tsv_expr_literal.op("@@")(tsquery),
+        )
+    )
+    search_query = _apply_search_filters(
+        search_query, group_api_id, participant_api_id
+    )
+    if sort == SearchSort.CREATED_AT_DESC:
+        search_query = search_query.order_by(
+            HybridSearchDocumentAssociation.entity_created_at.desc(),
+            distance,
+            ts_rank.desc(),
+        )
+    elif sort == SearchSort.CREATED_AT_ASC:
+        search_query = search_query.order_by(
+            HybridSearchDocumentAssociation.entity_created_at.asc(),
+            distance,
+            ts_rank.desc(),
+        )
+    else:
+        search_query = search_query.order_by(distance, ts_rank.desc())
+    rows = search_query.limit(limit).all()
+    return _documents_from_rows(rows)
+
+
+def dual_search_hits(
+    db: Session,
+    query: str,
+    limit: int = 10,
+    group_api_id: str | None = None,
+    participant_api_id: str | None = None,
+    sort: SearchSort = SearchSort.RELEVANCE,
+) -> list[SearchHit]:
+    text_embedding = _generate_text_embedding(query)
+    tsquery = func.plainto_tsquery("english", query)
+    distance = HybridSearchDocument.text_embedding_768.l2_distance(
+        text_embedding
+    )
+    ts_rank = func.ts_rank(HybridSearchDocument.text_tsv_expr_literal, tsquery)
+    search_query = (
+        _document_search_base_query(db)
+        .add_columns(HybridSearchDocumentAssociation)
         .filter(
             or_(
-                HybridSearchDocument.text_embedding_768.l2_distance(
-                    text_embedding
-                )
-                < 0.5,
+                distance < 0.5,
                 HybridSearchDocument.text_tsv_expr_literal.op("@@")(tsquery),
             )
         )
-        .order_by(
-            HybridSearchDocument.text_embedding_768.l2_distance(
-                text_embedding
-            ),
-            func.ts_rank(
-                HybridSearchDocument.text_tsv_expr_literal, tsquery
-            ).desc(),
-        )
-        .limit(limit)
-        .all()
     )
+    search_query = _apply_search_filters(
+        search_query, group_api_id, participant_api_id
+    )
+    if sort == SearchSort.CREATED_AT_DESC:
+        search_query = search_query.order_by(
+            HybridSearchDocumentAssociation.entity_created_at.desc(),
+            distance,
+            ts_rank.desc(),
+        )
+    elif sort == SearchSort.CREATED_AT_ASC:
+        search_query = search_query.order_by(
+            HybridSearchDocumentAssociation.entity_created_at.asc(),
+            distance,
+            ts_rank.desc(),
+        )
+    else:
+        search_query = search_query.order_by(distance, ts_rank.desc())
+    rows = search_query.limit(limit).all()
+    return _hits_from_rows(rows)
 
 
 def get_model_ids_from_hybrid_search_documents(
@@ -217,33 +436,58 @@ def hydrate_results(
     )
 
 
+def hydrate_ordered_results(
+    db: Session,
+    ordered_hits: list[SearchHit],
+) -> list[APIIdentified]:
+    if not ordered_hits:
+        return []
+
+    ids_by_type: dict[SearchableType, set[str]] = defaultdict(set)
+    for model_type, api_identifier in ordered_hits:
+        ids_by_type[model_type].add(api_identifier)
+
+    models_by_hit: dict[SearchHit, APIIdentified] = {}
+    for model_type, api_identifiers in ids_by_type.items():
+        for model in hydrate_results(db, model_type, list(api_identifiers)):
+            models_by_hit[(model_type, model.api_identifier)] = model
+
+    hydrated_results: list[APIIdentified] = []
+    for hit in ordered_hits:
+        if model := models_by_hit.get(hit):
+            hydrated_results.append(model)
+    return hydrated_results
+
+
 def search(
     db: Session,
     query: str,
     user: User,
     limit: int = 10,
     search_type: SearchType = SearchType.KEYWORD,
+    group_api_id: str | None = None,
+    participant_api_id: str | None = None,
+    sort: SearchSort = SearchSort.RELEVANCE,
 ) -> list[APIIdentified]:
-    # Resolve the search function at call time (rather than via a module-level
-    # dict) so the names stay patchable in tests.
-    search_dispatch: dict[
+    search_hit_dispatch: dict[
         SearchType,
-        Callable[[Session, str, int], list[HybridSearchDocument]],
+        Callable[..., list[SearchHit]],
     ] = {
-        SearchType.SEMANTIC: semantic_search_hybrid_search_document,
-        SearchType.KEYWORD: keyword_search_hybrid_search_document,
-        SearchType.DUAL: dual_search_hybrid_search_document,
+        SearchType.SEMANTIC: semantic_search_hits,
+        SearchType.KEYWORD: keyword_search_hits,
+        SearchType.DUAL: dual_search_hits,
     }
-    search_results = search_dispatch[search_type](db, query, limit)
-    model_ids_by_type = get_model_ids_from_hybrid_search_documents(
-        db, search_results
+    fetch_limit = limit * 3
+    ordered_hits = search_hit_dispatch[search_type](
+        db,
+        query,
+        limit=fetch_limit,
+        group_api_id=group_api_id,
+        participant_api_id=participant_api_id,
+        sort=sort,
     )
-    hydrated_results = []
-    for model_type, model_api_identifiers in model_ids_by_type.items():
-        hydrated_results.extend(
-            hydrate_results(db, model_type, model_api_identifiers)
-        )
-    hydrated_results = filter_to_authorized(
+    hydrated_results = hydrate_ordered_results(db, ordered_hits)
+    authorized_results = filter_to_authorized(
         db, user, Action.READ, hydrated_results
     )
-    return hydrated_results
+    return authorized_results[:limit]

--- a/ring/search/models/hybrid_search.py
+++ b/ring/search/models/hybrid_search.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime
 from enum import Enum
 
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import ForeignKey, UniqueConstraint, literal_column, select
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    UniqueConstraint,
+    literal_column,
+    select,
+)
 from sqlalchemy.dialects.postgresql import TSVECTOR
 from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
 
@@ -33,6 +40,15 @@ class HybridSearchDocumentAssociation(Base):
     )
     model_api_identifier: Mapped[str] = mapped_column(nullable=False)
     model_type: Mapped[str] = mapped_column(nullable=False)
+    group_api_id: Mapped[str | None] = mapped_column(nullable=True, index=True)
+    participant_api_id: Mapped[str | None] = mapped_column(
+        nullable=True, index=True
+    )
+    entity_created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        index=True,
+    )
 
     document: Mapped["HybridSearchDocument"] = relationship(
         back_populates="associations",
@@ -51,10 +67,16 @@ class HybridSearchDocumentAssociation(Base):
         model_api_identifier: str,
         model_type: str,
         hybrid_search_document: HybridSearchDocument,
+        entity_created_at: datetime,
+        group_api_id: str | None = None,
+        participant_api_id: str | None = None,
     ) -> None:
         self.model_api_identifier = model_api_identifier
         self.model_type = model_type
         self.document = hybrid_search_document
+        self.entity_created_at = entity_created_at
+        self.group_api_id = group_api_id
+        self.participant_api_id = participant_api_id
 
     @classmethod
     def create(
@@ -62,11 +84,17 @@ class HybridSearchDocumentAssociation(Base):
         model_api_identifier: str,
         model_type: str,
         hybrid_search_document: HybridSearchDocument,
+        entity_created_at: datetime,
+        group_api_id: str | None = None,
+        participant_api_id: str | None = None,
     ) -> HybridSearchDocumentAssociation:
         association = cls(
             model_api_identifier=model_api_identifier,
             model_type=model_type,
             hybrid_search_document=hybrid_search_document,
+            entity_created_at=entity_created_at,
+            group_api_id=group_api_id,
+            participant_api_id=participant_api_id,
         )
         return association
 

--- a/ring/search/schemas/search.py
+++ b/ring/search/schemas/search.py
@@ -21,3 +21,9 @@ class SearchType(str, Enum):
     SEMANTIC = "semantic"
     KEYWORD = "keyword"
     DUAL = "dual"
+
+
+class SearchSort(str, Enum):
+    RELEVANCE = "relevance"
+    CREATED_AT_DESC = "created_at_desc"
+    CREATED_AT_ASC = "created_at_asc"

--- a/ring/tests/unit/search/api/search_test.py
+++ b/ring/tests/unit/search/api/search_test.py
@@ -7,6 +7,7 @@ It verifies both successful operations and error cases.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
@@ -18,12 +19,19 @@ from ring.search.crud.hybrid_search import (
     HybridSearchDocument,
     HybridSearchDocumentAssociation,
     SearchableType,
+    create_hybrid_search_document,
 )
+from ring.search.schemas.search import SearchSort
+from ring.tests.factories.letters.letter_factory import LetterFactory
+from ring.tests.factories.letters.question_factory import QuestionFactory
+from ring.tests.factories.letters.response_factory import ResponseFactory
 from ring.tests.factories.parties.group_factory import GroupFactory
 from ring.tests.factories.parties.user_factory import UserFactory
 from ring.tests.lib.utils import (
     assert_pydantic_schema_json_dump_equivalent_to_response_dict,
 )
+
+TEST_CREATED_AT = datetime(2024, 6, 1, tzinfo=UTC)
 
 
 class TestSearchAPI:
@@ -66,6 +74,7 @@ class TestSearchAPI:
                 model_api_identifier=f"test_id_{i}",
                 model_type=SearchableType.USER.value,
                 hybrid_search_document=document,
+                entity_created_at=TEST_CREATED_AT,
             )
             db_session.add_all([document, association])
         db_session.commit()
@@ -152,6 +161,7 @@ class TestSearchAPI:
                 model_api_identifier=user.api_identifier,
                 model_type=SearchableType.USER.value,
                 hybrid_search_document=document,
+                entity_created_at=TEST_CREATED_AT,
             )
             db_session.add_all([document, association])
         db_session.commit()
@@ -174,4 +184,67 @@ class TestSearchAPI:
                 total=2,
             ),
             data,
+        )
+
+    def test_hydrated_search_with_group_filter(
+        self,
+        authenticated_client: TestClient,
+        current_user: User,
+        db_session: Session,
+    ) -> None:
+        group_a = GroupFactory.create(
+            admin=current_user, members=[current_user]
+        )
+        group_b = GroupFactory.create(
+            admin=current_user, members=[current_user]
+        )
+        letter_a = LetterFactory.create(group=group_a)
+        letter_b = LetterFactory.create(group=group_b)
+        question_a = QuestionFactory.create(
+            letter=letter_a, question_text="delta question"
+        )
+        QuestionFactory.create(letter=letter_b, question_text="delta question")
+        response_a = ResponseFactory.create(
+            question=question_a,
+            participant=current_user,
+            response_text="delta response",
+        )
+        db_session.commit()
+
+        create_hybrid_search_document(
+            db_session,
+            raw_text="delta response content",
+            model_api_identifier=response_a.api_identifier,
+            model_type=SearchableType.RESPONSE,
+            entity_created_at=response_a.created_at,
+            group_api_id=group_a.api_identifier,
+            participant_api_id=current_user.api_identifier,
+        )
+        create_hybrid_search_document(
+            db_session,
+            raw_text="delta response content",
+            model_api_identifier="rsp_other",
+            model_type=SearchableType.RESPONSE,
+            entity_created_at=TEST_CREATED_AT,
+            group_api_id=group_b.api_identifier,
+            participant_api_id=current_user.api_identifier,
+        )
+        db_session.commit()
+
+        response = authenticated_client.get(
+            "/search/search",
+            params={
+                "query": "delta",
+                "group_api_id": group_a.api_identifier,
+                "sort": SearchSort.CREATED_AT_DESC.value,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["results"][0]["type"] == "ResponseLinked"
+        assert (
+            data["results"][0]["model"]["api_identifier"]
+            == response_a.api_identifier
         )

--- a/ring/tests/unit/search/crud/hybrid_search_test.py
+++ b/ring/tests/unit/search/crud/hybrid_search_test.py
@@ -7,6 +7,7 @@ It verifies both basic operations and edge cases.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 from faker import Faker
@@ -17,7 +18,9 @@ from ring.authz.enforcer import Action
 from ring.search.crud.hybrid_search import (
     create_hybrid_search_document,
     get_model_ids_from_hybrid_search_documents,
+    hydrate_ordered_results,
     hydrate_results,
+    keyword_search_hits,
     register_search_function,
     search,
     semantic_search_hybrid_search_document,
@@ -28,8 +31,14 @@ from ring.search.models.hybrid_search import (
     HybridSearchDocumentAssociation,
     SearchableType,
 )
-from ring.search.schemas.search import SearchType
+from ring.search.schemas.search import SearchSort, SearchType
+from ring.tests.factories.letters.letter_factory import LetterFactory
+from ring.tests.factories.letters.question_factory import QuestionFactory
+from ring.tests.factories.letters.response_factory import ResponseFactory
+from ring.tests.factories.parties.group_factory import GroupFactory
 from ring.tests.factories.parties.user_factory import UserFactory
+
+TEST_CREATED_AT = datetime(2024, 6, 1, tzinfo=UTC)
 
 
 class TestHybridSearchCRUD:
@@ -66,6 +75,7 @@ class TestHybridSearchCRUD:
             raw_text=raw_text,
             model_api_identifier="test_id",
             model_type=SearchableType.USER,
+            entity_created_at=TEST_CREATED_AT,
         )
 
         assert document.raw_text == raw_text
@@ -112,6 +122,7 @@ class TestHybridSearchCRUD:
                 model_api_identifier=f"test_id_{i}",
                 model_type=SearchableType.USER.value,
                 hybrid_search_document=document,
+                entity_created_at=TEST_CREATED_AT,
             )
             db_session.add_all([document, association])
             documents.append(document)
@@ -159,6 +170,7 @@ class TestHybridSearchCRUD:
                 model_api_identifier=f"test_id_{i}",
                 model_type=SearchableType.USER.value,
                 hybrid_search_document=document,
+                entity_created_at=TEST_CREATED_AT,
             )
             db_session.add_all([document, association])
             documents.append(document)
@@ -201,18 +213,14 @@ class TestHybridSearchCRUD:
 
         assert results == models
 
-    @patch("ring.search.crud.hybrid_search.dual_search_hybrid_search_document")
-    @patch(
-        "ring.search.crud.hybrid_search.get_model_ids_from_hybrid_search_documents"
-    )
-    @patch("ring.search.crud.hybrid_search.hydrate_results")
+    @patch("ring.search.crud.hybrid_search.dual_search_hits")
+    @patch("ring.search.crud.hybrid_search.hydrate_ordered_results")
     @patch("ring.search.crud.hybrid_search.filter_to_authorized")
     def test_search(
         self,
         mock_filter_authorized: MagicMock,
         mock_hydrate: MagicMock,
-        mock_get_model_ids: MagicMock,
-        mock_dual_search: MagicMock,
+        mock_dual_search_hits: MagicMock,
         faker: Faker,
         db_session: Session,
     ) -> None:
@@ -227,16 +235,15 @@ class TestHybridSearchCRUD:
         Args:
             mock_filter_authorized (MagicMock): Mock for authorization filtering
             mock_hydrate (MagicMock): Mock for result hydration
-            mock_get_model_ids (MagicMock): Mock for model ID extraction
-            mock_dual_search (MagicMock): Mock for dual search
+            mock_dual_search_hits (MagicMock): Mock for dual search hits
             faker (Faker): Faker instance for generating test data
             db_session (Session): Database session
         """
-        mock_documents = [MagicMock(), MagicMock()]
-        mock_dual_search.return_value = mock_documents
-
-        mock_model_ids = {SearchableType.USER: ["test_id_1", "test_id_2"]}
-        mock_get_model_ids.return_value = mock_model_ids
+        mock_ordered_hits = [
+            (SearchableType.USER, "test_id_1"),
+            (SearchableType.USER, "test_id_2"),
+        ]
+        mock_dual_search_hits.return_value = mock_ordered_hits
 
         mock_hydrated = [MagicMock(), MagicMock()]
         mock_hydrate.return_value = mock_hydrated
@@ -254,9 +261,179 @@ class TestHybridSearchCRUD:
         )
 
         assert results == mock_hydrated
-        mock_dual_search.assert_called_once_with(db_session, "test query", 10)
-        mock_get_model_ids.assert_called_once_with(db_session, mock_documents)
-        mock_hydrate.assert_called_once()
+        mock_dual_search_hits.assert_called_once_with(
+            db_session,
+            "test query",
+            limit=30,
+            group_api_id=None,
+            participant_api_id=None,
+            sort=SearchSort.RELEVANCE,
+        )
+        mock_hydrate.assert_called_once_with(db_session, mock_ordered_hits)
         mock_filter_authorized.assert_called_once_with(
             db_session, user, Action.READ, mock_hydrated
         )
+
+    def test_keyword_search_group_filter(
+        self,
+        db_session: Session,
+        current_user,
+    ) -> None:
+        group_a = GroupFactory.create(
+            admin=current_user, members=[current_user]
+        )
+        group_b = GroupFactory.create(
+            admin=current_user, members=[current_user]
+        )
+        letter_a = LetterFactory.create(group=group_a)
+        letter_b = LetterFactory.create(group=group_b)
+        question_a = QuestionFactory.create(
+            letter=letter_a, question_text="alpha question"
+        )
+        QuestionFactory.create(letter=letter_b, question_text="alpha question")
+        response_a = ResponseFactory.create(
+            question=question_a,
+            participant=current_user,
+            response_text="alpha response",
+        )
+        db_session.commit()
+
+        create_hybrid_search_document(
+            db_session,
+            raw_text="alpha response content",
+            model_api_identifier=response_a.api_identifier,
+            model_type=SearchableType.RESPONSE,
+            entity_created_at=response_a.created_at,
+            group_api_id=group_a.api_identifier,
+            participant_api_id=current_user.api_identifier,
+        )
+        create_hybrid_search_document(
+            db_session,
+            raw_text="alpha response content",
+            model_api_identifier="rsp_other",
+            model_type=SearchableType.RESPONSE,
+            entity_created_at=TEST_CREATED_AT,
+            group_api_id=group_b.api_identifier,
+            participant_api_id=current_user.api_identifier,
+        )
+        db_session.commit()
+
+        hits = keyword_search_hits(
+            db_session,
+            "alpha",
+            group_api_id=group_a.api_identifier,
+        )
+
+        assert len(hits) == 1
+        assert hits[0] == (
+            SearchableType.RESPONSE,
+            response_a.api_identifier,
+        )
+
+    def test_keyword_search_participant_filter(
+        self,
+        db_session: Session,
+        current_user,
+    ) -> None:
+        other_user = UserFactory.create()
+        group = GroupFactory.create(
+            admin=current_user, members=[current_user, other_user]
+        )
+        letter = LetterFactory.create(group=group)
+        question = QuestionFactory.create(
+            letter=letter, question_text="bravo question"
+        )
+        response = ResponseFactory.create(
+            question=question,
+            participant=current_user,
+            response_text="bravo response",
+        )
+        db_session.commit()
+
+        create_hybrid_search_document(
+            db_session,
+            raw_text="bravo response content",
+            model_api_identifier=response.api_identifier,
+            model_type=SearchableType.RESPONSE,
+            entity_created_at=response.created_at,
+            group_api_id=group.api_identifier,
+            participant_api_id=current_user.api_identifier,
+        )
+        create_hybrid_search_document(
+            db_session,
+            raw_text="bravo response content",
+            model_api_identifier="rsp_other",
+            model_type=SearchableType.RESPONSE,
+            entity_created_at=TEST_CREATED_AT,
+            group_api_id=group.api_identifier,
+            participant_api_id=other_user.api_identifier,
+        )
+        db_session.commit()
+
+        hits = keyword_search_hits(
+            db_session,
+            "bravo",
+            participant_api_id=current_user.api_identifier,
+        )
+
+        assert len(hits) == 1
+        assert hits[0] == (
+            SearchableType.RESPONSE,
+            response.api_identifier,
+        )
+
+    def test_keyword_search_created_at_sort(
+        self,
+        db_session: Session,
+    ) -> None:
+        older = datetime(2024, 1, 1, tzinfo=UTC)
+        newer = datetime(2024, 6, 1, tzinfo=UTC)
+        create_hybrid_search_document(
+            db_session,
+            raw_text="charlie older document",
+            model_api_identifier="user_old",
+            model_type=SearchableType.USER,
+            entity_created_at=older,
+        )
+        create_hybrid_search_document(
+            db_session,
+            raw_text="charlie newer document",
+            model_api_identifier="user_new",
+            model_type=SearchableType.USER,
+            entity_created_at=newer,
+        )
+        db_session.commit()
+
+        hits_desc = keyword_search_hits(
+            db_session,
+            "charlie",
+            sort=SearchSort.CREATED_AT_DESC,
+        )
+        hits_asc = keyword_search_hits(
+            db_session,
+            "charlie",
+            sort=SearchSort.CREATED_AT_ASC,
+        )
+
+        assert hits_desc[0][1] == "user_new"
+        assert hits_desc[1][1] == "user_old"
+        assert hits_asc[0][1] == "user_old"
+        assert hits_asc[1][1] == "user_new"
+
+    def test_hydrate_ordered_results_preserves_order(
+        self,
+        db_session: Session,
+    ) -> None:
+        users = [UserFactory.create() for _ in range(2)]
+        db_session.commit()
+        ordered_hits = [
+            (SearchableType.USER, users[1].api_identifier),
+            (SearchableType.USER, users[0].api_identifier),
+        ]
+
+        results = hydrate_ordered_results(db_session, ordered_hits)
+
+        assert [model.api_identifier for model in results] == [
+            users[1].api_identifier,
+            users[0].api_identifier,
+        ]

--- a/ring/tests/unit/search/models/hybrid_search_test.py
+++ b/ring/tests/unit/search/models/hybrid_search_test.py
@@ -7,6 +7,7 @@ It verifies both model attributes and relationships with other models.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from logging import Logger
 
 import sqlalchemy
@@ -18,6 +19,8 @@ from ring.search.models.hybrid_search import (
     HybridSearchDocumentAssociation,
     SearchableType,
 )
+
+TEST_CREATED_AT = datetime(2024, 6, 1, tzinfo=UTC)
 
 
 class TestHybridSearchDocument:
@@ -93,6 +96,7 @@ class TestHybridSearchDocument:
             model_api_identifier="test_id",
             model_type=SearchableType.USER.value,
             hybrid_search_document=document,
+            entity_created_at=TEST_CREATED_AT,
         )
         db_session.add(association)
         db_session.commit()
@@ -136,6 +140,7 @@ class TestHybridSearchDocumentAssociation:
             model_api_identifier="test_id",
             model_type=SearchableType.USER.value,
             hybrid_search_document=document,
+            entity_created_at=TEST_CREATED_AT,
         )
         db_session.add(association)
         db_session.commit()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds server-side search filtering and sorting so users can narrow results by group and responder and order them by relevance or creation time.

### Backend
- New association metadata columns: `group_api_id`, `participant_api_id`, `entity_created_at` (Alembic migration `f36847c5bb55`)
- Search registrars populate metadata at index time
- `/search/search` and `/search/raw-search` accept `group_api_id`, `participant_api_id`, and `sort` (`relevance`, `created_at_desc`, `created_at_asc`)
- Filter/sort applied in SQL before limit; hit order preserved through hydration and auth

### Frontend
- Search page filter bar: group, responder (enabled when group selected), sort
- Regenerated OpenAPI client; result rows show timestamps when sorting by time

### Production deploy notes
After migration, run the search backfill with `replace_existing=True` and `dry_run=False` to refresh association metadata on existing documents.

## Walkthrough

<a href="https://cursor.com/agents/bc-6f1b16e3-3dd3-43c5-8fec-87030d18b79a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_filters_sorting_demo.mp4"><img src="https://cursor.com/artifacts/c/art-17160ca7-4c3a-484b-a51e-2eb37837e7a6" alt="search_filters_sorting_demo.mp4" /></a>
Search page with group, responder, and sort controls.

![Search filter controls](https://cursor.com/artifacts/c/art-4c4efe7c-ed1a-4d4d-a525-54acbbed5d06)
![Sort dropdown options](https://cursor.com/artifacts/c/art-8434b925-8cc1-4275-aded-58080ce7f7f1)

## Testing
- `sudo docker compose -f compose.test.yml --profile test run --rm test-runner pytest -c ring/tests/pytest.ini ring/tests/unit/search/` — 19 passed
- `cd react && pnpm run lint && npx tsc --noEmit`
- Manual browser test on `/search` (login: test@example.com)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f1b16e3-3dd3-43c5-8fec-87030d18b79a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f1b16e3-3dd3-43c5-8fec-87030d18b79a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

