### PR TITLE
fix(letters): only push back send date once the deadline arrives

### DIFF
--- a/ring/letters/crud/letter.py
+++ b/ring/letters/crud/letter.py
@@ -541,20 +541,19 @@ def postpend_upcoming_letters_with_session(
     This helper is used by the scheduled postpend job and tests that need to
     provide their own transaction-scoped session.
 
-    Letters below the responder send threshold are deferred instead of marked
-    SENT without an email.
+    Letters below the responder send threshold are left in progress instead of
+    marked SENT without an email, and have their send date deferred once that
+    send date has arrived.
 
     Args:
         db (Session): Database session
         letter_ids (list[int]): IDs of letters to postpend
     """
-    from ring.letters.send_threshold import (
-        defer_letter_send_if_below_threshold,
-    )
+    from ring.letters.send_threshold import hold_letter_for_send_threshold
 
     letters = db.scalars(select(Letter).where(Letter.id.in_(letter_ids))).all()
     for letter in letters:
-        if defer_letter_send_if_below_threshold(db, letter):
+        if hold_letter_for_send_threshold(db, letter):
             continue
         letter.status = LetterStatus.SENT
         create_letter_with_questions(

--- a/ring/letters/send_threshold.py
+++ b/ring/letters/send_threshold.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from numbers import Real
 from typing import TYPE_CHECKING, Any
 
@@ -146,24 +146,23 @@ def letter_responder_count(letter: Letter) -> int:
     return len(letter.responders)
 
 
-def defer_letter_send_if_below_threshold(db: Session, letter: Letter) -> bool:
-    """Defer a letter's send date when the responder threshold is not met.
-
-    Returns:
-        True if the send was deferred, False otherwise.
-    """
-    from ring.letters.crud import letter as letter_crud
-
-    if letter.status != LetterStatus.IN_PROGRESS:
-        return False
-
+def is_below_send_threshold(letter: Letter) -> bool:
+    """Return True when fewer participants responded than required to send."""
     required_responders = minimum_responders_required(letter)
     if required_responders <= 0:
         return False
+    return letter_responder_count(letter) < required_responders
 
-    responder_count = letter_responder_count(letter)
-    if responder_count >= required_responders:
-        return False
+
+def has_send_date_arrived(letter: Letter, now: datetime | None = None) -> bool:
+    """Return True once the letter's send date has been reached."""
+    return letter.send_at <= (now or datetime.now(tz=UTC))
+
+
+def defer_letter_send(db: Session, letter: Letter) -> None:
+    """Push a letter's send date out by the deferral interval."""
+    # Imported here because ring.letters.crud.letter imports this module.
+    from ring.letters.crud import letter as letter_crud
 
     new_send_at = letter.send_at + timedelta(days=LETTER_SEND_DEFERRAL_DAYS)
     logger.info(
@@ -171,9 +170,47 @@ def defer_letter_send_if_below_threshold(db: Session, letter: Letter) -> bool:
             letter.id,
             letter.send_at,
             new_send_at,
-            responder_count,
-            required_responders,
+            letter_responder_count(letter),
+            minimum_responders_required(letter),
         )
     )
     letter_crud.edit_letter(db, letter, send_at=new_send_at)
+
+
+def defer_letter_send_if_below_threshold(db: Session, letter: Letter) -> bool:
+    """Defer a letter's send date when the responder threshold is not met.
+
+    Intended for the send-email task, which runs when the send date arrives.
+
+    Returns:
+        True if the send was deferred, False otherwise.
+    """
+    if letter.status != LetterStatus.IN_PROGRESS:
+        return False
+
+    if not is_below_send_threshold(letter):
+        return False
+
+    defer_letter_send(db, letter)
+    return True
+
+
+def hold_letter_for_send_threshold(db: Session, letter: Letter) -> bool:
+    """Return True when a letter must not be marked SENT yet.
+
+    The poll job collects letters up to a week before their send date, so the
+    send date is only pushed out once the deadline itself has arrived. Before
+    then the letter is left untouched, still open for responses.
+
+    Returns:
+        True if the letter is below its send threshold, False otherwise.
+    """
+    if letter.status != LetterStatus.IN_PROGRESS:
+        return False
+
+    if not is_below_send_threshold(letter):
+        return False
+
+    if has_send_date_arrived(letter):
+        defer_letter_send(db, letter)
     return True

