### PR TITLE
Publish SHA-tagged ring-api images from CI

### DIFF
--- a/.cursor/skills/ring-deploy-prod/SKILL.md
+++ b/.cursor/skills/ring-deploy-prod/SKILL.md
@@ -1,92 +1,64 @@
 ---
 name: ring-deploy-prod
-description: Build and ship Ring's production images to public ECR. Use when the user asks to deploy to prod, push prod images, release, or rebuild/publish the frontend, api, or llm images to public.ecr.aws.
+description: Build and ship Ring's production API image to public ECR, or pull a SHA-tagged image on the EC2 host. Use when the user asks to deploy to prod, push the API image, release, publish ring-api, or roll back a backend deploy.
 ---
 
 # Deploying Ring to prod
 
-Prod runs from images published to the public ECR registry
-`public.ecr.aws/z2k1e8p1/` (`ring-frontend`, `ring-api`, `ring-llm`). Deploying
-means building those images locally, authenticating to ECR, and pushing them.
+Frontend prod is Cloudflare Workers Builds + Workers Routes (see
+[docs/infrastructure.md](../../../docs/infrastructure.md) and PR #301).
+Backend images live in `public.ecr.aws/z2k1e8p1/ring-api`. `ring-llm` is
+manual and currently inactive. Do not build `ring-frontend` unless rolling
+the SPA back onto nginx.
 
-## One command
+## Preferred: CI publish
+
+Pushes to `dev` that touch `ring/**` (or **Actions → Publish ring-api**)
+run [`.github/workflows/publish_api.yml`](../../../.github/workflows/publish_api.yml):
+
+1. Build `linux/amd64` from `ring/ring.Dockerfile` with registry layer cache.
+2. Push `:latest` and `:<git-sha>`.
+
+This does **not** restart EC2. Host pull is still manual (Phase 3 of the
+CD plan).
+
+Requires GitHub secrets `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+from a dedicated IAM user — not laptop keys.
+
+## Laptop fallback
 
 ```bash
 ring deploy prod
+# SHA tag (same as CI):
+ring deploy prod -t "$(git rev-parse HEAD)"
 ```
 
-This runs, in order:
+Default image is `ring-api`. Pass `-i ring-frontend` / `-i ring-llm` only
+when you really need those images.
 
-1. `ring fe build` — build the frontend bundle (`react/dist`) served by nginx.
-2. `compose --profile prod build` — build all prod images, passing
-   `VITE_API_URL` / `VITE_MAINTENANCE_MODE` as frontend build args.
-3. `aws ecr-public get-login-password | docker login … public.ecr.aws` —
-   authenticate Docker against public ECR (`us-east-1`).
-4. `ring docker tp` — tag the `prod-*` images and push them to ECR.
-
-### Options
-
-| Flag | Default | Purpose |
-|------|---------|---------|
-| `--vite-api-url` | `https://ring.neilsriv.tech` | `VITE_API_URL` baked into the frontend image |
-| `--maintenance-mode` / `--no-maintenance-mode` | off | `VITE_MAINTENANCE_MODE` build arg |
-| `--region` | `us-east-1` | AWS region for the ECR login |
-| `--skip-fe-build` | off | Reuse existing `react/dist`, skip step 1 |
-| `--skip-login` | off | Skip step 3 if already logged in |
-
-## Manual equivalent
-
-```bash
-uv run ring fe build
-VITE_API_URL=https://ring.neilsriv.tech VITE_MAINTENANCE_MODE=false \
-  uv run ring compose any --profile prod build
-aws ecr-public get-login-password --region us-east-1 \
-  | docker login --username AWS --password-stdin public.ecr.aws
-uv run ring docker tp
-```
-
-Restrict to specific images with `-i`, e.g. `ring docker tp -i ring-api`.
-
-## Prerequisites
-
-- AWS CLI configured with credentials that can push to `public.ecr.aws/z2k1e8p1/`.
-- Docker running and able to build `linux/amd64` images (prod compose pins
-  `platform: linux/amd64`).
-- A populated `.env` (referenced by the prod compose services).
-
-## After the push: host pull is required
-
-Pushing to ECR does **not** restart prod. On the EC2 host:
+## Host pull
 
 ```bash
 cd ring
-git checkout dev            # detached HEAD makes `git pull` fail
-git pull origin dev
-./dev_util/prod.sh
+git checkout dev && git pull origin dev
+./dev_util/prod.sh                 # ring-api:latest
+# ./dev_util/prod.sh <git-sha>     # pin / rollback
+ring db upgrade                    # if this commit has a migration
 ring compose any --profile prod up -d --force-recreate
 ```
 
-The API volume-mounts `./ring` with `--reload`, so the checkout on disk is the
-running Python. Verify with:
+Do not skip `--force-recreate`: compose keeps the old container when the
+local tag name (`prod-ring-api:latest`) is unchanged.
+
+Verify:
 
 ```bash
 curl -sS https://ring.neilsriv.tech/api/v1/version
 ```
 
-Expect a 200 JSON body with `git.sha`, `image_build.sha`, and
-`docker.containers[].image_id` / `image_digest`. Container identity comes
-from `.ring-runtime-version.json` written by `ring compose` / `prod.sh` —
-the API does not mount `docker.sock`. A connection error or missing route
-means the host is still on a pre-version image/checkout.
-
-Do not skip `--force-recreate`: compose keeps the old container when the local
-tag name (`prod-ring-api:latest`) is unchanged.
-
 ## Notes
 
-- Pushing publishes `:latest`; there is no per-release version tag today.
-- Set `--maintenance-mode` to ship a frontend that renders the maintenance page.
-- Image/registry names live in `dev_util/docker.py`; the deploy command lives in
-  `dev_util/deploy.py`.
-- Builds bake the current git SHA into image labels (`org.opencontainers.image.revision`)
-  and `RING_BUILD_GIT_*` env vars via `dev_util/git_meta.py`.
+- Prod SPA and API share `ring.neilsriv.tech` via Cloudflare route split
+  (`/api/*` and `/.well-known/*` passthrough). No extra CORS for prod.
+- Image/registry names live in `dev_util/docker.py`.
+- Builds bake git SHA into `RING_BUILD_GIT_*` via `dev_util/git_meta.py`.

--- a/.cursor/skills/ring-deploy-prod/SKILL.md
+++ b/.cursor/skills/ring-deploy-prod/SKILL.md
@@ -42,13 +42,24 @@ when you really need those images.
 cd ring
 git checkout dev && git pull origin dev
 ./dev_util/prod.sh                 # ring-api:latest
-# ./dev_util/prod.sh <git-sha>     # pin / rollback
+# ./dev_util/prod.sh <git-sha>     # match image/deps to that SHA
 ring db upgrade                    # if this commit has a migration
 ring compose any --profile prod up -d --force-recreate
 ```
 
 Do not skip `--force-recreate`: compose keeps the old container when the
 local tag name (`prod-ring-api:latest`) is unchanged.
+
+Rollback today is the host checkout **plus** the matching image:
+
+```bash
+git checkout <sha>
+./dev_util/prod.sh <sha>
+ring compose any --profile prod up -d --force-recreate
+```
+
+`prod.sh <sha>` alone does not roll back running Python while `./ring`
+is bind-mounted with `--reload`.
 
 Verify:
 

--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -85,4 +85,4 @@ jobs:
           provenance: false
           sbom: false
           cache-from: type=registry,ref=${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          cache-to: type=registry,ref=${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true

--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -1,0 +1,88 @@
+name: Publish ring-api
+
+# Phase 2 of the CD plan (see PR #301): every backend-touching push to
+# dev publishes a SHA-tagged image. This does not restart EC2 — pull +
+# swap is still manual until Phase 3.
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - "ring/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "compose.core.yml"
+      - "compose.prod.yml"
+      - ".github/workflows/publish_api.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-api-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  ECR_REGISTRY: public.ecr.aws/z2k1e8p1
+  IMAGE_NAME: ring-api
+  AWS_REGION: us-east-1
+
+jobs:
+  publish:
+    name: Build and push ring-api
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Collect git metadata
+        id: git
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "branch=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          echo "subject=$(git log -1 --pretty=format:%s | tr '\n' ' ' | cut -c1-500)" >> "$GITHUB_OUTPUT"
+          echo "author_name=$(git log -1 --pretty=format:%an)" >> "$GITHUB_OUTPUT"
+          echo "author_email=$(git log -1 --pretty=format:%ae)" >> "$GITHUB_OUTPUT"
+          echo "committed_at=$(git log -1 --pretty=format:%cI)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./ring
+          file: ./ring/ring.Dockerfile
+          target: ring
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          build-args: |
+            RING_GIT_SHA=${{ steps.git.outputs.sha }}
+            RING_GIT_SHORT_SHA=${{ steps.git.outputs.short }}
+            RING_GIT_BRANCH=${{ steps.git.outputs.branch }}
+            RING_GIT_SUBJECT=${{ steps.git.outputs.subject }}
+            RING_GIT_AUTHOR_NAME=${{ steps.git.outputs.author_name }}
+            RING_GIT_AUTHOR_EMAIL=${{ steps.git.outputs.author_email }}
+            RING_GIT_COMMITTED_AT=${{ steps.git.outputs.committed_at }}
+            RING_GIT_DIRTY=0
+          provenance: false
+          sbom: false
+          cache-from: type=registry,ref=${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.ECR_REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,4 +201,4 @@ separate CockroachDB instance on port 8008.
   - `ring-db-migration/` — generate/modify Alembic migrations the correct way
   - `ring-cloud-dev/` — Cursor Cloud VM bootstrap, health checks, browser testing
   - `ring-cloud-prod-db/` — point cloud Vite/API at CockroachDB Cloud (prod/staging)
-  - `ring-deploy-prod/` — build + push prod images to public ECR (`ring deploy prod`)
+  - `ring-deploy-prod/` — publish `ring-api` to ECR Public (CI on `dev`, or `ring deploy prod`)

--- a/README.md
+++ b/README.md
@@ -211,32 +211,29 @@ Public** (`public.ecr.aws/z2k1e8p1/`); the database is **CockroachDB Cloud**
 (`ring-db`). See [docs/infrastructure.md](docs/infrastructure.md) for the full
 topology (S3, CloudFront, SES, request flows).
 
-### Build and push images
+### Publish API images
 
-Preferred one-shot from a machine with AWS credentials:
+Pushes to `dev` that touch backend paths publish `ring-api:latest` and
+`ring-api:<sha>` to ECR Public (Actions → **Publish ring-api**). Frontend
+prod is Cloudflare Workers; do not build `ring-frontend` unless you are
+rolling back to the nginx SPA.
+
+Laptop fallback:
 
 ```bash
-ring deploy prod
+ring deploy prod -t "$(git rev-parse HEAD)"   # ring-api only
 ```
 
-Or the manual equivalent:
-
-```bash
-ring fe build
-VITE_API_URL=https://ring.neilsriv.tech ring compose any --profile prod build
-ring docker tp
-```
-
-### Deploy
+### Pull on the host
 
 SSH into the EC2 host, then:
 
 ```bash
 cd ring
-git pull
-./dev_util/prod.sh          # pull ring-api, ring-frontend, ring-llm from ECR
+git checkout dev && git pull origin dev
+./dev_util/prod.sh                  # or: ./dev_util/prod.sh <sha>
 ring db upgrade
-ring compose any --profile prod up -d
-# may need to restart nginx
-ring compose any --profile prod restart nginx
+ring compose any --profile prod up -d --force-recreate
 ```
+
+Rollback: `./dev_util/prod.sh <previous-sha>` then the same `up -d --force-recreate`.

--- a/README.md
+++ b/README.md
@@ -236,4 +236,7 @@ ring db upgrade
 ring compose any --profile prod up -d --force-recreate
 ```
 
-Rollback: `./dev_util/prod.sh <previous-sha>` then the same `up -d --force-recreate`.
+Prod still bind-mounts `./ring` with `--reload`, so running code is the
+checkout. Rollback is `git checkout <sha>` **and**
+`./dev_util/prod.sh <sha>` if the image/deps must match, then
+`up -d --force-recreate`. Image-only SHA pull is not a code rollback.

--- a/dev_util/deploy.py
+++ b/dev_util/deploy.py
@@ -7,12 +7,18 @@ import click
 
 from dev_util.compose import compose_starter
 from dev_util.dev import dev_command, dev_group, subprocess_run
-from dev_util.docker import push, tag
+from dev_util.docker import (
+    COMPOSE_SERVICE_BY_IMAGE,
+    IMAGE_TAG_NAMES,
+    push,
+    tag,
+)
 from dev_util.frontend import fe_build
 
 DEFAULT_VITE_API_URL = "https://ring.neilsriv.tech"
 DEFAULT_AWS_REGION = "us-east-1"
 ECR_PUBLIC_REGISTRY = "public.ecr.aws"
+DEFAULT_DEPLOY_IMAGES = ("ring-api",)
 
 
 @dev_group("deploy")
@@ -36,6 +42,23 @@ def _ecr_public_login(region: str) -> None:
             ECR_PUBLIC_REGISTRY,
         ],
         input=password,
