### PR TITLE
Add manual GitHub Actions CD for prod deploy

### DIFF
--- a/.cursor/skills/ring-deploy-prod/SKILL.md
+++ b/.cursor/skills/ring-deploy-prod/SKILL.md
@@ -1,15 +1,29 @@
 ---
 name: ring-deploy-prod
-description: Build and ship Ring's production images to public ECR. Use when the user asks to deploy to prod, push prod images, release, or rebuild/publish the frontend, api, or llm images to public.ecr.aws.
+description: Build and ship Ring's production images to public ECR, or roll them out on the EC2 host. Use when the user asks to deploy to prod, push prod images, release, run CD, or rebuild/publish the frontend, api, or llm images to public.ecr.aws.
 ---
 
 # Deploying Ring to prod
 
 Prod runs from images published to the public ECR registry
 `public.ecr.aws/z2k1e8p1/` (`ring-frontend`, `ring-api`, `ring-llm`). Deploying
-means building those images locally, authenticating to ECR, and pushing them.
+means building those images, pushing them, then pulling/restarting Compose on
+the EC2 host.
 
-## One command
+## Preferred: GitHub Actions CD
+
+Trigger **Actions → Deploy Prod → Run workflow**
+([`.github/workflows/deploy_prod.yml`](../../../.github/workflows/deploy_prod.yml)):
+
+1. Build/push images to ECR (`:latest` + `:<git-sha>`).
+2. SSH to EC2 and run `./dev_util/deploy_host.sh --ref <sha>`.
+
+Inputs: `maintenance_mode`, `deploy_host`, `include_llm`, `skip_migrate`.
+
+Required secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `PROD_SSH_HOST`,
+`PROD_SSH_USER`, `PROD_SSH_KEY`. Variables: `PROD_APP_DIR`, `PROD_SSH_PORT`.
+
+## Local one command (push only)
 
 ```bash
 ring deploy prod
@@ -17,8 +31,9 @@ ring deploy prod
 
 This runs, in order:
 
-1. `ring fe build` — build the frontend bundle (`react/dist`) served by nginx.
-2. `compose --profile prod build` — build all prod images, passing
+1. `ring fe build` — build the frontend bundle (`react/dist`) served by nginx
+   (skip with `--skip-fe-build`; the frontend image builds its own dist).
+2. `compose --profile prod build` — build selected prod images, passing
    `VITE_API_URL` / `VITE_MAINTENANCE_MODE` as frontend build args.
 3. `aws ecr-public get-login-password | docker login … public.ecr.aws` —
    authenticate Docker against public ECR (`us-east-1`).
@@ -33,6 +48,22 @@ This runs, in order:
 | `--region` | `us-east-1` | AWS region for the ECR login |
 | `--skip-fe-build` | off | Reuse existing `react/dist`, skip step 1 |
 | `--skip-login` | off | Skip step 3 if already logged in |
+| `-i` / `--image` | all three | Limit which images to build/push |
+| `-t` / `--extra-tag` | none | Also push this tag (e.g. git SHA) |
+
+## Host rollout
+
+On the EC2 host (or via CD SSH):
+
+```bash
+./dev_util/deploy_host.sh
+# or:
+ring deploy host --ref <sha> -i ring-api -i ring-frontend
+```
+
+This syncs git (optional `--ref`), pulls/retags ECR images, copies
+`react/dist` out of `prod-ring-frontend` for nginx's SW/manifest mounts, runs
+`ring db upgrade`, then `compose up -d` + nginx restart.
 
 ## Manual equivalent
 
@@ -52,11 +83,12 @@ Restrict to specific images with `-i`, e.g. `ring docker tp -i ring-api`.
 - AWS CLI configured with credentials that can push to `public.ecr.aws/z2k1e8p1/`.
 - Docker running and able to build `linux/amd64` images (prod compose pins
   `platform: linux/amd64`).
-- A populated `.env` (referenced by the prod compose services).
+- A populated `.env` on the **host** (referenced by the prod compose services).
+  CI only needs a stub `.env` for compose build.
 
 ## Notes
 
-- Pushing publishes `:latest`; there is no per-release version tag today.
+- Pushing always publishes `:latest`; CD also publishes `:<git-sha>`.
 - Set `--maintenance-mode` to ship a frontend that renders the maintenance page.
 - Image/registry names live in `dev_util/docker.py`; the deploy command lives in
   `dev_util/deploy.py`.

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,0 +1,134 @@
+name: Deploy Prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      maintenance_mode:
+        description: Bake VITE_MAINTENANCE_MODE=true into the frontend image
+        type: boolean
+        default: false
+      deploy_host:
+        description: SSH to EC2 and run deploy_host.sh after pushing images
+        type: boolean
+        default: true
+      include_llm:
+        description: Also build and push ring-llm
+        type: boolean
+        default: false
+      skip_migrate:
+        description: Skip ring db upgrade on the host
+        type: boolean
+        default: false
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  push-images:
+    name: Build and push ECR images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      image_args: ${{ steps.images.outputs.args }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set image list
+        id: images
+        run: |
+          args="-i ring-api -i ring-frontend"
+          if [[ "${{ inputs.include_llm }}" == "true" ]]; then
+            args="$args -i ring-llm"
+          fi
+          echo "args=$args" >> "$GITHUB_OUTPUT"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Sync Python deps
+        run: uv sync --frozen --all-extras
+
+      - name: Create stub .env for compose build
+        run: printf 'API_PORT=8001\n' > .env
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Build and push prod images
+        env:
+          VITE_API_URL: https://ring.neilsriv.tech
+        run: |
+          maintenance_flag="--no-maintenance-mode"
+          if [[ "${{ inputs.maintenance_mode }}" == "true" ]]; then
+            maintenance_flag="--maintenance-mode"
+          fi
+          # Frontend image builds its own dist; skip host-side fe build.
+          # shellcheck disable=SC2086
+          uv run ring deploy prod \
+            --skip-fe-build \
+            --skip-login \
+            $maintenance_flag \
+            ${{ steps.images.outputs.args }} \
+            --extra-tag "${GITHUB_SHA}"
+
+  deploy-host:
+    name: Roll out on EC2
+    needs: push-images
+    if: ${{ inputs.deploy_host }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.PROD_SSH_HOST }}
+          username: ${{ secrets.PROD_SSH_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          port: ${{ vars.PROD_SSH_PORT || 22 }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            APP_DIR="${{ vars.PROD_APP_DIR }}"
+            if [[ -z "$APP_DIR" ]]; then
+              APP_DIR="$HOME/ring"
+            fi
+            cd "$APP_DIR"
+
+            # Fetch the SHA that built the images so deploy_host.sh exists/matches.
+            git fetch --prune origin
+            git checkout --detach "${{ github.sha }}"
+            chmod +x ./dev_util/deploy_host.sh
+
+            migrate_flag=""
+            if [[ "${{ inputs.skip_migrate }}" == "true" ]]; then
+              migrate_flag="--skip-migrate"
+            fi
+
+            image_flags="--image ring-api --image ring-frontend"
+            if [[ "${{ inputs.include_llm }}" == "true" ]]; then
+              image_flags="$image_flags --image ring-llm"
+            fi
+
+            # shellcheck disable=SC2086
+            ./dev_util/deploy_host.sh \
+              --skip-git \
+              $migrate_flag \
+              $image_flags

--- a/README.md
+++ b/README.md
@@ -211,12 +211,32 @@ Public** (`public.ecr.aws/z2k1e8p1/`); the database is **CockroachDB Cloud**
 (`ring-db`). See [docs/infrastructure.md](docs/infrastructure.md) for the full
 topology (S3, CloudFront, SES, request flows).
 
-### Build and push images
+### Continuous deploy (GitHub Actions)
+
+Manual CD is available via **Actions → Deploy Prod → Run workflow**
+(`.github/workflows/deploy_prod.yml`). It builds/pushes images to ECR Public,
+then SSHs to the EC2 host and runs `./dev_util/deploy_host.sh`.
+
+Required GitHub **secrets**:
+
+| Secret | Purpose |
+|--------|---------|
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Push to `public.ecr.aws/z2k1e8p1/` |
+| `PROD_SSH_HOST` | EC2 hostname or IP |
+| `PROD_SSH_USER` | SSH user |
+| `PROD_SSH_KEY` | Private key for that user |
+
+Optional repo **variables**: `PROD_APP_DIR` (default `$HOME/ring`),
+`PROD_SSH_PORT` (default `22`).
+
+### Build and push images (local)
 
 Preferred one-shot from a machine with AWS credentials:
 
 ```bash
 ring deploy prod