--- a/ring/letters/send_threshold.py
+++ b/ring/letters/send_threshold.py
@@ -159,10 +159,22 @@ def has_send_date_arrived(letter: Letter, now: datetime | None = None) -> bool:
     return letter.send_at <= (now or datetime.now(tz=UTC))
 
 
-def defer_letter_send(db: Session, letter: Letter) -> None:
-    """Push a letter's send date out by the deferral interval."""
+def defer_letter_send(db: Session, letter: Letter) -> bool:
+    """Push a letter's send date out by the deferral interval.
+
+    Idempotent across callers that may both run at the same deadline moment
+    (send-email task and postpend): once ``send_at`` is in the future, further
+    calls are a no-op.
+
+    Returns:
+        True if the send date was deferred, False if it had not yet arrived
+        (or had already been deferred into the future).
+    """
     # Imported here because ring.letters.crud.letter imports this module.
     from ring.letters.crud import letter as letter_crud
+
+    if not has_send_date_arrived(letter):
+        return False
 
     new_send_at = letter.send_at + timedelta(days=LETTER_SEND_DEFERRAL_DAYS)
     logger.info(
@@ -175,6 +187,7 @@ def defer_letter_send(db: Session, letter: Letter) -> None:
         )
     )
     letter_crud.edit_letter(db, letter, send_at=new_send_at)
+    return True
 
 
 def defer_letter_send_if_below_threshold(db: Session, letter: Letter) -> bool:
@@ -191,8 +204,7 @@ def defer_letter_send_if_below_threshold(db: Session, letter: Letter) -> bool:
     if not is_below_send_threshold(letter):
         return False
 
-    defer_letter_send(db, letter)
-    return True
+    return defer_letter_send(db, letter)
 
 
 def hold_letter_for_send_threshold(db: Session, letter: Letter) -> bool:
@@ -200,7 +212,9 @@ def hold_letter_for_send_threshold(db: Session, letter: Letter) -> bool:
 
     The poll job collects letters up to a week before their send date, so the
     send date is only pushed out once the deadline itself has arrived. Before
-    then the letter is left untouched, still open for responses.
+    then the letter is left untouched, still open for responses. Deferral is
+    idempotent via ``defer_letter_send``, so a concurrent send-email task that
+    already pushed ``send_at`` will not stack a second day.
 
     Returns:
         True if the letter is below its send threshold, False otherwise.
@@ -211,6 +225,5 @@ def hold_letter_for_send_threshold(db: Session, letter: Letter) -> bool:
     if not is_below_send_threshold(letter):
         return False
 
-    if has_send_date_arrived(letter):
-        defer_letter_send(db, letter)
+    defer_letter_send(db, letter)
     return True

--- a/ring/tests/unit/letters/crud/postpend_letter_test.py
+++ b/ring/tests/unit/letters/crud/postpend_letter_test.py
@@ -8,7 +8,11 @@ from sqlalchemy.orm import Session
 
 from ring.letters.constants import LetterStatus
 from ring.letters.crud import letter as letter_crud
-from ring.letters.send_threshold import LETTER_SEND_DEFERRAL_DAYS
+from ring.letters.send_threshold import (
+    LETTER_SEND_DEFERRAL_DAYS,
+    defer_letter_send_if_below_threshold,
+    hold_letter_for_send_threshold,
+)
 from ring.tests.factories.letters.letter_factory import LetterFactory
 from ring.tests.factories.letters.question_factory import QuestionFactory
 from ring.tests.factories.letters.response_factory import ResponseFactory