+    )
+
+
+def _build_llm_image() -> None:
+    subprocess_run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            "llm/compose.llm.yml",
+            "-f",
+            "llm/compose.prod.llm.yml",
+            "--profile",
+            "prod",
+            "build",
+            "llm",
+        ]
     )
 
 
@@ -72,6 +95,21 @@ def _ecr_public_login(region: str) -> None:
     default=False,
     help="Skip the public ECR `docker login` step.",
 )
+@click.option(
+    "--image",
+    "-i",
+    type=click.Choice(IMAGE_TAG_NAMES),
+    multiple=True,
+    default=DEFAULT_DEPLOY_IMAGES,
+    help="Images to build and push (default: ring-api).",
+)
+@click.option(
+    "--extra-tag",
+    "-t",
+    multiple=True,
+    default=(),
+    help="Additional image tag(s) besides :latest (e.g. git SHA).",
+)
 def deploy_prod(
     ctx: click.Context,
     vite_api_url: str,
@@ -79,18 +117,25 @@ def deploy_prod(
     region: str,
     skip_fe_build: bool,
     skip_login: bool,
+    image: tuple[str, ...],
+    extra_tag: tuple[str, ...],
     *args: list[Any],
     **kwargs: dict[Any, Any],
 ) -> None:
-    """Build, tag, and push the production images to public ECR.
+    """Build, tag, and push production images to public ECR.
 
-    Mirrors the manual prod deploy flow:
-      1. ring fe build
-      2. compose --profile prod build (with VITE_* build args)
-      3. aws ecr-public login -> docker login
-      4. ring docker tp (tag + push)
+    Default is ring-api only. Frontend prod is Cloudflare; ring-llm is
+    manual. Laptop builds are the fallback — CI publishes SHA tags on
+    push to dev.
     """
-    if not skip_fe_build:
+    images = list(image) or list(DEFAULT_DEPLOY_IMAGES)
+    compose_services = [
+        COMPOSE_SERVICE_BY_IMAGE[name]
+        for name in images
+        if name in COMPOSE_SERVICE_BY_IMAGE
+    ]
+
+    if not skip_fe_build and "ring-frontend" in images:
         ctx.invoke(fe_build)
 
     build_env = {
@@ -98,10 +143,16 @@ def deploy_prod(
         "VITE_API_URL": vite_api_url,
         "VITE_MAINTENANCE_MODE": "true" if maintenance_mode else "false",
     }
-    subprocess_run(compose_starter("prod") + ["build"], env=build_env)
+    if compose_services:
+        subprocess_run(
+            compose_starter("prod") + ["build", *compose_services],
+            env=build_env,
+        )
+    if "ring-llm" in images:
+        _build_llm_image()
 
     if not skip_login:
         _ecr_public_login(region)
 
-    ctx.invoke(tag)
-    ctx.invoke(push)
+    ctx.invoke(tag, image=images, extra_tag=extra_tag)
+    ctx.invoke(push, image=images, extra_tag=extra_tag)

--- a/dev_util/docker.py
+++ b/dev_util/docker.py
@@ -12,11 +12,26 @@ IMAGE_TAG_NAMES = [
     "ring-llm",
 ]
 
+# Compose service names for images built via compose.core + compose.prod.
+COMPOSE_SERVICE_BY_IMAGE = {
+    "ring-api": "api",
+    "ring-frontend": "frontend",
+}
+
 
 @dev_group("docker")
 @click.pass_context
 def docker(ctx: click.Context) -> None:
     pass
+
+
+def _ecr_refs(image: str, extra_tags: tuple[str, ...] = ()) -> list[str]:
+    refs = [f"{ECR_URI_BASE}{image}:latest"]
+    for extra in extra_tags:
+        if not extra or extra == "latest":
+            continue
+        refs.append(f"{ECR_URI_BASE}{image}:{extra}")
+    return refs
 
 
 @dev_command("tag", docker)
@@ -27,13 +42,21 @@ def docker(ctx: click.Context) -> None:
     multiple=True,
     default=IMAGE_TAG_NAMES,
 )
-def tag(ctx: click.Context, image: list[str]) -> None:
-    run_cmds = [
-        ["docker", "tag", f"prod-{i}:latest", f"{ECR_URI_BASE}{i}:latest"]
-        for i in image
-    ]
-    for cmd in run_cmds:
-        subprocess_run(cmd)
+@click.option(
+    "--extra-tag",
+    "-t",
+    multiple=True,
+    default=(),
+    help="Additional image tag(s) besides :latest (e.g. git SHA).",
+)
+def tag(
+    ctx: click.Context,
+    image: list[str],
+    extra_tag: tuple[str, ...],
+) -> None:
+    for name in image:
+        for ref in _ecr_refs(name, extra_tag):
+            subprocess_run(["docker", "tag", f"prod-{name}:latest", ref])
 
 
 @dev_command("push", docker)
@@ -44,10 +67,21 @@ def tag(ctx: click.Context, image: list[str]) -> None:
     multiple=True,
     default=IMAGE_TAG_NAMES,
 )
-def push(ctx: click.Context, image: list[str]) -> None:
-    run_cmds = [["docker", "push", f"{ECR_URI_BASE}{i}:latest"] for i in image]
-    for cmd in run_cmds:
-        subprocess_run(cmd)
+@click.option(
+    "--extra-tag",
+    "-t",
+    multiple=True,
+    default=(),
+    help="Additional image tag(s) besides :latest (e.g. git SHA).",
+)
+def push(
+    ctx: click.Context,
+    image: list[str],
+    extra_tag: tuple[str, ...],
+) -> None:
+    for name in image:
+        for ref in _ecr_refs(name, extra_tag):
+            subprocess_run(["docker", "push", ref])
 
 
 @dev_command("tp", docker)
@@ -58,8 +92,17 @@ def push(ctx: click.Context, image: list[str]) -> None:
     multiple=True,
     default=IMAGE_TAG_NAMES,
 )
-def push_and_tag(ctx: click.Context, image: list[str]) -> None:
-    ctx.forward(tag)
-    # ctx.invoke(tag)
-    ctx.forward(push)
-    # ctx.invoke(push)
+@click.option(
+    "--extra-tag",
+    "-t",
+    multiple=True,
+    default=(),
+    help="Additional image tag(s) besides :latest (e.g. git SHA).",
+)
+def push_and_tag(
+    ctx: click.Context,
+    image: list[str],
+    extra_tag: tuple[str, ...],
+) -> None:
+    ctx.invoke(tag, image=image, extra_tag=extra_tag)
+    ctx.invoke(push, image=image, extra_tag=extra_tag)

--- a/dev_util/prod.sh
+++ b/dev_util/prod.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# Pull ECR images onto the prod host and retag as prod-*.
+#
+# Usage:
+#   ./dev_util/prod.sh                  # ring-api:latest
+#   ./dev_util/prod.sh <git-sha>        # ring-api:<sha>  (rollback / pin)
+#   ./dev_util/prod.sh --image ring-api --image ring-frontend <sha>
+
+set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PYTHON="${ROOT}/.venv/bin/python"
@@ -6,17 +14,71 @@ if [[ ! -x "$PYTHON" ]]; then
     PYTHON="${PYTHON3:-python3}"
 fi
 
-declare -a images=("ring-api" "ring-frontend" "ring-llm")
+ECR_URI_BASE="public.ecr.aws/z2k1e8p1/"
+TAG="latest"
+IMAGES=()
 
-for i in "${images[@]}"
-do
-    docker pull public.ecr.aws/z2k1e8p1/"$i":latest
-    docker tag public.ecr.aws/z2k1e8p1/"$i":latest "prod-$i":latest
-    docker rmi public.ecr.aws/z2k1e8p1/"$i":latest
+usage() {
+  cat <<'EOF'
+Usage: prod.sh [--image name]... [sha]
+
+Pull ECR Public images and retag them as prod-<name>:latest for Compose.
+
+  --image <name>   Image to pull (repeatable). Default: ring-api
+  sha              Tag to pull instead of :latest (usually a git SHA)
+
+Rollback:
+  ./dev_util/prod.sh <previous-sha>
+  ring compose any --profile prod up -d --force-recreate
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --image)
+      IMAGES+=("${2:-}")
+      shift 2
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      if [[ "$TAG" != "latest" ]]; then
+        echo "Only one sha argument is allowed" >&2
+        exit 1
+      fi
+      TAG="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#IMAGES[@]} -eq 0 ]]; then
+  IMAGES=("ring-api")
+fi
+
+for image in "${IMAGES[@]}"; do
+  remote="${ECR_URI_BASE}${image}:${TAG}"
+  docker pull "$remote"
+  docker tag "$remote" "prod-${image}:latest"
+  docker rmi "$remote" || true
 done
 
 # Snapshot pulled image identity for GET /version. Compose up refreshes
 # this with running container ids after --force-recreate.
+snapshot_images=""
+for image in "${IMAGES[@]}"; do
+  if [[ -n "$snapshot_images" ]]; then
+    snapshot_images+=","
+  fi
+  snapshot_images+="prod-${image}"
+done
 "$PYTHON" "${ROOT}/dev_util/runtime_version.py" write \
-    --images prod-ring-api,prod-ring-frontend,prod-ring-llm \
+    --images "$snapshot_images" \
     || true

--- a/dev_util/prod.sh
+++ b/dev_util/prod.sh
@@ -3,8 +3,12 @@
 #
 # Usage:
 #   ./dev_util/prod.sh                  # ring-api:latest
-#   ./dev_util/prod.sh <git-sha>        # ring-api:<sha>  (rollback / pin)
+#   ./dev_util/prod.sh <git-sha>        # ring-api:<sha> (deps / image pin)
 #   ./dev_util/prod.sh --image ring-api --image ring-frontend <sha>
+#
+# This only swaps the image (deps + RING_BUILD_GIT_*). Prod still
+# bind-mounts ./ring with --reload, so running Python comes from the
+# host checkout. Image-only SHA pull is not a code rollback.
 
 set -euo pipefail
 
@@ -27,8 +31,9 @@ Pull ECR Public images and retag them as prod-<name>:latest for Compose.
   --image <name>   Image to pull (repeatable). Default: ring-api
   sha              Tag to pull instead of :latest (usually a git SHA)
 
-Rollback:
-  ./dev_util/prod.sh <previous-sha>
+Rollback (code is the host checkout today):
+  git checkout <previous-sha>
+  ./dev_util/prod.sh <previous-sha>   # only if image/deps must match
   ring compose any --profile prod up -d --force-recreate
 EOF
 }

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -198,10 +198,17 @@ cd ring
 git checkout dev
 git pull origin dev
 ./dev_util/prod.sh                 # pull ring-api:latest → prod-ring-api
-# ./dev_util/prod.sh <git-sha>     # pin / rollback to a CI-published SHA
+# ./dev_util/prod.sh <git-sha>     # match image/deps to that SHA
 ring db upgrade                    # only if this commit has a migration
 ring compose any --profile prod up -d --force-recreate
 ```
+
+`prod.sh <sha>` only swaps the image (installed deps + baked
+`RING_BUILD_GIT_*`). It does **not** roll back running Python. True
+rollback today is `git checkout <sha>` (or reset `dev` to that commit)
+and `./dev_util/prod.sh <sha>` if deps/image need to match, then
+`up -d --force-recreate`. Image-only SHA pull becomes a real rollback
+in Phase 3/4 when the bind-mount and `--reload` go away.
 
 Confirm what is actually running (no auth):
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -102,8 +102,10 @@ flowchart TB
 ### ECR Public — container registry
 
 - **Registry:** `public.ecr.aws/z2k1e8p1/`
-- **Images pushed by deploy:** `ring-api`, `ring-frontend`, `ring-llm` ([dev_util/docker.py](../dev_util/docker.py))
-- **Also in registry (legacy / unused in current deploy):** `ring-worker`, `ring-beat`, `ring-test-runner`, `ring-next`
+- **Images pushed by CD:** `ring-api` (`:latest` and `:<git-sha>`) via
+  [`.github/workflows/publish_api.yml`](../.github/workflows/publish_api.yml)
+- **Still in registry (manual / leftover):** `ring-frontend`, `ring-llm`,
+  plus unused `ring-worker`, `ring-beat`, `ring-test-runner`, `ring-next`
 - **CI tests** use `ghcr.io`, not ECR.
 
 ---
@@ -161,25 +163,43 @@ Embedding generation → ring-llm microservice (not AWS Bedrock)
 
 ## Deployment
 
-Build and push from a dev machine:
+Roadmap: [PR #301](https://github.com/neil-sriv/ring/pull/301) — frontend
+via Cloudflare Workers Routes, backend via CI-built SHA-tagged images.
+Frontend prod traffic already hits the Worker (`/*`); `/api/*` and
+`/.well-known/*` still pass through to this nginx. The steps below are
+the current backend flow.
+
+### Publish API images (CI)
+
+Pushes to `dev` that touch `ring/**` (or a manual **Actions → Publish
+ring-api** run) build `linux/amd64` and push to ECR Public:
+
+- `public.ecr.aws/z2k1e8p1/ring-api:latest`
+- `public.ecr.aws/z2k1e8p1/ring-api:<git-sha>`
+
+Requires repo secrets `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` with
+push access to that registry. Use a dedicated IAM user for GitHub Actions,
+not laptop keys.
+
+Laptop fallback (API only by default):
 
 ```bash
-ring deploy prod
-# or manually:
-# VITE_API_URL=https://ring.neilsriv.tech ring compose any --profile prod build
-# ring docker tp   # tag + push to ECR Public
+ring deploy prod -t "$(git rev-parse HEAD)"
 ```
 
-On the EC2 host the API bind-mounts `./ring` and runs uvicorn `--reload`, so
-**the checkout on disk is the running API code**. The host must be on a branch
+### Pull on the EC2 host
+
+The API bind-mounts `./ring` and runs uvicorn `--reload`, so **the
+checkout on disk is the running API code**. The host must be on a branch
 (detached `HEAD` makes `git pull` fail):
 
 ```bash
 cd ring
 git checkout dev
 git pull origin dev
-./dev_util/prod.sh          # pull images from ECR, retag as prod-*
-ring db upgrade             # only if this commit has a migration
+./dev_util/prod.sh                 # pull ring-api:latest → prod-ring-api
+# ./dev_util/prod.sh <git-sha>     # pin / rollback to a CI-published SHA
+ring db upgrade                    # only if this commit has a migration
 ring compose any --profile prod up -d --force-recreate
 ```
 

--- a/ring/ring.Dockerfile
+++ b/ring/ring.Dockerfile
@@ -10,8 +10,12 @@ RUN pip install uv
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
-COPY ./ ./ring
+# Install deps before copying the rest of the tree so code-only rebuilds
+# reuse this layer (requirements.txt + the path-dep llm_service client).
+COPY requirements.txt ./ring/requirements.txt
+COPY packages/service_clients/llm_service ./ring/packages/service_clients/llm_service
 RUN uv pip install -r ring/requirements.txt --system --no-cache
+COPY ./ ./ring
 
 ARG RING_GIT_SHA
 ARG RING_GIT_SHORT_SHA


### PR DESCRIPTION
## Summary
- Add `Publish ring-api` workflow: backend-touching pushes to `dev` (or `workflow_dispatch`) build `linux/amd64` and push `:latest` + `:<sha>` to ECR Public
- Default `ring deploy prod` / `prod.sh` to `ring-api` only (frontend is Cloudflare; llm stays manual); `prod.sh <sha>` pins or rolls back
- Cache Docker deps by copying `requirements.txt` + `llm_service` before the rest of the tree

Implements Phase 2 of #301. Does not restart EC2 — host pull is still manual.

## Test plan
- [ ] Add GitHub secrets `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from a dedicated IAM user (not laptop keys)
- [ ] Run **Actions → Publish ring-api** and confirm `public.ecr.aws/z2k1e8p1/ring-api:<sha>` exists
- [ ] On EC2: `./dev_util/prod.sh <sha>` then `ring compose any --profile prod up -d --force-recreate`
- [ ] `curl -sS https://ring.neilsriv.tech/api/v1/version` shows the new SHA
- [ ] Rollback smoke: `./dev_util/prod.sh <previous-sha>` + recreate


Made with [Cursor](https://cursor.com)