+# restrict images / add a SHA tag:
+# ring deploy prod -i ring-api -i ring-frontend -t "$(git rev-parse HEAD)"
 ```
 
 Or the manual equivalent:
@@ -227,16 +247,15 @@ VITE_API_URL=https://ring.neilsriv.tech ring compose any --profile prod build
 ring docker tp
 ```
 
-### Deploy
+### Deploy on the host
 
 SSH into the EC2 host, then:
 
 ```bash
 cd ring
-git pull
-./dev_util/prod.sh          # pull ring-api, ring-frontend, ring-llm from ECR
-ring db upgrade
-ring compose any --profile prod up -d
-# may need to restart nginx
-ring compose any --profile prod restart nginx
+./dev_util/deploy_host.sh              # preferred one-shot
+# or: ring deploy host --ref <sha>
 ```
+
+That pulls ECR images, syncs `react/dist` from `prod-ring-frontend` (for the
+nginx SW/manifest mounts), runs `ring db upgrade`, and `compose up -d`.

--- a/dev_util/deploy.py
+++ b/dev_util/deploy.py
@@ -1,18 +1,25 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Any
 
 import click
 
 from dev_util.compose import compose_starter
-from dev_util.dev import dev_command, dev_group, subprocess_run
-from dev_util.docker import push, tag
+from dev_util.dev import ROOT_DIR, dev_command, dev_group, subprocess_run
+from dev_util.docker import (
+    COMPOSE_SERVICE_BY_IMAGE,
+    IMAGE_TAG_NAMES,
+    push,
+    tag,
+)
 from dev_util.frontend import fe_build
 
 DEFAULT_VITE_API_URL = "https://ring.neilsriv.tech"
 DEFAULT_AWS_REGION = "us-east-1"
 ECR_PUBLIC_REGISTRY = "public.ecr.aws"
