### PR TITLE
Fix circular vendor chunks that blank every prod build

### DIFF
--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -113,6 +113,14 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks(id) {
+          /* Rollup's CommonJS interop helpers are virtual modules whose ids
+             contain no "node_modules". Left unassigned, Rollup hoisted them
+             into editor-vendor while react-vendor imported them, creating a
+             circular chunk import that evaluated tiptap's use-sync-external-store
+             shim before React initialized — blank page in every prod build. */
+          if (id.includes("commonjsHelpers")) {
+            return "react-vendor"
+          }
           if (!id.includes("node_modules")) {
             return
           }
@@ -128,7 +136,8 @@ export default defineConfig({
           if (
             id.includes("node_modules/react/") ||
             id.includes("node_modules/react-dom/") ||
-            id.includes("node_modules/scheduler/")
+            id.includes("node_modules/scheduler/") ||
+            id.includes("node_modules/use-sync-external-store/")
           ) {
             return "react-vendor"
           }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Prod is currently serving a blank page** — this PR is the fix. Deploying today shipped the first prod frontend build containing the `manualChunks` split from #292, which has a latent circular-chunk bug that crashes React at startup.

## Root cause

Rollup's CommonJS interop helpers are virtual modules whose ids contain no `node_modules`, so the `manualChunks` function left them unassigned. Rollup hoisted them into `editor-vendor`, while `react-vendor` imported them back:

```
editor-vendor  →  react-vendor   (tiptap needs React)
react-vendor   →  editor-vendor  (interop helpers hoisted into the wrong chunk)
```

With that cycle, the browser evaluates `editor-vendor`'s body before `react-vendor` has initialized, and tiptap's `use-sync-external-store` shim reads `undefined.useState`:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'useState')
    at editor-vendor-BTreV3j_.js:36
```

React never mounts → blank page. The same broken bundle is live on `ring.neilsriv.tech` (deployed via `ring deploy prod`) and on the Cloudflare Worker (`ring-frontend.*.workers.dev`).

## Fix

Two additions to `manualChunks` in `react/vite.config.ts`:

- Route the virtual `commonjsHelpers` module into `react-vendor` so no chunk needs to import it from `editor-vendor` (removes the back-edge).
- Route `use-sync-external-store` into `react-vendor` so the React shim always evaluates in the same chunk as React itself.

After the fix, `react-vendor` imports nothing and `editor-vendor` imports only `react-vendor` — acyclic.

## Testing

- Reproduced the blank page + `useState` crash in a real browser against the pre-fix `vite preview` build.
- Rebuilt with the fix, verified chunk headers: `react-vendor` has zero imports, cycle gone.
- Browser-verified in incognito: login page renders on `/` and `/login`, console shows no `useState` error (only expected CORS failures against the prod API, unrelated).

<a href="https://cursor.com/agents/bc-525957eb-b333-4dc0-8ffa-a14f28b1f788/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffixed_build_login_page_renders.mp4"><img src="https://cursor.com/artifacts/c/art-c4a287b5-ef29-4bf2-9f80-0ee065ca27ee" alt="fixed_build_login_page_renders.mp4" /></a>

![Fixed build rendering login page in incognito](https://cursor.com/artifacts/c/art-3770b22b-1ecd-458e-a0fd-0181df22a5f7)

## Deploy

After merge: `ring deploy prod` from `dev`, then pull + restart on EC2. The Cloudflare Worker redeploys itself on the next push to `dev`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-525957eb-b333-4dc0-8ffa-a14f28b1f788?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-525957eb-b333-4dc0-8ffa-a14f28b1f788&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

