### PR TITLE
Retire EC2 frontend serving after Cloudflare cutover

### DIFF
--- a/.cursor/skills/ring-deploy-prod/SKILL.md
+++ b/.cursor/skills/ring-deploy-prod/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: ring-deploy-prod
-description: Build and ship Ring's production images to public ECR. Use when the user asks to deploy to prod, push prod images, release, or rebuild/publish the frontend, api, or llm images to public.ecr.aws.
+description: Build and ship Ring's production backend images to public ECR. Use when the user asks to deploy to prod, push prod images, release, or rebuild/publish the api or llm images to public.ecr.aws. The frontend deploys via Cloudflare, not this flow.
 ---
 
 # Deploying Ring to prod
 
-Prod runs from images published to the public ECR registry
-`public.ecr.aws/z2k1e8p1/` (`ring-frontend`, `ring-api`, `ring-llm`). Deploying
-means building those images locally, authenticating to ECR, and pushing them.
+Prod backend runs from images published to the public ECR registry
+`public.ecr.aws/z2k1e8p1/` (`ring-api`, `ring-llm`). Deploying means
+building those images locally, authenticating to ECR, and pushing them.
+
+**The frontend is NOT deployed this way.** It is served by the Cloudflare
+Worker `ring-frontend`, auto-deployed by Cloudflare Workers Builds on
+every merge to `dev` that touches `react/`. See the "Frontend PR
+previews" section of [docs/infrastructure.md](../../../docs/infrastructure.md)
+and [docs/continuous-deploy-plan.md](../../../docs/continuous-deploy-plan.md).
 
 ## One command
 
@@ -17,29 +23,22 @@ ring deploy prod
 
 This runs, in order:
 
-1. `ring fe build` — build the frontend bundle (`react/dist`) served by nginx.
-2. `compose --profile prod build` — build all prod images, passing
-   `VITE_API_URL` / `VITE_MAINTENANCE_MODE` as frontend build args.
-3. `aws ecr-public get-login-password | docker login … public.ecr.aws` —
+1. `compose --profile prod build` — build the prod backend images.
+2. `aws ecr-public get-login-password | docker login … public.ecr.aws` —
    authenticate Docker against public ECR (`us-east-1`).
-4. `ring docker tp` — tag the `prod-*` images and push them to ECR.
+3. `ring docker tp` — tag the `prod-*` images and push them to ECR.
 
 ### Options
 
 | Flag | Default | Purpose |
 |------|---------|---------|
-| `--vite-api-url` | `https://ring.neilsriv.tech` | `VITE_API_URL` baked into the frontend image |
-| `--maintenance-mode` / `--no-maintenance-mode` | off | `VITE_MAINTENANCE_MODE` build arg |
 | `--region` | `us-east-1` | AWS region for the ECR login |
-| `--skip-fe-build` | off | Reuse existing `react/dist`, skip step 1 |
-| `--skip-login` | off | Skip step 3 if already logged in |
+| `--skip-login` | off | Skip step 2 if already logged in |
 
 ## Manual equivalent
 
 ```bash
-uv run ring fe build
-VITE_API_URL=https://ring.neilsriv.tech VITE_MAINTENANCE_MODE=false \
-  uv run ring compose any --profile prod build
+uv run ring compose any --profile prod build
 aws ecr-public get-login-password --region us-east-1 \
   | docker login --username AWS --password-stdin public.ecr.aws
 uv run ring docker tp
@@ -63,8 +62,11 @@ cd ring
 git checkout dev            # detached HEAD makes `git pull` fail
 git pull origin dev
 ./dev_util/prod.sh
-ring compose any --profile prod up -d --force-recreate
+ring compose any --profile prod up -d --force-recreate --remove-orphans
 ```
+
+`--remove-orphans` clears containers whose services were removed from the
+compose files (e.g. the retired `ring-frontend` container).
 
 The API volume-mounts `./ring` with `--reload`, so the checkout on disk is the
 running Python. Verify with:
@@ -82,10 +84,19 @@ means the host is still on a pre-version image/checkout.
 Do not skip `--force-recreate`: compose keeps the old container when the local
 tag name (`prod-ring-api:latest`) is unchanged.
 
+## Frontend deploys (for reference)
+
+- Merge to `dev` → Cloudflare Workers Builds builds `react/` and deploys
+  the `ring-frontend` Worker (~2 min). No ECR, no EC2 involvement.
+- Maintenance mode: set `VITE_MAINTENANCE_MODE=true` in the Worker's
+  build variables (Settings → Build) and retry the latest build; unset
+  to restore.
+- Rollback: redeploy a previous version from the Worker's Deployments
+  tab in the Cloudflare dashboard.
+
 ## Notes
 
 - Pushing publishes `:latest`; there is no per-release version tag today.
-- Set `--maintenance-mode` to ship a frontend that renders the maintenance page.
 - Image/registry names live in `dev_util/docker.py`; the deploy command lives in
   `dev_util/deploy.py`.
 - Builds bake the current git SHA into image labels (`org.opencontainers.image.revision`)

--- a/README.md
+++ b/README.md
@@ -234,9 +234,13 @@ SSH into the EC2 host, then:
 ```bash
 cd ring
 git pull
-./dev_util/prod.sh          # pull ring-api, ring-frontend, ring-llm from ECR
+./dev_util/prod.sh          # pull ring-api, ring-llm from ECR
 ring db upgrade
-ring compose any --profile prod up -d
+ring compose any --profile prod up -d --remove-orphans
 # may need to restart nginx
 ring compose any --profile prod restart nginx
 ```
+
+The frontend is not deployed from this host — Cloudflare Workers Builds
+deploys it automatically on merges to `dev`
+(see [docs/infrastructure.md](docs/infrastructure.md)).

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -14,7 +14,6 @@ services:
   nginx:
     mem_limit: 300m
     volumes:
-      - ./react/dist:/usr/share/nginx/html:ro
       - ./prod.nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - ./etc/letsencrypt:/etc/letsencrypt:ro
       - ./certbot/www:/var/www/certbot
@@ -27,31 +26,6 @@ services:
     volumes:
       - ./etc/letsencrypt:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot
-
-  frontend:
-    restart: unless-stopped
-    mem_limit: 300m
-    container_name: ring-frontend
-    image: prod-ring-frontend
-    env_file:
-      - ./.env
-    build:
-      context: ./react
-      dockerfile: client.Dockerfile
-      args:
-        VITE_API_URL: ${VITE_API_URL:-https://ring.neilsriv.tech}
-        VITE_MAINTENANCE_MODE: ${VITE_MAINTENANCE_MODE:-false}
-        RING_GIT_SHA: ${RING_GIT_SHA:-}
-        RING_GIT_SHORT_SHA: ${RING_GIT_SHORT_SHA:-}
-        RING_GIT_BRANCH: ${RING_GIT_BRANCH:-}
-        RING_GIT_SUBJECT: ${RING_GIT_SUBJECT:-}
-        RING_GIT_AUTHOR_NAME: ${RING_GIT_AUTHOR_NAME:-}
-        RING_GIT_AUTHOR_EMAIL: ${RING_GIT_AUTHOR_EMAIL:-}
-        RING_GIT_COMMITTED_AT: ${RING_GIT_COMMITTED_AT:-}
-        RING_GIT_DIRTY: ${RING_GIT_DIRTY:-}
-    platform: linux/amd64
-    networks:
-      - default
 
 volumes:
   pgdata:

--- a/dev_util/deploy.py
+++ b/dev_util/deploy.py
@@ -8,9 +8,7 @@ import click
 from dev_util.compose import compose_starter
 from dev_util.dev import dev_command, dev_group, subprocess_run
 from dev_util.docker import push, tag
-from dev_util.frontend import fe_build
 
-DEFAULT_VITE_API_URL = "https://ring.neilsriv.tech"
 DEFAULT_AWS_REGION = "us-east-1"
 ECR_PUBLIC_REGISTRY = "public.ecr.aws"
 
@@ -41,30 +39,11 @@ def _ecr_public_login(region: str) -> None:
 
 @dev_command("prod", deploy)
 @click.option(
-    "--vite-api-url",
-    type=str,
-    default=DEFAULT_VITE_API_URL,
-    show_default=True,
-    help="VITE_API_URL build arg baked into the frontend image.",
-)
-@click.option(
-    "--maintenance-mode/--no-maintenance-mode",
-    default=False,
-    show_default=True,
-    help="VITE_MAINTENANCE_MODE build arg baked into the frontend image.",
-)
-@click.option(
     "--region",
     type=str,
     default=DEFAULT_AWS_REGION,
     show_default=True,
     help="AWS region used for the public ECR login.",
-)
-@click.option(
-    "--skip-fe-build",
-    is_flag=True,
-    default=False,
-    help="Skip the `ring fe build` step (use the existing react/dist).",
 )
 @click.option(
     "--skip-login",
@@ -74,31 +53,21 @@ def _ecr_public_login(region: str) -> None:
 )
 def deploy_prod(
     ctx: click.Context,
-    vite_api_url: str,
-    maintenance_mode: bool,
     region: str,
-    skip_fe_build: bool,
     skip_login: bool,
     *args: list[Any],
     **kwargs: dict[Any, Any],
 ) -> None:
-    """Build, tag, and push the production images to public ECR.
+    """Build, tag, and push the production backend images to public ECR.
 
-    Mirrors the manual prod deploy flow:
-      1. ring fe build
-      2. compose --profile prod build (with VITE_* build args)
-      3. aws ecr-public login -> docker login
-      4. ring docker tp (tag + push)
+    The frontend is deployed by Cloudflare Workers Builds on merges to
+    dev and is not part of this flow.
+
+      1. compose --profile prod build
+      2. aws ecr-public login -> docker login
+      3. ring docker tp (tag + push)
     """
-    if not skip_fe_build:
-        ctx.invoke(fe_build)
-
-    build_env = {
-        **os.environ,
-        "VITE_API_URL": vite_api_url,
-        "VITE_MAINTENANCE_MODE": "true" if maintenance_mode else "false",
-    }
-    subprocess_run(compose_starter("prod") + ["build"], env=build_env)
+    subprocess_run(compose_starter("prod") + ["build"], env=dict(os.environ))
 
     if not skip_login:
         _ecr_public_login(region)

--- a/dev_util/docker.py
+++ b/dev_util/docker.py
@@ -6,8 +6,8 @@ from dev_util.dev import dev_command, dev_group, subprocess_run
 
 ECR_URI_BASE = "public.ecr.aws/z2k1e8p1/"
 
+# ring-frontend is deployed by Cloudflare Workers Builds, not via ECR.
 IMAGE_TAG_NAMES = [
-    "ring-frontend",
     "ring-api",
     "ring-llm",
 ]

--- a/dev_util/prod.sh
+++ b/dev_util/prod.sh
@@ -6,7 +6,9 @@ if [[ ! -x "$PYTHON" ]]; then
     PYTHON="${PYTHON3:-python3}"
 fi
 
-declare -a images=("ring-api" "ring-frontend" "ring-llm")
+# ring-frontend is served by Cloudflare Workers (auto-deployed on dev
+# merges), not from an image on this host.
+declare -a images=("ring-api" "ring-llm")
 
 for i in "${images[@]}"
 do
@@ -18,5 +20,5 @@ done
 # Snapshot pulled image identity for GET /version. Compose up refreshes
 # this with running container ids after --force-recreate.
 "$PYTHON" "${ROOT}/dev_util/runtime_version.py" write \
-    --images prod-ring-api,prod-ring-frontend,prod-ring-llm \
+    --images prod-ring-api,prod-ring-llm \
     || true

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -11,9 +11,19 @@ For local development topology, see the Architecture table in
 
 ## Production topology
 
-Prod is **Docker Compose on one EC2 instance**. Nginx terminates TLS and
-reverse-proxies to the API; the React app is served as static files from the
-same host.
+The **frontend is served by Cloudflare** (Worker `ring-frontend`, static
+assets, auto-deployed on merges to `dev`). The **API runs on one EC2
+instance** behind nginx via Docker Compose. The zone is proxied through
+Cloudflare; Workers Routes split traffic by path:
+
+| Route | Destination |
+|-------|-------------|
+| `ring.neilsriv.tech/api/*` | passthrough → EC2 nginx → `ring-api` |
+| `ring.neilsriv.tech/.well-known/*` | passthrough → EC2 nginx (certbot webroot) |
+| `ring.neilsriv.tech/*` | Worker `ring-frontend` (static assets) |
+
+Never attach the domain to the Worker as a custom domain — that swallows
+`/api/*` (it briefly took prod down on 2026-08-11).
 
 ```mermaid
 flowchart TB
@@ -21,10 +31,14 @@ flowchart TB
         Browser[Browser / PWA]
     end
 
-    subgraph EC2["EC2 (ring.neilsriv.tech)"]
+    subgraph CFEdge["Cloudflare (proxied zone)"]
+        Routes[Workers Routes]
+        FE[ring-frontend Worker static assets]
+    end
+
+    subgraph EC2["EC2 (origin)"]
         Nginx[Nginx + Let's Encrypt]
         API[ring-api FastAPI]
-        FE[ring-frontend static]
         LLM[ring-llm optional]
     end
 
@@ -37,11 +51,11 @@ flowchart TB
 
     subgraph External["Outside AWS"]
         CRDB[CockroachDB Cloud ring-db]
-        DNS[DNS registrar]
     end
 
-    Browser --> DNS --> Nginx
-    Nginx --> FE
+    Browser --> Routes
+    Routes -->|"/*"| FE
+    Routes -->|"/api/* and /.well-known/*"| Nginx
     Nginx --> API
     API --> CRDB
     API --> S3
@@ -49,18 +63,19 @@ flowchart TB
     API --> LLM
     Browser --> CF
     CF --> S3
-    ECR -. pull images .-> EC2
+    ECR -. pull backend images .-> EC2
 ```
 
 | Layer | What runs | Where |
 |-------|-----------|-------|
-| Compute | `ring-api`, `ring-frontend`, Nginx, optional `ring-llm` | EC2 `t2.micro`, Compose (`compose.prod.yml`) |
+| Frontend | Vite static build | Cloudflare Worker `ring-frontend` (Workers Builds, deploys on `dev` merges; PR branches get preview URLs) |
+| Compute | `ring-api`, Nginx (API only), optional `ring-llm` | EC2 `t2.micro`, Compose (`compose.prod.yml`) |
 | Database | CockroachDB | **CockroachDB Cloud** — cluster `ring-db` (GCP `us-east1`). Staging: `ring-db-staging`. |
 | Object storage | User-uploaded response images/videos | S3 bucket `rings3files` (`us-east-1`) |
 | CDN | Public URLs for uploaded media | CloudFront `du32exnxihxuf.cloudfront.net` → S3 origin |
 | Email | Invites, auth, letter notifications | SES (`us-east-1`), domain `neilsriv.tech`, sender `ring@neilsriv.tech` |
-| Container images | Prod Docker images | ECR Public `public.ecr.aws/z2k1e8p1/` |
-| DNS / TLS | `ring.neilsriv.tech` | DNS at registrar (not Route 53). TLS via Let's Encrypt + certbot on the EC2 host. |
+| Container images | Prod backend Docker images | ECR Public `public.ecr.aws/z2k1e8p1/` |
+| DNS / TLS | `ring.neilsriv.tech` | DNS proxied through Cloudflare (edge TLS at Cloudflare; origin TLS via Let's Encrypt + certbot on EC2). |
 
 ---
 
@@ -70,7 +85,7 @@ flowchart TB
 |---------|-----------|------------|
 | Database | CockroachDB in Docker (`compose.dev.yml`) | CockroachDB Cloud (`COCKROACH_DATABASE_URI` in `.env` on server) |
 | API URL | `https://localhost/api/v1/` | `https://ring.neilsriv.tech/api/v1/` |
-| Frontend | Vite dev server `:5173` | Static build behind Nginx on EC2 |
+| Frontend | Vite dev server `:5173` | Cloudflare Worker `ring-frontend` (static assets) |
 | S3 / CloudFront | Same AWS resources (boto3 uses instance/profile creds locally if configured) | EC2 IAM role |
 | LLM | Optional Compose service (`llm/`) | Optional `ring-llm` container from ECR |
 | TLS | Self-signed local certs (`ring setup local-ssl`) | Let's Encrypt (`compose.prod.yml` certbot profile) |
@@ -131,10 +146,16 @@ migrations against the cloud URI.
 
 ## Request flows
 
+### Frontend
+
+```
+Browser → ring.neilsriv.tech (Cloudflare Workers route /*) → ring-frontend Worker static assets
+```
+
 ### Normal API traffic
 
 ```
-Browser → ring.neilsriv.tech (Nginx) → ring-api:8001 → CockroachDB Cloud
+Browser → ring.neilsriv.tech/api/v1/* (Workers route: passthrough) → Nginx → ring-api:8001 → CockroachDB Cloud
 ```
 
 ### Image upload
@@ -161,12 +182,17 @@ Embedding generation → ring-llm microservice (not AWS Bedrock)
 
 ## Deployment
 
-Build and push from a dev machine:
+**Frontend:** merge to `dev`. Cloudflare Workers Builds builds `react/`
+and deploys the `ring-frontend` Worker automatically (~2 min). PR
+branches get preview URLs (section below). Rollback: redeploy a previous
+version from the Worker's Deployments tab.
+
+**Backend:** build and push from a dev machine:
 
 ```bash
 ring deploy prod
 # or manually:
-# VITE_API_URL=https://ring.neilsriv.tech ring compose any --profile prod build
+# ring compose any --profile prod build
 # ring docker tp   # tag + push to ECR Public
 ```
 
@@ -180,8 +206,11 @@ git checkout dev
 git pull origin dev
 ./dev_util/prod.sh          # pull images from ECR, retag as prod-*
 ring db upgrade             # only if this commit has a migration
-ring compose any --profile prod up -d --force-recreate
+ring compose any --profile prod up -d --force-recreate --remove-orphans
 ```
+
+(`--remove-orphans` clears containers whose services were removed, e.g.
+the retired `ring-frontend` container after the Cloudflare cutover.)
 
 Confirm what is actually running (no auth):
 
@@ -205,9 +234,9 @@ Cloudflare's 2026 dashboard is **Workers-first**. The create flow is
 "Connect to Git / Build output directory" form. Use Workers Builds.
 
 The React app is built on every PR and served at a `*.workers.dev`
-preview URL, pointed at the **production API** over CORS. Production
-traffic still serves the static build from nginx on EC2 (see topology
-above). Cloudflare is previews-only unless/until we cut prod over.
+preview URL, pointed at the **production API** over CORS. Merges to
+`dev` deploy the same Worker as the **production frontend** behind the
+`ring.neilsriv.tech/*` Workers route (see topology above).
 
 ### How it fits together
 

--- a/prod.nginx.conf
+++ b/prod.nginx.conf
@@ -1,22 +1,11 @@
+## Prod nginx serves the API only. The frontend is served by the
+## Cloudflare Worker `ring-frontend`; zone Workers Routes send
+## ring.neilsriv.tech/* to the Worker and pass /api/* and
+## /.well-known/* through to this origin.
+
 server {
     listen 80;
-    # server_name http://34.203.31.64;
-    # server_name http://ec2-54-221-74-168.compute-1.amazonaws.com;
     server_name ring.neilsriv.tech www.ring.neilsriv.tech;
-
-    location /serviceWorker.js {
-        include mime.types;
-        alias /usr/share/nginx/html/serviceWorker.js;
-    }
-
-    location /manifest.webmanifest {
-        include mime.types;
-        types {
-            application/manifest+json  webmanifest;
-        }
-
-        alias /usr/share/nginx/html/manifest.webmanifest;
-    }
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
@@ -36,18 +25,8 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $remote_addr;
 
-    location /serviceWorker.js {
-        include mime.types;
-        alias /usr/share/nginx/html/serviceWorker.js;
-    }
-
-    location /manifest.webmanifest {
-        include mime.types;
-        types {
-            application/manifest+json  webmanifest;
-        }
-
-        alias /usr/share/nginx/html/manifest.webmanifest;
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
     }
 
     location ^~ /api/v1/ws/ {
@@ -83,7 +62,9 @@ server {
         return 404;
     }
 
+    # Frontend paths never reach this origin (Workers route); anything
+    # that does fall through has no content here.
     location / {
-        proxy_pass http://ring-frontend:80/;
+        return 404;
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 1 cleanup from `docs/continuous-deploy-plan.md` (#301): the production frontend is now served by the Cloudflare Worker `ring-frontend` via zone Workers Routes (cut over and verified 2026-08-11), so the EC2 side stops building, shipping, and serving it.

**Merge timing:** hold until you're done soaking the cutover. While this PR is unmerged, nginx keeps serving the old frontend underneath as an instant fallback (rollback = delete the `/*` Workers route). Merging + deploying this makes the Worker the only frontend.

## Changes

- `compose.prod.yml`: remove the `frontend` service and nginx's `react/dist` mount (frees ~300MB of the t2.micro's RAM budget).
- `prod.nginx.conf`: remove the `location /` frontend proxy and the `serviceWorker.js` / `manifest.webmanifest` aliases (those paths route to the Worker now); `location /` returns 404. Adds the acme-challenge webroot location to the **443** server too, which removes the "https `.well-known` serves app HTML" oddity documented in the plan.
- `dev_util/prod.sh`: pull only `ring-api` / `ring-llm`; version snapshot drops the frontend image.
- `dev_util/docker.py`: `ring docker tag|push|tp` default to `ring-api` / `ring-llm`.
- `dev_util/deploy.py`: `ring deploy prod` no longer runs `ring fe build` or passes `VITE_*` build args; drops `--vite-api-url`, `--maintenance-mode`, `--skip-fe-build`.
- `.cursor/skills/ring-deploy-prod/SKILL.md`, `README.md`, `docs/infrastructure.md`: topology (mermaid + tables), deploy flows, and the Workers Routes table; maintenance mode now toggles via the Worker's `VITE_MAINTENANCE_MODE` build variable.

## Deploy note (on EC2, after merge)

```bash
git pull origin dev
./dev_util/prod.sh
ring compose any --profile prod up -d --force-recreate --remove-orphans
```

`--remove-orphans` removes the now-orphaned `ring-frontend` container. The `prod-ring-frontend` image can be `docker rmi`'d afterwards.

## Testing

- `ring check lint` passes; `bash -n dev_util/prod.sh` OK; `ring deploy prod --help` renders the new interface.
- `nginx -t` passes on the new `prod.nginx.conf` (validated in the `nginx:latest` container with dummy certs and a stub `ring-api` host).
- `docker compose -f compose.core.yml -f compose.prod.yml --profile prod config` is valid; prod profile services are now exactly `api` and `nginx`.
- No backend (`ring/`) code changed, so the Python test suite is unaffected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-525957eb-b333-4dc0-8ffa-a14f28b1f788?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-525957eb-b333-4dc0-8ffa-a14f28b1f788&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

