### PR TITLE
Remove PR approval enforcement

### DIFF
--- a/.github/workflows/pr-approval-check.yml
+++ b/.github/workflows/pr-approval-check.yml
@@ -1,145 +1,22 @@
-name: PR Approval Check
+name: PR Merge Gate Compatibility
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
-  pull_request_review:
-    types: [submitted, dismissed]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
-  group: pr-approval-check-${{ github.event.pull_request.number || github.event.review.pull_request_number }}
+  group: pr-merge-gate-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  pull-requests: read
-  issues: read
 
 jobs:
   check:
     name: Require approval or skip label
     runs-on: ubuntu-latest
-    env:
-      SKIP_LABEL: "URGENT: SKIP PR APPROVAL"
-      # Optional hardening: set to "true" to require that a user with write/admin
-      # permissions applied the skip label (prevents contributors from bypassing).
-      REQUIRE_PRIVILEGED_LABEL_ADDER: "true"
     steps:
-      - name: Check approvals (with skip label)
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // Extract PR number reliably from different event types
-            let pull_number;
-            if (context.payload.pull_request?.number) {
-              pull_number = context.payload.pull_request.number;
-            } else if (context.payload.review?.pull_request?.number) {
-              pull_number = context.payload.review.pull_request.number;
-            } else if (context.payload.review?.pull_request_url) {
-              // Extract from URL: https://api.github.com/repos/owner/repo/pulls/123
-              const match = context.payload.review.pull_request_url.match(/\/pulls\/(\d+)$/);
-              pull_number = match ? parseInt(match[1], 10) : null;
-            } else {
-              core.setFailed("Could not determine PR number from event payload");
-              return;
-            }
-
-            // Always fetch the full PR object via API to ensure labels are populated
-            const prResponse = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pull_number
-            });
-            const pr = prResponse.data;
-
-            if (pr.draft) {
-              core.info("PR is draft; passing.");
-              return;
-            }
-
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const skipLabel = process.env.SKIP_LABEL;
-
-            // Fetch labels separately to ensure they're populated (PR API response may not include labels)
-            const issueResponse = await github.rest.issues.get({
-              owner, repo, issue_number: pull_number
-            });
-            const labels = issueResponse.data.labels || [];
-
-            // 1) If the skip label is present, optionally verify who added it
-            const hasSkip = labels.some(l => l.name === skipLabel);
-
-            if (hasSkip) {
-              core.info(`Skip label "${skipLabel}" present.`);
-
-              if (process.env.REQUIRE_PRIVILEGED_LABEL_ADDER === "true") {
-                // Find the most recent "labeled" event for this label
-                const events = await github.paginate(github.rest.issues.listEvents, {
-                  owner, repo, issue_number: pull_number, per_page: 100
-                });
-                const lastLabelEvent = [...events].reverse().find(e =>
-                  e.event === "labeled" && e.label && e.label.name === skipLabel
-                );
-                if (!lastLabelEvent) {
-                  core.setFailed(`Skip label found, but couldn't verify who applied it.`);
-                  return;
-                }
-                const actor = lastLabelEvent.actor.login;
-                const perm = await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner, repo, username: actor
-                });
-                const level = perm.data.permission; // admin|write|maintain|triage|read
-                if (!["admin","maintain","write"].includes(level)) {
-                  core.setFailed(`Skip label was applied by @${actor} (permission=${level}), not allowed to bypass.`);
-                  return;
-                }
-                core.info(`Skip label applied by @${actor} (permission=${level}); bypass allowed.`);
-              }
-
-              return; // allow bypass
-            }
-
-            // 2) Otherwise, require ≥1 approval (excluding the PR author, and counting the latest state per reviewer)
-            const reviews = await github.paginate(github.rest.pulls.listReviews, {
-              owner, repo, pull_number, per_page: 100
-            });
-
-            // Reduce to each reviewer's latest state (submitted_at)
-            const latestByUser = new Map();
-            for (const r of reviews) {
-              // GitHub sometimes includes outdated/dismissed—latest state wins
-              const key = r.user?.login ?? "unknown";
-              const curr = latestByUser.get(key);
-              if (!curr || new Date(r.submitted_at || r.dismissed_at || 0) > new Date(curr.when || 0)) {
-                latestByUser.set(key, {
-                  state: r.state, // APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED
-                  when: r.submitted_at || r.dismissed_at || null
-                });
-              }
-            }
-
-            // Count approvals excluding PR author and dismissed/overruled states
-            const author = pr.user.login;
-            let approvals = 0;
-            for (const [user, info] of latestByUser.entries()) {
-              if (user === author) continue; // ignore self-approval
-              if (info.state === "APPROVED") approvals += 1;
-            }
-
-            core.info(`Approvals (excluding author): ${approvals}`);
-            if (approvals >= 1) {
-              core.info("Approval requirement satisfied.");
-              return;
-            }
-
-            // Help message if failing
-            const msg = [
-              "❌ PR requires at least one approval OR the label:",
-              `   "${skipLabel}"`,
-              "",
-              "Tips:",
-              "• Ask a teammate to approve the PR, or",
-              `• Add the label "${skipLabel}" for urgent bypass.`,
-            ].join("\n");
-            core.setFailed(msg);
+      # Keep this job name until its required status entry is removed from the
+      # dev branch ruleset. Deleting it first would block every pull request.
+      - name: Allow solo-maintainer pull requests
+        run: echo "PR approval is not required."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove collaborator approval and emergency-label checks from the PR workflow
- preserve the existing required status as a pass-through compatibility job so the `dev` ruleset does not block all PRs
- reduce workflow permissions to read-only repository contents

## Follow-up
After this lands, remove `Require approval or skip label` from the `dev` ruleset's required status checks; the compatibility workflow can then be deleted safely.

## Validation
- `actionlint .github/workflows/pr-approval-check.yml` passes
- `git diff --check dev...HEAD` passes
- this draft PR's required approval status reports success
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c3667ed-9155-4a6b-9e05-5a0d8410bc6a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c3667ed-9155-4a6b-9e05-5a0d8410bc6a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

