### PR TITLE
perf(ci): speed up pytest runs (~2.5min → ~22s)

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -32,10 +32,14 @@ jobs:
     - name: Docker set-up
       run: |
         docker login ghcr.io -u neil-sriv -p ${{ secrets.GITHUB_TOKEN }}
-        docker pull ghcr.io/neil-sriv/ring/ring-test-runner:latest
+        docker pull ghcr.io/neil-sriv/ring/ring-test-runner:latest &
+        test_runner_pull_pid=$!
+        uv run ring compose any --profile test pull test-cockroach &
+        cockroach_pull_pid=$!
+        wait "$test_runner_pull_pid"
+        wait "$cockroach_pull_pid"
         docker tag ghcr.io/neil-sriv/ring/ring-test-runner:latest ring-test-runner:latest
         docker rmi ghcr.io/neil-sriv/ring/ring-test-runner:latest
-        uv run ring compose any --profile test pull test-cockroach
         docker network create ring-network
 
     - name: Run tests

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -33,6 +33,7 @@ services:
       - sqlalchemy_database_uri=blank
       - cockroach_database_uri=cockroachdb://ringcockroach:ringcockroach@test-cockroach:26257/test
       - environment=test
+      - DISABLE_SCHEDULER=true
       - VAPID_PRIVATE_KEY=private_key
       - LLM_SERVICE_API_KEY=test
     networks:

--- a/dev_util/test.py
+++ b/dev_util/test.py
@@ -55,6 +55,7 @@ def run(
         "pytest",
         "-c",
         "ring/tests/pytest.ini",
+        "--durations=25",
     ]
 
 
@@ -76,6 +77,7 @@ def server(
         "-f",
         "-c",
         "ring/tests/pytest.ini",
+        "--durations=25",
         "--color=yes",
         "--code-highlight=yes",
     ]

--- a/ring/tests/conftest.py
+++ b/ring/tests/conftest.py
@@ -164,27 +164,30 @@ def db_engine(logger: logging.Logger) -> Generator[Engine, None, None]:
         logger.info("Test database cleanup complete")
 
 
-def _patch_factories(logger: logging.Logger, session: Session) -> None:
+@pytest.fixture(scope="session")
+def initialized_factories() -> None:
+    """Hydrate factory registries once for the whole test session."""
+    from ring.tests.factories.entrypoint.initialize import initialize_factories
+
+    initialize_factories()
+
+
+def _patch_factories(session: Session) -> None:
     """Initialize and patch test factories with the current database session.
 
     This helper function ensures all test factories are properly configured
     with the current database session for test data creation.
 
     Args:
-        logger (logging.Logger): Logger instance for tracking factory operations
         session (Session): Current database session
     """
-    from ring.tests.factories.entrypoint.initialize import initialize_factories
-
-    initialize_factories()
-
     for factory in ALL_FACTORIES:
         factory._meta.sqlalchemy_session = session
 
 
 @pytest.fixture(scope="function")
 def db_session(
-    db_engine: Engine, logger: logging.Logger
+    db_engine: Engine, initialized_factories: None, logger: logging.Logger
 ) -> Generator[Session, None, None]:
     """Create a database session for each test function.
 
@@ -203,7 +206,7 @@ def db_session(
     transaction = connection.begin()
     session = Session(bind=connection)
 
-    _patch_factories(logger, session)
+    _patch_factories(session)
 
     yield session
 

--- a/ring/tests/factories/parties/user_factory.py
+++ b/ring/tests/factories/parties/user_factory.py
@@ -8,7 +8,6 @@ from ring.parties.models.user_model import User
 from ring.security import get_password_hash
 from ring.tests.factories.base_factory import BaseFactory, register_factory
 
-
 DEFAULT_PASSWORD_HASH = get_password_hash("password")
 
 

--- a/ring/tests/factories/parties/user_factory.py
+++ b/ring/tests/factories/parties/user_factory.py
@@ -9,6 +9,9 @@ from ring.security import get_password_hash
 from ring.tests.factories.base_factory import BaseFactory, register_factory
 
 
+DEFAULT_PASSWORD_HASH = get_password_hash("password")
+
+
 @register_factory
 class UserFactory(BaseFactory[User]):
     class Meta:
@@ -18,8 +21,10 @@ class UserFactory(BaseFactory[User]):
     def password(
         obj, create: bool, extracted: str | None, **kwargs: Any
     ) -> None:
-        password = extracted or "password"
-        obj.hashed_password = get_password_hash(password)
+        if extracted is None or extracted == "password":
+            obj.hashed_password = DEFAULT_PASSWORD_HASH
+        else:
+            obj.hashed_password = get_password_hash(extracted)
 
     # Sequence avoids unique-constraint flakes on User.email (unique=True).
     email = Sequence(lambda n: f"user-{n}@example.com")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cuts backend CI pytest wall clock sharply by removing avoidable per-test overhead and parallelizing Docker image pulls.

**Measured:** GitHub Actions pytest job went from ~3m23s → **~1m02s** on this PR. Local `ring test run` went from ~2.5min suite time → **~22s** (302 passed).

## Changes

- **Precompute default bcrypt hash** in `UserFactory` so the common `"password"` path skips ~200ms hashing per user
- **`DISABLE_SCHEDULER=true`** in `compose.test.yml` so TestClient lifespan does not start APScheduler
- **Initialize factories once per session** and only rebind SQLAlchemy sessions per test
- **`--durations=25`** on `ring test run` / `ring test server` for ongoing slow-test visibility
- **Parallel Docker pulls** for `ring-test-runner` and Cockroach in GitHub Actions

## Validation

- CI: lint, frontend-lint-build, pytest all green
- Local: `ring test run` → 302 passed in 22.34s

## Follow-ups (not in this PR)

- pytest-xdist + per-worker DBs (invasive; highest remaining ceiling)
- Slim host `uv sync` bootstrap in CI
- Module-scoped `TestClient`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb2c672c-97a9-4db9-ac71-2215042629f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb2c672c-97a9-4db9-ac71-2215042629f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

