### PR TITLE
fix(email): preserve newlines with br tags in HTML newsletters

### DIFF
--- a/ring/tasks/crud/send_email_task.py
+++ b/ring/tasks/crud/send_email_task.py
@@ -38,7 +38,10 @@ def _linkify_escaped_text(escaped_text: str) -> str:
 
 def _format_response_body_html(text: str) -> str:
     """Format response body text for HTML email bodies."""
-    return _linkify_escaped_text(html.escape(text))
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    escaped = html.escape(normalized)
+    linkified = _linkify_escaped_text(escaped)
+    return linkified.replace("\n", "<br />")
 
 
 def construct_question_html(
@@ -89,8 +92,8 @@ def construct_response_html(response: tuple[str, list[str]]) -> str:
         else ""
     )
     body_html = (
-        '<p style="margin:0;font-size:15px;line-height:1.5;color:#1a202c;'
-        'white-space:pre-line;">{text}</p>'
+        '<p style="margin:0;font-size:15px;line-height:1.5;color:#1a202c;">'
+        "{text}</p>"
     ).format(text=_format_response_body_html(body))
     image_htmls = "".join(
         [

--- a/ring/tests/unit/tasks/crud/send_email_task_test.py
+++ b/ring/tests/unit/tasks/crud/send_email_task_test.py
@@ -17,11 +17,17 @@ class TestSendEmailTask:
 
         html_body = construct_response_html(response)
 
-        assert "white-space:pre-line" in html_body
-        assert "Line one\nLine two" in html_body
+        assert "Line one<br />Line two" in html_body
         assert "Line one" in html_body
         assert "Line two" in html_body
         assert "Alice" in html_body
+
+    def test_construct_response_html_preserves_crlf_newlines(self) -> None:
+        response = ("Alice: Line one\r\nLine two", [])
+
+        html_body = construct_response_html(response)
+
+        assert "Line one<br />Line two" in html_body
 
     def test_construct_response_html_linkifies_urls(self) -> None:
         response = (
@@ -73,7 +79,7 @@ class TestSendEmailTask:
         html_body = email_draft.message["Body"]["Html"]["Data"]
         text_body = email_draft.message["Body"]["Text"]["Data"]
 
-        assert "white-space:pre-line" in html_body
+        assert "First line<br />Second line" in html_body
         assert "First line" in html_body
         assert "Second line" in html_body
         assert "Dana: First line\nSecond line" in text_body


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes multi-line response text collapsing to a single line in newsletter/issue emails.

The previous approach used `white-space: pre-line` in inline CSS, which many HTML email clients (Gmail, Outlook, etc.) ignore. Response bodies now convert normalized line breaks to `<br />` tags after HTML escaping and URL linkification.

## Changes

- Normalize `\r\n` and `\r` to `\n` before formatting
- Replace newlines with `<br />` in HTML response bodies
- Remove unused `white-space: pre-line` from response paragraph styling
- Update/add unit tests for `\n` and `\r\n` line breaks

## Test plan

- [x] `uv run pytest ring/tests/unit/tasks/crud/send_email_task_test.py` (6 passed)
- [x] `ring check lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ef9e6-1857-7736-a82f-7d05eb164e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ef9e6-1857-7736-a82f-7d05eb164e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

