### PR TITLE
Add BACKEND_CORS_ORIGIN_REGEX for preview deploy origins

### DIFF
--- a/ring/fastapp/config.py
+++ b/ring/fastapp/config.py
@@ -45,6 +45,8 @@ class RingConfig(BaseSettings):
         BUCKET_NAME (str): S3 bucket name for file storage (default: "rings3files")
         DISABLE_SCHEDULER (bool): Skip APScheduler lifespan start/shutdown
         BACKEND_CORS_ORIGINS (list[AnyUrl] | str): List of allowed CORS origins
+        BACKEND_CORS_ORIGIN_REGEX (str): Regex matched against the Origin header
+            to allow additional origins (e.g. per-PR preview deploys)
     """
 
     environment: str
@@ -62,6 +64,10 @@ class RingConfig(BaseSettings):
         list[AnyUrl] | str,
         BeforeValidator(parse_cors),
     ] = []
+    # Allows wildcard-style origins that can't be enumerated in
+    # BACKEND_CORS_ORIGINS, e.g. Cloudflare Pages / Vercel PR preview URLs:
+    # BACKEND_CORS_ORIGIN_REGEX="^https://[a-z0-9-]+\.ring-cvq\.pages\.dev$"
+    BACKEND_CORS_ORIGIN_REGEX: str = ""
 
 
 @lru_cache

--- a/ring/fastapp/fast.py
+++ b/ring/fastapp/fast.py
@@ -40,13 +40,17 @@ def create_app() -> FastAPI:
 
     init_app_modules()
 
-    if ring_config.BACKEND_CORS_ORIGINS:
+    if (
+        ring_config.BACKEND_CORS_ORIGINS
+        or ring_config.BACKEND_CORS_ORIGIN_REGEX
+    ):
         app.add_middleware(
             CORSMiddleware,
             allow_origins=[
                 str(origin).strip("/")
                 for origin in ring_config.BACKEND_CORS_ORIGINS
             ],
+            allow_origin_regex=ring_config.BACKEND_CORS_ORIGIN_REGEX or None,
             allow_credentials=True,
             allow_methods=["*"],
             allow_headers=["*"],

--- a/ring/tests/unit/fastapp/cors_test.py
+++ b/ring/tests/unit/fastapp/cors_test.py
@@ -1,0 +1,88 @@
+"""Tests for CORS middleware configuration in the app factory.
+
+Preflight OPTIONS requests are answered by Starlette's CORSMiddleware before
+routing, so these tests never touch the database or run the app lifespan.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from ring.fastapp.config import RingConfig
+from ring.fastapp.fast import create_app
+
+PREVIEW_ORIGIN_REGEX = r"^https://[a-z0-9-]+\.ring-cvq\.pages\.dev$"
+
+
+def _build_config(**overrides: str) -> RingConfig:
+    settings: dict[str, str] = {
+        "environment": "test",
+        "sqlalchemy_database_uri": "postgresql://unused:unused@db/unused",
+        "cockroach_database_uri": "cockroachdb://unused:unused@db/unused",
+        "JWT_SIGNING_KEY": "test-signing-key",
+        "JWT_SIGNING_ALGORITHM": "HS256",
+        "VAPID_PRIVATE_KEY": "test-vapid-key",
+        "BACKEND_CORS_ORIGINS": "https://ring.neilsriv.tech",
+        **overrides,
+    }
+    return RingConfig(**settings)
+
+
+def _preflight(client: TestClient, origin: str):
+    return client.options(
+        "/parties/me",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+
+def test_explicit_origin_allowed() -> None:
+    config = _build_config()
+    with patch("ring.fastapp.fast.get_config", return_value=config):
+        client = TestClient(create_app())
+    response = _preflight(client, "https://ring.neilsriv.tech")
+    assert response.status_code == 200
+    assert (
+        response.headers["access-control-allow-origin"]
+        == "https://ring.neilsriv.tech"
+    )
+
+
+def test_origin_regex_allows_preview_origins() -> None:
+    config = _build_config(BACKEND_CORS_ORIGIN_REGEX=PREVIEW_ORIGIN_REGEX)
+    with patch("ring.fastapp.fast.get_config", return_value=config):
+        client = TestClient(create_app())
+    response = _preflight(client, "https://pr-42.ring-cvq.pages.dev")
+    assert response.status_code == 200
+    assert (
+        response.headers["access-control-allow-origin"]
+        == "https://pr-42.ring-cvq.pages.dev"
+    )
+
+
+def test_origin_regex_rejects_unrelated_origins() -> None:
+    config = _build_config(BACKEND_CORS_ORIGIN_REGEX=PREVIEW_ORIGIN_REGEX)
+    with patch("ring.fastapp.fast.get_config", return_value=config):
+        client = TestClient(create_app())
+    response = _preflight(client, "https://evil.example.com")
+    assert response.status_code == 400
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_regex_only_config_enables_cors() -> None:
+    config = _build_config(
+        BACKEND_CORS_ORIGINS="",
+        BACKEND_CORS_ORIGIN_REGEX=PREVIEW_ORIGIN_REGEX,
+    )
+    with patch("ring.fastapp.fast.get_config", return_value=config):
+        client = TestClient(create_app())
+    response = _preflight(client, "https://pr-7.ring-cvq.pages.dev")
+    assert response.status_code == 200
+    assert (
+        response.headers["access-control-allow-origin"]
+        == "https://pr-7.ring-cvq.pages.dev"
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `BACKEND_CORS_ORIGIN_REGEX` setting so the API can allow CORS requests from wildcard-style origins that can't be enumerated in `BACKEND_CORS_ORIGINS` — specifically per-PR preview deployments (e.g. Cloudflare Pages `https://<hash>.<project>.pages.dev`, Vercel preview URLs).

This is the backend prerequisite for hosting the React frontend (and its PR previews) on an external static host while the API stays behind nginx on EC2.

## Changes

- `ring/fastapp/config.py`: new optional `BACKEND_CORS_ORIGIN_REGEX` setting (default `""`, i.e. disabled — no behavior change unless set).
- `ring/fastapp/fast.py`: pass `allow_origin_regex` to Starlette's `CORSMiddleware`; the middleware is now also installed when only the regex is configured.
- `ring/tests/unit/fastapp/cors_test.py`: preflight tests covering explicit origins, regex-matched preview origins, rejected unrelated origins, and regex-only configuration. These run without DB access since `CORSMiddleware` answers preflights before routing.

## Usage

On the server, add to `.env` and recreate the API container:

```
BACKEND_CORS_ORIGIN_REGEX=^https://[a-z0-9-]+\.<project>\.pages\.dev$
```

## Testing

- `ring check lint` passes.
- New unit tests in `ring/tests/unit/fastapp/cors_test.py` (run via `ring test run`).
- Verified live against the dev compose stack: preflight from `https://pr-123.ring-cvq.pages.dev` returns `access-control-allow-origin` echoing the origin; `https://evil.example.com` gets `400 Disallowed CORS origin`; existing explicit origins are unaffected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-525957eb-b333-4dc0-8ffa-a14f28b1f788?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-525957eb-b333-4dc0-8ffa-a14f28b1f788&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