+DEPLOY_HOST_SCRIPT = Path(ROOT_DIR) / "dev_util" / "deploy_host.sh"
 
 
 @dev_group("deploy")
@@ -36,6 +43,23 @@ def _ecr_public_login(region: str) -> None:
             ECR_PUBLIC_REGISTRY,
         ],
         input=password,
+    )
+
+
+def _build_llm_image() -> None:
+    subprocess_run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            "llm/compose.llm.yml",
+            "-f",
+            "llm/compose.prod.llm.yml",
+            "--profile",
+            "prod",
+            "build",
+            "llm",
+        ]
     )
 
 
@@ -72,6 +96,21 @@ def _ecr_public_login(region: str) -> None:
     default=False,
     help="Skip the public ECR `docker login` step.",
 )
+@click.option(
+    "--image",
+    "-i",
+    type=click.Choice(IMAGE_TAG_NAMES),
+    multiple=True,
+    default=IMAGE_TAG_NAMES,
+    help="Images to build and push (default: all).",
+)
+@click.option(
+    "--extra-tag",
+    "-t",
+    multiple=True,
+    default=(),
+    help="Additional image tag(s) besides :latest (e.g. git SHA).",
+)
 def deploy_prod(
     ctx: click.Context,
     vite_api_url: str,
@@ -79,6 +118,8 @@ def deploy_prod(
     region: str,
     skip_fe_build: bool,
     skip_login: bool,
+    image: tuple[str, ...],
+    extra_tag: tuple[str, ...],
     *args: list[Any],
     **kwargs: dict[Any, Any],
 ) -> None:
@@ -90,7 +131,15 @@ def deploy_prod(
       3. aws ecr-public login -> docker login
       4. ring docker tp (tag + push)
     """
-    if not skip_fe_build:
+    images = list(image) or list(IMAGE_TAG_NAMES)
+    compose_services = [
+        COMPOSE_SERVICE_BY_IMAGE[name]
+        for name in images
+        if name in COMPOSE_SERVICE_BY_IMAGE
+    ]
+    build_llm = "ring-llm" in images
+
+    if not skip_fe_build and "ring-frontend" in images:
         ctx.invoke(fe_build)
 
     build_env = {
@@ -98,10 +147,65 @@ def deploy_prod(
         "VITE_API_URL": vite_api_url,
         "VITE_MAINTENANCE_MODE": "true" if maintenance_mode else "false",
     }
-    subprocess_run(compose_starter("prod") + ["build"], env=build_env)
+    if compose_services:
+        subprocess_run(
+            compose_starter("prod") + ["build", *compose_services],
+            env=build_env,
+        )
+    if build_llm:
+        _build_llm_image()
 
     if not skip_login:
         _ecr_public_login(region)
 
-    ctx.invoke(tag)
-    ctx.invoke(push)
+    ctx.invoke(tag, image=images, extra_tag=extra_tag)
+    ctx.invoke(push, image=images, extra_tag=extra_tag)
+
+
+@dev_command("host", deploy)
+@click.option(
+    "--ref",
+    type=str,
+    default=None,
+    help="Git ref/SHA to check out before rolling out (default: leave as-is).",
+)
+@click.option(
+    "--skip-git/--no-skip-git",
+    default=False,
+    show_default=True,
+    help="Skip git fetch/checkout.",
+)
+@click.option(
+    "--skip-migrate/--no-skip-migrate",
+    default=False,
+    show_default=True,
+    help="Skip `ring db upgrade`.",
+)
+@click.option(
+    "--image",
+    "-i",
+    type=click.Choice(IMAGE_TAG_NAMES),
+    multiple=True,
+    default=("ring-api", "ring-frontend"),
+    help="Images to pull from ECR (default: api + frontend).",
+)
+def deploy_host(
+    ctx: click.Context,
+    ref: str | None,
+    skip_git: bool,
+    skip_migrate: bool,
+    image: tuple[str, ...],
+    *args: list[Any],
+    **kwargs: dict[Any, Any],
+) -> None:
+    """Pull ECR images and roll out Compose on the current host (EC2)."""
+    cmd = ["bash", str(DEPLOY_HOST_SCRIPT)]
+    if ref:
+        cmd.extend(["--ref", ref])
+    if skip_git:
+        cmd.append("--skip-git")
+    if skip_migrate:
+        cmd.append("--skip-migrate")
+    for name in image:
+        cmd.extend(["--image", name])
+    subprocess_run(cmd)

--- a/dev_util/deploy_host.sh
+++ b/dev_util/deploy_host.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Roll out the latest ECR images on the prod EC2 host.
+#
+# Typical usage (from the ring repo checkout on the host):
+#   ./dev_util/deploy_host.sh
+#   ./dev_util/deploy_host.sh --ref abc123 --image ring-api --image ring-frontend
+#
+# Or via the CLI wrapper:
+#   ring deploy host --ref abc123
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ECR_URI_BASE="public.ecr.aws/z2k1e8p1/"
+REF=""
+SKIP_GIT=0
+SKIP_MIGRATE=0
+IMAGES=()
+
+usage() {
+  cat <<'EOF'
+Usage: deploy_host.sh [options]
+
+Options:
+  --ref <git-ref>       Fetch and check out this ref before rolling out
+  --skip-git            Do not run git fetch/checkout
+  --skip-migrate        Do not run `ring db upgrade`
+  --image <name>        Image to pull (repeatable). Default: ring-api ring-frontend
+  -h, --help            Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ref)
+      REF="${2:-}"
+      shift 2
+      ;;
+    --skip-git)
+      SKIP_GIT=1
+      shift
+      ;;
+    --skip-migrate)
+      SKIP_MIGRATE=1
+      shift
+      ;;
+    --image)
+      IMAGES+=("${2:-}")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ${#IMAGES[@]} -eq 0 ]]; then
+  IMAGES=("ring-api" "ring-frontend")
+fi
+
+ring_cmd() {
+  if command -v uv >/dev/null 2>&1; then
+    uv run ring "$@"
+  else
+    ring "$@"
+  fi
+}
+
+if [[ "$SKIP_GIT" -eq 0 ]]; then
+  echo "==> Syncing git checkout"
+  git fetch --prune origin
+  if [[ -n "$REF" ]]; then
+    git checkout --detach "$REF"
+  else
+    # Stay on the current branch tip if one is checked out; otherwise leave HEAD.
+    if branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" && [[ "$branch" != "HEAD" ]]; then
+      git pull --ff-only origin "$branch"
+    fi
+  fi
+fi
+
+echo "==> Pulling images from ECR Public"
+for image in "${IMAGES[@]}"; do
+  remote="${ECR_URI_BASE}${image}:latest"
+  docker pull "$remote"
+  docker tag "$remote" "prod-${image}:latest"
+  docker rmi "$remote" || true
+done
+
+if printf '%s\n' "${IMAGES[@]}" | grep -qx "ring-frontend"; then
+  echo "==> Syncing react/dist from prod-ring-frontend (SW / manifest for nginx)"
+  mkdir -p react/dist
+  cid="$(docker create prod-ring-frontend:latest)"
+  docker cp "${cid}:/usr/share/nginx/html/." react/dist/
+  docker rm "$cid" >/dev/null
+fi
+
+if [[ "$SKIP_MIGRATE" -eq 0 ]]; then
+  echo "==> Running migrations"
+  ring_cmd db upgrade
+fi
+
+echo "==> Starting Compose (prod profile)"
+ring_cmd compose any --profile prod up -d
+ring_cmd compose any --profile prod restart nginx
+
+echo "==> Deploy complete"
+ring_cmd compose any --profile prod ps

--- a/dev_util/docker.py
+++ b/dev_util/docker.py
@@ -12,11 +12,26 @@ IMAGE_TAG_NAMES = [
     "ring-llm",
 ]
 
+# Compose service names for images built via compose.core + compose.prod.
+COMPOSE_SERVICE_BY_IMAGE = {
+    "ring-api": "api",
+    "ring-frontend": "frontend",
+}
+
 
 @dev_group("docker")
 @click.pass_context
 def docker(ctx: click.Context) -> None:
     pass
+
+
+def _ecr_refs(image: str, extra_tags: tuple[str, ...] = ()) -> list[str]:
+    refs = [f"{ECR_URI_BASE}{image}:latest"]
+    for extra in extra_tags:
+        if not extra or extra == "latest":
+            continue
+        refs.append(f"{ECR_URI_BASE}{image}:{extra}")
+    return refs
 
 
 @dev_command("tag", docker)
@@ -27,13 +42,21 @@ def docker(ctx: click.Context) -> None:
     multiple=True,
     default=IMAGE_TAG_NAMES,
 )
-def tag(ctx: click.Context, image: list[str]) -> None:
-    run_cmds = [
-        ["docker", "tag", f"prod-{i}:latest", f"{ECR_URI_BASE}{i}:latest"]
-        for i in image
-    ]
-    for cmd in run_cmds:
-        subprocess_run(cmd)
+@click.option(
+    "--extra-tag",
+    "-t",
+    multiple=True,
+    default=(),
+    help="Additional image tag(s) besides :latest (e.g. git SHA).",
+)
+def tag(
+    ctx: click.Context,
+    image: list[str],
+    extra_tag: tuple[str, ...],
+) -> None:
+    for name in image:
+        for ref in _ecr_refs(name, extra_tag):
+            subprocess_run(["docker", "tag", f"prod-{name}:latest", ref])
 
 
 @dev_command("push", docker)
@@ -44,10 +67,21 @@ def tag(ctx: click.Context, image: list[str]) -> None:
     multiple=True,
     default=IMAGE_TAG_NAMES,
 )
-def push(ctx: click.Context, image: list[str]) -> None:
-    run_cmds = [["docker", "push", f"{ECR_URI_BASE}{i}:latest"] for i in image]
-    for cmd in run_cmds:
-        subprocess_run(cmd)
+@click.option(
+    "--extra-tag",
+    "-t",
+    multiple=True,
+    default=(),
+    help="Additional image tag(s) besides :latest (e.g. git SHA).",
+)
+def push(
+    ctx: click.Context,
+    image: list[str],
+    extra_tag: tuple[str, ...],
+) -> None:
+    for name in image:
+        for ref in _ecr_refs(name, extra_tag):
+            subprocess_run(["docker", "push", ref])
 
 
 @dev_command("tp", docker)
@@ -58,8 +92,17 @@ def push(ctx: click.Context, image: list[str]) -> None:
     multiple=True,
     default=IMAGE_TAG_NAMES,
 )
-def push_and_tag(ctx: click.Context, image: list[str]) -> None:
-    ctx.forward(tag)
-    # ctx.invoke(tag)
-    ctx.forward(push)
-    # ctx.invoke(push)
+@click.option(
+    "--extra-tag",
+    "-t",
+    multiple=True,
+    default=(),
+    help="Additional image tag(s) besides :latest (e.g. git SHA).",
+)
+def push_and_tag(
+    ctx: click.Context,
+    image: list[str],
+    extra_tag: tuple[str, ...],
+) -> None:
+    ctx.invoke(tag, image=image, extra_tag=extra_tag)
+    ctx.invoke(push, image=image, extra_tag=extra_tag)

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -161,6 +161,22 @@ Embedding generation → ring-llm microservice (not AWS Bedrock)
 
 ## Deployment
 
+### GitHub Actions CD
+
+[`.github/workflows/deploy_prod.yml`](../.github/workflows/deploy_prod.yml) runs
+on **workflow_dispatch**:
+
+1. Build/push `ring-api` + `ring-frontend` (optional `ring-llm`) to ECR Public,
+   tagged `:latest` and `:<git-sha>`.
+2. SSH to the EC2 host and run
+   [`dev_util/deploy_host.sh`](../dev_util/deploy_host.sh).
+
+Secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `PROD_SSH_HOST`,
+`PROD_SSH_USER`, `PROD_SSH_KEY`. Variables: `PROD_APP_DIR` (default
+`$HOME/ring`), `PROD_SSH_PORT` (default `22`).
+
+### Manual
+
 Build and push from a dev machine:
 
 ```bash
@@ -174,11 +190,11 @@ On the EC2 host:
 
 ```bash
 cd ring
-git pull
-./dev_util/prod.sh          # pull images from ECR, retag as prod-*
-ring db upgrade
-ring compose any --profile prod up -d
-ring compose any --profile prod restart nginx   # if needed
+./dev_util/deploy_host.sh   # git sync, pull images, migrate, compose up
+# lower-level equivalent:
+# ./dev_util/prod.sh
+# ring db upgrade
+# ring compose any --profile prod up -d
 ```
 
 Compose files: `compose.core.yml` + `compose.prod.yml` (+ `llm/compose.prod.llm.yml` if LLM is enabled).
@@ -208,5 +224,7 @@ Helpful for agents so they do not assume these exist:
 | [compose.prod.yml](../compose.prod.yml) | Prod Compose overrides (images, certbot, Cockroach cert mount) |
 | [prod.nginx.conf](../prod.nginx.conf) | Prod Nginx config (`ring.neilsriv.tech`) |
 | [dev_util/prod.sh](../dev_util/prod.sh) | Pull ECR images on the server |
+| [dev_util/deploy_host.sh](../dev_util/deploy_host.sh) | Full host rollout (git + pull + migrate + up) |
 | [dev_util/docker.py](../dev_util/docker.py) | Tag/push to ECR Public |
+| [.github/workflows/deploy_prod.yml](../.github/workflows/deploy_prod.yml) | Manual CD (build/push + SSH rollout) |
 | [.cursor/cloud-start.sh](../.cursor/cloud-start.sh) | Cursor Cloud Agent VM bootstrap (local Cockroach, not prod) |


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` Deploy Prod workflow that builds/pushes `ring-api` + `ring-frontend` (optional `ring-llm`) to ECR Public with `:latest` and `:<sha>` tags, then SSHs to EC2 for rollout
- Add `dev_util/deploy_host.sh` / `ring deploy host` for git sync, image pull, `react/dist` extract, migrations, and Compose up
- Extend `ring deploy prod` / `ring docker tp` with image selection (`-i`) and extra tags (`-t`); document secrets and usage

## Test plan
- [ ] Add GitHub secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `PROD_SSH_HOST`, `PROD_SSH_USER`, `PROD_SSH_KEY`) and optional vars (`PROD_APP_DIR`, `PROD_SSH_PORT`)
- [ ] Run **Actions → Deploy Prod** with `deploy_host` unchecked and confirm images land in `public.ecr.aws/z2k1e8p1/`
- [ ] Re-run with `deploy_host` checked and confirm EC2 pulls images, migrates, and serves the new build
- [ ] Locally smoke-test `ring deploy prod --help` and `ring deploy host --help`


Made with [Cursor](https://cursor.com)