### PR TITLE
Show loading spinner while search API request is in flight

### DIFF
--- a/react/src/routes/_layout/search.tsx
+++ b/react/src/routes/_layout/search.tsx
@@ -23,8 +23,9 @@ export const Route = createFileRoute("/_layout/search")({
 function SearchContent() {
   const [searchQuery, setSearchQuery] = useState("")
   const [hasSearched, setHasSearched] = useState(false)
+  const [isSearching, setIsSearching] = useState(false)
 
-  const { data: searchResults, refetch, isFetching } = useQuery({
+  const { data: searchResults, refetch } = useQuery({
     ...performSearchSearchSearchGetOptions({
       query: {
         query: searchQuery,
@@ -36,7 +37,12 @@ function SearchContent() {
   const handleSearch = async () => {
     if (!searchQuery.trim()) return
     setHasSearched(true)
-    await refetch()
+    setIsSearching(true)
+    try {
+      await refetch()
+    } finally {
+      setIsSearching(false)
+    }
   }
 
   return (
@@ -69,13 +75,13 @@ function SearchContent() {
         </div>
       </div>
 
-      {isFetching && (
+      {isSearching && (
         <div className="flex justify-center p-8">
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
         </div>
       )}
 
-      {hasSearched && !isFetching && searchResults && (
+      {hasSearched && !isSearching && searchResults && (
         <div className="px-4 overflow-auto">
           <Table>
             <TableHeader>

--- a/react/src/routes/_layout/search.tsx
+++ b/react/src/routes/_layout/search.tsx
@@ -22,9 +22,9 @@ export const Route = createFileRoute("/_layout/search")({
 
 function SearchContent() {
   const [searchQuery, setSearchQuery] = useState("")
-  const [isSearching, setIsSearching] = useState(false)
+  const [hasSearched, setHasSearched] = useState(false)
 
-  const { data: searchResults, refetch } = useQuery({
+  const { data: searchResults, refetch, isFetching } = useQuery({
     ...performSearchSearchSearchGetOptions({
       query: {
         query: searchQuery,
@@ -35,7 +35,7 @@ function SearchContent() {
 
   const handleSearch = async () => {
     if (!searchQuery.trim()) return
-    setIsSearching(true)
+    setHasSearched(true)
     await refetch()
   }
 
@@ -69,7 +69,13 @@ function SearchContent() {
         </div>
       </div>
 
-      {isSearching && searchResults && (
+      {isFetching && (
+        <div className="flex justify-center p-8">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {hasSearched && !isFetching && searchResults && (
         <div className="px-4 overflow-auto">
           <Table>
             <TableHeader>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a loading spinner to the search page that displays while the search API request is in progress.

Previously, the search page set `isSearching` to true but never reset it, and results were gated on that flag in a way that prevented proper loading UX. This change:

- Tracks `hasSearched` to know when to show results after a search has been initiated
- Uses explicit `isSearching` state around `refetch()` (with `try`/`finally`) since TanStack Query's `isFetching` does not reliably reflect in-flight requests when the query is disabled
- Renders a centered `Loader2` spinner below the search input while `isSearching` is true
- Shows results only after the request completes (`hasSearched && !isSearching`)

## Demo

![Search loading spinner visible during API request](https://cursor.com/artifacts/c/art-a6993fff-c356-4869-a1f3-9eb0afbabb82)

![Search results after request completes](https://cursor.com/artifacts/c/art-6be96a17-ba79-491d-a685-f294799f456f)

## Testing

- `npx tsc --noEmit` in `react/`
- Playwright capture script with delayed search API route confirms spinner renders during request
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dda8ae36-39d0-438e-96f6-b912950a1175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dda8ae36-39d0-438e-96f6-b912950a1175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

