### PR TITLE
Fix Casbin enforcer cartesian join on policy load

### DIFF
--- a/ring/authz/enforcer.py
+++ b/ring/authz/enforcer.py
@@ -6,7 +6,6 @@ from casbin import Enforcer, Model
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from ring.api_identifier.util import get_model
 from ring.letters.models.letter_model import Letter
 from ring.letters.models.question_model import Question
 from ring.letters.models.response_model import Response
@@ -29,68 +28,86 @@ def get_enforcer() -> Enforcer:
 
 
 def build_stateless_enforcer(db: Session, sub_api_id: str) -> Enforcer:
-    """Build a stateless enforcer for a request."""
+    """Build a stateless enforcer for a request.
+
+    Loads grouping and permission policies with separate queries (no
+    letters × members × questions × responses cartesian join) and
+    deduplicates before inserting into Casbin.
+    """
     enforcer = get_enforcer()
 
-    # add g1 rules for user groups
-    stmt = (
-        select(Group.api_identifier, User.api_identifier)
-        .join(Group.members)
-        .where(Group.members.any(User.api_identifier == sub_api_id))
+    group_api_ids = list(
+        db.execute(
+            select(Group.api_identifier)
+            .join(Group.members)
+            .where(User.api_identifier == sub_api_id)
+        )
+        .scalars()
+        .all()
     )
-    user_groups = db.execute(stmt).all()
+    if not group_api_ids:
+        return enforcer
 
-    for group_api_id, user_api_id in user_groups:
+    # g + g2: every member of the subject's groups
+    member_pairs = {
+        (user_api_id, group_api_id)
+        for user_api_id, group_api_id in db.execute(
+            select(User.api_identifier, Group.api_identifier)
+            .join(Group.members)
+            .where(Group.api_identifier.in_(group_api_ids))
+        ).all()
+    }
+    for user_api_id, group_api_id in member_pairs:
         enforcer.add_grouping_policy(user_api_id, group_api_id)
+        enforcer.add_named_grouping_policy("g2", user_api_id, group_api_id)
 
-    # add g2 rules for resource hierarchy
-    stmt = (
-        select(
-            Group.api_identifier,
-            User.api_identifier,
-            Letter.api_identifier,
-            Question.api_identifier,
-            Response.api_identifier,
-        )
-        .outerjoin(Group.letters)
-        .outerjoin(Group.members)
-        .outerjoin(Letter.questions)
-        .outerjoin(Question.responses)
-        .where(
-            Group.api_identifier.in_(
-                [group_api_id for group_api_id, _ in user_groups]
-            )
-        )
-    )
-    resources = db.execute(stmt).all()
+    # g2: letter -> group
+    letter_pairs = {
+        (letter_api_id, group_api_id)
+        for letter_api_id, group_api_id in db.execute(
+            select(Letter.api_identifier, Group.api_identifier)
+            .join(Letter.group)
+            .where(Group.api_identifier.in_(group_api_ids))
+        ).all()
+    }
+    for letter_api_id, group_api_id in letter_pairs:
+        enforcer.add_named_grouping_policy("g2", letter_api_id, group_api_id)
 
-    for (
-        group_api_id,
-        user_api_id,
-        letter_api_id,
-        question_api_id,
-        response_api_id,
-    ) in resources:
-        if user_api_id:
-            enforcer.add_named_grouping_policy("g2", user_api_id, group_api_id)
-        if letter_api_id:
-            enforcer.add_named_grouping_policy(
-                "g2", letter_api_id, group_api_id
-            )
-        if question_api_id:
-            enforcer.add_named_grouping_policy(
-                "g2", question_api_id, letter_api_id
-            )
-        if response_api_id:
-            enforcer.add_named_grouping_policy(
-                "g2", response_api_id, question_api_id
-            )
-
-    # add p rules for group permissions
-    for group in user_groups:
-        enforcer.add_policy(
-            group.api_identifier, group.api_identifier, Action.READ.value
+    # g2: question -> letter
+    question_pairs = {
+        (question_api_id, letter_api_id)
+        for question_api_id, letter_api_id in db.execute(
+            select(Question.api_identifier, Letter.api_identifier)
+            .join(Question.letter)
+            .join(Letter.group)
+            .where(Group.api_identifier.in_(group_api_ids))
+        ).all()
+    }
+    for question_api_id, letter_api_id in question_pairs:
+        enforcer.add_named_grouping_policy(
+            "g2", question_api_id, letter_api_id
         )
+
+    # g2: response -> question
+    response_pairs = {
+        (response_api_id, question_api_id)
+        for response_api_id, question_api_id in db.execute(
+            select(Response.api_identifier, Question.api_identifier)
+            .join(Response.question)
+            .join(Question.letter)
+            .join(Letter.group)
+            .where(Group.api_identifier.in_(group_api_ids))
+        ).all()
+    }
+    for response_api_id, question_api_id in response_pairs:
+        enforcer.add_named_grouping_policy(
+            "g2", response_api_id, question_api_id
+        )
+
+    # p: READ on each of the subject's groups
+    for group_api_id in set(group_api_ids):
+        enforcer.add_policy(group_api_id, group_api_id, Action.READ.value)
+
     return enforcer
 
 


### PR DESCRIPTION
## Summary
- Rewrite `build_stateless_enforcer` to load `g` / `g2` / `p` via separate queries instead of a letters × members × questions × responses outer join
- Deduplicate policy pairs before `add_named_grouping_policy` / `add_policy`
- No auth semantics change — PR1 characterization suite stays green

Stacked on #304 (`neil/authz-enforcer-characterization`).

## Test plan
- [x] `pytest ring/tests/unit/authz/` — 47 passed (includes characterization)
- [x] `ruff format` + `ruff check` on `ring/authz/enforcer.py`


Made with [Cursor](https://cursor.com)