### PR TITLE
perf(frontend): cut initial JS and post-login waterfalls

### DIFF
--- a/react/nginx.conf
+++ b/react/nginx.conf
@@ -13,6 +13,12 @@ server {
     try_files $uri =404;
   }
 
+  location /assets/images/ {
+    root /usr/share/nginx/html;
+    add_header Cache-Control "no-cache, must-revalidate";
+    try_files $uri =404;
+  }
+
   location /assets/ {
     root /usr/share/nginx/html;
     add_header Cache-Control "public, max-age=31536000, immutable";

--- a/react/nginx.conf
+++ b/react/nginx.conf
@@ -13,6 +13,12 @@ server {
     try_files $uri =404;
   }
 
+  location /assets/ {
+    root /usr/share/nginx/html;
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    try_files $uri =404;
+  }
+
   location / {
     root /usr/share/nginx/html;
     index index.html index.htm;

--- a/react/src/components/Common/SingleUploadImage.tsx
+++ b/react/src/components/Common/SingleUploadImage.tsx
@@ -145,10 +145,15 @@ export function S3Image({
       onClick={() => setLightboxOpen(true)}
       aria-label="View image full screen"
     >
-      <img src={url} alt={alt ?? ""} className={imageClassName} />
+      <img
+        src={url}
+        alt={alt ?? ""}
+        className={imageClassName}
+        loading="lazy"
+      />
     </button>
   ) : (
-    <img src={url} alt={alt ?? ""} className={imageClassName} />
+    <img src={url} alt={alt ?? ""} className={imageClassName} loading="lazy" />
   )
 
   return (

--- a/react/src/components/GroupKeyValues/GroupKeyValuesTable.tsx
+++ b/react/src/components/GroupKeyValues/GroupKeyValuesTable.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import type { AxiosError } from "axios"
-import { useState } from "react"
-import ReactJson from "react-json-view"
+import { Suspense, lazy, useState } from "react"
 import type {
   FullReplaceGroupKeyValuesPartiesGroupGroupApiIdKeyValuePutError,
   GroupKeyValue,
@@ -11,6 +10,8 @@ import {
   readGroupKeyValuesPartiesGroupGroupApiIdKeyValueGetQueryKey,
 } from "../../client/@tanstack/react-query.gen"
 import useCustomToast from "../../hooks/useCustomToast"
+
+const ReactJson = lazy(() => import("react-json-view"))
 
 export function GroupKeyValuesTable({
   keyValues,
@@ -58,17 +59,19 @@ export function GroupKeyValuesTable({
     <div className="w-full flex flex-col gap-4">
       <p>Group Key Values; use this as a fast data store for the group.</p>(
       <div className="border border-gray-200 rounded-md p-4">
-        <ReactJson
-          src={editableData}
-          onEdit={handleEdit}
-          onAdd={handleEdit}
-          onDelete={handleEdit}
-          theme="monokai"
-          enableClipboard={false}
-          displayDataTypes={false}
-          collapsed={false}
-          name={false}
-        />
+        <Suspense fallback={<div>Loading editor...</div>}>
+          <ReactJson
+            src={editableData}
+            onEdit={handleEdit}
+            onAdd={handleEdit}
+            onDelete={handleEdit}
+            theme="monokai"
+            enableClipboard={false}
+            displayDataTypes={false}
+            collapsed={false}
+            name={false}
+          />
+        </Suspense>
       </div>
       )
     </div>

--- a/react/src/components/Question/PublishedQuestion.tsx
+++ b/react/src/components/Question/PublishedQuestion.tsx
@@ -87,6 +87,7 @@ function ResponseBlock({
                   src={`https://du32exnxihxuf.cloudfront.net/${image.s3_url}`}
                   alt={response.participant.name}
                   className="w-full max-h-[300px] object-contain hover:scale-[1.02] transition-all duration-200"
+                  loading="lazy"
                 />
               </div>
             </button>

--- a/react/src/main.tsx
+++ b/react/src/main.tsx
@@ -68,7 +68,14 @@ client.instance.interceptors.response.use(
 )
 /**/
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      refetchOnWindowFocus: true,
+    },
+  },
+})
 
 const router = createRouter({
   routeTree,
@@ -85,7 +92,6 @@ function App() {
   const resp = useQuery({
     ...readUserMePartiesMeGetOptions({}),
     retry: false,
-    refetchInterval: 5000,
     enabled: localStorage.getItem("access_token") !== null,
   })
 

--- a/react/src/routes/_layout.tsx
+++ b/react/src/routes/_layout.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react"
 
 import { useQueryClient } from "@tanstack/react-query"
 import {
+  listDashboardLettersLettersLettersDashboardGetOptions,
   readUserMePartiesMeGetOptions,
   readUserMePartiesMeGetQueryKey,
 } from "../client/@tanstack/react-query.gen"
@@ -21,6 +22,9 @@ export const Route = createFileRoute("/_layout")({
         ...readUserMePartiesMeGetOptions(),
       })
       context.auth.user = user
+      void context.queryClient.prefetchQuery({
+        ...listDashboardLettersLettersLettersDashboardGetOptions(),
+      })
     } catch (error) {
       // If authentication fails, redirect to login with the current path as next parameter
       // Only add next parameter if we're not already on the login page
@@ -54,7 +58,15 @@ function Layout() {
     if (!userApiId) {
       return
     }
-    void subscribeToPush(userApiId)
+    const subscribe = () => {
+      void subscribeToPush(userApiId)
+    }
+    if ("requestIdleCallback" in window) {
+      const idleId = window.requestIdleCallback(subscribe)
+      return () => window.cancelIdleCallback(idleId)
+    }
+    const timeoutId = setTimeout(subscribe, 0)
+    return () => clearTimeout(timeoutId)
   }, [userApiId])
 
   return (

--- a/react/src/routes/_layout/documents/$documentId.tsx
+++ b/react/src/routes/_layout/documents/$documentId.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { Loader2 } from "lucide-react"
-import { Suspense, useRef, useState } from "react"
+import { Suspense, lazy, useRef, useState } from "react"
 import type { DocumentResponse } from "../../../client"
 import {
   getDocumentEndpointNotebookDocumentsDocumentApiIdGetOptions,
@@ -9,11 +9,16 @@ import {
   updateDocumentEndpointNotebookDocumentsDocumentApiIdPutMutation,
 } from "../../../client/@tanstack/react-query.gen"
 import { EditableTitle } from "../../../components/Document/EditableTitle"
-import { CollabEditor } from "../../../components/Document/Editor"
 
 type DocumentLoaderProps = {
   document: DocumentResponse
 }
+
+const CollabEditor = lazy(() =>
+  import("../../../components/Document/Editor").then((module) => ({
+    default: module.CollabEditor,
+  })),
+)
 
 export const Route = createFileRoute("/_layout/documents/$documentId")({
   loader: async ({ params, context }): Promise<DocumentLoaderProps> => {

--- a/react/src/routes/_layout/documents/$documentId.tsx
+++ b/react/src/routes/_layout/documents/$documentId.tsx
@@ -139,20 +139,20 @@ function DocumentContentLoader() {
         </div>
       </div>
       <div className="backdrop-blur-md bg-white/80 border border-white/20 dark:bg-gray-900/80 dark:border-gray-700/50 p-6 rounded-xl shadow-md">
-        <CollabEditor
-          docId={documentId}
-          onSavingChange={handleSavingChange}
-          onEditingChange={setIsEditing}
-        />
+        <Suspense
+          fallback={<Loader2 className="h-8 w-8 animate-spin mx-auto" />}
+        >
+          <CollabEditor
+            docId={documentId}
+            onSavingChange={handleSavingChange}
+            onEditingChange={setIsEditing}
+          />
+        </Suspense>
       </div>
     </div>
   )
 }
 
 function DocumentContent() {
-  return (
-    <Suspense fallback={<Loader2 className="h-8 w-8 animate-spin" />}>
-      <DocumentContentLoader />
-    </Suspense>
-  )
+  return <DocumentContentLoader />
 }

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -109,4 +109,31 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes("node_modules")) {
+            return
+          }
+          if (
+            id.includes("node_modules/@tiptap/") ||
+            id.includes("node_modules/prosemirror-")
+          ) {
+            return "editor-vendor"
+          }
+          if (id.includes("node_modules/react-json-view/")) {
+            return "json-view"
+          }
+          if (
+            id.includes("node_modules/react/") ||
+            id.includes("node_modules/react-dom/") ||
+            id.includes("node_modules/scheduler/")
+          ) {
+            return "react-vendor"
+          }
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Initial page load shipped a monolithic ~1.7MB JS bundle and then polled `/parties/me` every 5s while waiting on a dashboard waterfall. This PR splits heavy vendors, lazy-loads TipTap/json-view, stops aggressive `/me` polling, and prefetches the dashboard after auth.

## Changes

- Remove `/me` `refetchInterval: 5000`; add QueryClient `staleTime: 30s`
- Prefetch dashboard letters in `_layout` `beforeLoad` after `/me`
- Vite `manualChunks` for react, TipTap/ProseMirror, and react-json-view
- Dynamic import TipTap editor and GroupKeyValues json viewer
- `loading="lazy"` on S3/published media images
- Defer push subscribe via `requestIdleCallback` / timeout
- Long-cache hashed `/assets/` in `react/nginx.conf`

## Bundle impact (local `vite build`)

| Chunk | Size (gzip) |
|-------|-------------|
| Main entry | **768 KB → 169 KB gzip** (was 1,735 / 394) |
| editor-vendor | 450 / 120 |
| react-vendor | 201 / 52 |
| json-view | 161 / 38 |

## Validation

- `npx tsc --noEmit` passed
- `npx vite build` passed
- Targeted Biome check passed

## Follow-ups (not in this PR)

- Full `createLazyFileRoute` migration for route-level splitting
- Slim `/me` and dashboard `PublicLetter` payloads (backend API change)
- Lean `GET /groups/` list response
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb2c672c-97a9-4db9-ac71-2215042629f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb2c672c-97a9-4db9-ac71-2215042629f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