@@ -93,6 +97,32 @@ class TestPostpendLetters:
 
         for _ in range(3):
             self.run_postpend_job(db_session, [letter.id])
+        db_session.refresh(letter)
+
+        assert letter.status == LetterStatus.IN_PROGRESS
+        assert letter.send_at == send_at + timedelta(
+            days=LETTER_SEND_DEFERRAL_DAYS
+        )
+
+    def test_send_email_and_postpend_defer_send_date_once(
+        self, db_session: Session
+    ) -> None:
+        """At deadline, send-email and postpend must not stack two deferrals."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        send_at = datetime.now(tz=UTC) - timedelta(minutes=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        db_session.commit()
+
+        assert defer_letter_send_if_below_threshold(db_session, letter) is True
+        assert hold_letter_for_send_threshold(db_session, letter) is True
         db_session.refresh(letter)
 
         assert letter.status == LetterStatus.IN_PROGRESS

--- a/ring/tests/unit/letters/crud/postpend_letter_test.py
+++ b/ring/tests/unit/letters/crud/postpend_letter_test.py
@@ -33,7 +33,7 @@ class TestPostpendLetters:
         admin = UserFactory.create()
         members = [admin] + [UserFactory.create() for _ in range(3)]
         group = GroupFactory.create(admin=admin, members=members)
-        send_at = datetime.now(tz=UTC) + timedelta(days=1)
+        send_at = datetime.now(tz=UTC) - timedelta(minutes=1)
         letter = LetterFactory.create(
             group=group,
             status=LetterStatus.IN_PROGRESS,
@@ -44,6 +44,55 @@ class TestPostpendLetters:
         db_session.commit()
 
         self.run_postpend_job(db_session, [letter.id])
+        db_session.refresh(letter)
+
+        assert letter.status == LetterStatus.IN_PROGRESS
+        assert letter.send_at == send_at + timedelta(
+            days=LETTER_SEND_DEFERRAL_DAYS
+        )
+
+    def test_postpend_does_not_defer_before_send_date(
+        self, db_session: Session
+    ) -> None:
+        """Leave the send date alone when the deadline has not arrived yet."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        send_at = datetime.now(tz=UTC) + timedelta(days=5)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        db_session.commit()
+
+        self.run_postpend_job(db_session, [letter.id])
+        db_session.refresh(letter)
+
+        assert letter.status == LetterStatus.IN_PROGRESS
+        assert letter.send_at == send_at
+
+    def test_repeated_postpend_polls_defer_send_date_once(
+        self, db_session: Session
+    ) -> None:
+        """Deferring once moves the deadline out of reach of later polls."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        send_at = datetime.now(tz=UTC) - timedelta(minutes=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        db_session.commit()
+
+        for _ in range(3):
+            self.run_postpend_job(db_session, [letter.id])
         db_session.refresh(letter)
 
         assert letter.status == LetterStatus.IN_PROGRESS

--- a/ring/tests/unit/tasks/crud/task_test.py
+++ b/ring/tests/unit/tasks/crud/task_test.py
@@ -33,7 +33,7 @@ class TestTaskCrud:
         admin = UserFactory.create()
         members = [admin] + [UserFactory.create() for _ in range(3)]
         group = GroupFactory.create(admin=admin, members=members)
-        send_at = datetime.now(tz=UTC) + timedelta(days=1)
+        send_at = datetime.now(tz=UTC) - timedelta(minutes=1)
         letter = LetterFactory.create(
             group=group,
             status=LetterStatus.IN_PROGRESS,
@@ -120,7 +120,7 @@ class TestTaskCrud:
         members = [admin] + [UserFactory.create() for _ in range(3)]
         group = GroupFactory.create(admin=admin, members=members)
         group.key_values.set_value(GROUP_SETTING_MIN_RESPONDERS_KEY, 3)
-        send_at = datetime.now(tz=UTC) + timedelta(days=1)
+        send_at = datetime.now(tz=UTC) - timedelta(minutes=1)
         letter = LetterFactory.create(
             group=group,
             status=LetterStatus.IN_PROGRESS,
@@ -198,7 +198,7 @@ class TestTaskCrud:
         members = [admin] + [UserFactory.create() for _ in range(3)]
         group = GroupFactory.create(admin=admin, members=members)
         group.key_values.set_value(GROUP_SETTING_MIN_RESPONDER_RATIO_KEY, 0.75)
-        send_at = datetime.now(tz=UTC) + timedelta(days=1)
+        send_at = datetime.now(tz=UTC) - timedelta(minutes=1)
         letter = LetterFactory.create(
             group=group,
             status=LetterStatus.IN_PROGRESS,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The bug

The responder-threshold pushback could fire up to a week before a letter's deadline, and then repeat on every poll.

`poll_schedule_task` runs once a minute and calls `collect_future_letters(db, curr_time + 7 days)`, so `postpend_upcoming_letters` receives in-progress letters whose `send_at` is up to seven days out. Since PR #260 that job calls `defer_letter_send_if_below_threshold`, which pushes `send_at` forward a day whenever the responder threshold is unmet — with no check that the deadline has actually arrived. Two consequences:

- A letter five days from its deadline with too few responses had its send date pushed immediately.
- Because a deferred letter is still inside the 7-day collection window and still below threshold, the next poll (a minute later) pushed it again. `send_at` walked forward roughly a day per minute until it escaped the window, dragging the 1-day reminder task along with it (`upsert_letter_tasks` re-times it on every `edit_letter`).

This is reachable whenever a group has an in-progress letter and no upcoming letter — `collect_future_letters` filters postpend candidates on `not l.group.upcoming_letters`, which is the state left behind by the letter status toggle in `edit_letter`, or by a group whose next letter was never created.

## The fix

`postpend_upcoming_letters_with_session` now calls `hold_letter_for_send_threshold`, which keeps a below-threshold letter `IN_PROGRESS` (never silently `SENT`) but only touches `send_at` once `has_send_date_arrived` is true. Before the deadline the letter is left completely alone and stays open for responses.

`defer_letter_send` itself is also idempotent: it no-ops unless `has_send_date_arrived` is true. At deadline, `poll_schedule_task` commonly schedules both the pending `SEND_EMAIL` task and `postpend_upcoming_letters` in the same minute; without this guard both paths could each push `send_at` by a day (+2 total).

The send-email task path is unchanged aside from sharing that guarded helper. `send_threshold.py` is split into `is_below_send_threshold`, `has_send_date_arrived`, and `defer_letter_send` so both call sites share the same policy.

Net behavior: the deadline slides by exactly one day per missed deadline, and never earlier than the deadline itself.

## Verification

Reproduced first with the two new tests against the unfixed code (`--tb=line`):

```
postpend_letter_test.py:75: assert datetime(2026, 8, 14, 0, 48, 13) == datetime(2026, 8, 13, 0, 48, 13)
postpend_letter_test.py:99: assert datetime(2026, 8, 11, 0, 47, 14) == (datetime(2026, 8, 8, 0, 47, 14) + timedelta(days=1))
Results (12.89s): 2 failed, 2 passed
```

The first shows a deadline five days out being pushed a day early; the second shows three polls stacking three days of pushback.

With the fix (including review follow-up for double-defer idempotency):

- `postpend_letter_test.py`, `task_test.py`, `send_threshold_test.py`, `letter_test.py` — 59 passed
- `ring test run` (full backend suite) — 294 passed
- `ring check lint` — clean

## Not changed

The 7-day postpend lookahead itself still marks an above-threshold letter `SENT` early when its group has no upcoming letter. That predates the threshold feature and is left alone here, but it is the reason the pushback needs its own deadline check rather than a narrower collection window (narrowing it would race with the send-email task and could leave such a group with no letters at all).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdecb-30f2-7dc3-9e91-1013c0c0fc9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdecb-30f2-7dc3-9e91-1013c0c0fc9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

