### PR TITLE
Scope Casbin filter_to_authorized to candidate resources

### DIFF
--- a/ring/authz/authz.py
+++ b/ring/authz/authz.py
@@ -9,11 +9,10 @@ from ring.api_identifier.api_identified_model import APIIdentified
 from ring.api_identifier.util import (
     IDNotFoundException,
     bulk_get_models,
-    get_models,
 )
 from ring.authz.enforcer import (
     Action,
-    build_stateless_enforcer,
+    build_stateless_enforcer_for_resources,
     enforce_stateless,
 )
 from ring.parties.models.user_model import User
@@ -57,7 +56,13 @@ def filter_to_authorized(
     resources: Sequence[APIIdentified],
 ) -> Sequence[APIIdentified]:
     """Filter a sequence of resources to only include those that the user has permission to perform an action on."""
-    enforcer = build_stateless_enforcer(db, user.api_identifier)
+    if not resources:
+        return []
+    enforcer = build_stateless_enforcer_for_resources(
+        db,
+        user.api_identifier,
+        [resource.api_identifier for resource in resources],
+    )
     return [
         resource
         for resource in resources
@@ -72,7 +77,13 @@ def bulk_can_or_inaccessible(
     resources: Sequence[APIIdentified],
 ) -> Sequence[APIIdentified | InaccessibleResource]:
     """Check if a user has permission to perform an action on a sequence of resources."""
-    enforcer = build_stateless_enforcer(db, user.api_identifier)
+    if not resources:
+        return []
+    enforcer = build_stateless_enforcer_for_resources(
+        db,
+        user.api_identifier,
+        [resource.api_identifier for resource in resources],
+    )
     return [
         resource
         if can(db, user, action, resource, enforcer)

--- a/ring/authz/enforcer.py
+++ b/ring/authz/enforcer.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Sequence
 
 from casbin import Enforcer, Model
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from ring.api_identifier.api_identified_model import APIPrefix
 from ring.letters.models.letter_model import Letter
 from ring.letters.models.question_model import Question
 from ring.letters.models.response_model import Response
@@ -27,16 +29,8 @@ def get_enforcer() -> Enforcer:
     return Enforcer(model=model, adapter=None)
 
 
-def build_stateless_enforcer(db: Session, sub_api_id: str) -> Enforcer:
-    """Build a stateless enforcer for a request.
-
-    Loads grouping and permission policies with separate queries (no
-    letters × members × questions × responses cartesian join) and
-    deduplicates before inserting into Casbin.
-    """
-    enforcer = get_enforcer()
-
-    group_api_ids = list(
+def _subject_group_api_ids(db: Session, sub_api_id: str) -> list[str]:
+    return list(
         db.execute(
             select(Group.api_identifier)
             .join(Group.members)
@@ -45,10 +39,49 @@ def build_stateless_enforcer(db: Session, sub_api_id: str) -> Enforcer:
         .scalars()
         .all()
     )
-    if not group_api_ids:
-        return enforcer
 
-    # g + g2: every member of the subject's groups
+
+def _add_subject_membership_policies(
+    enforcer: Enforcer,
+    db: Session,
+    sub_api_id: str,
+    group_api_ids: Sequence[str],
+    *,
+    include_all_member_g: bool,
+) -> None:
+    """Add g + p for the subject's groups.
+
+    When ``include_all_member_g`` is True (full corpus build), every member of
+    those groups gets a ``g`` edge — matching historical join shape. The scoped
+    build only needs the subject's own ``g`` edges for enforce decisions.
+    """
+    if include_all_member_g:
+        member_pairs = {
+            (user_api_id, group_api_id)
+            for user_api_id, group_api_id in db.execute(
+                select(User.api_identifier, Group.api_identifier)
+                .join(Group.members)
+                .where(Group.api_identifier.in_(group_api_ids))
+            ).all()
+        }
+        for user_api_id, group_api_id in member_pairs:
+            enforcer.add_grouping_policy(user_api_id, group_api_id)
+    else:
+        for group_api_id in group_api_ids:
+            enforcer.add_grouping_policy(sub_api_id, group_api_id)
+
+    for group_api_id in set(group_api_ids):
+        enforcer.add_policy(group_api_id, group_api_id, Action.READ.value)
+
+
+def _add_g2_pairs(enforcer: Enforcer, pairs: set[tuple[str, str]]) -> None:
+    for child, parent in pairs:
+        enforcer.add_named_grouping_policy("g2", child, parent)
+
+
+def _load_full_g2(
+    enforcer: Enforcer, db: Session, group_api_ids: Sequence[str]
+) -> None:
     member_pairs = {
         (user_api_id, group_api_id)
         for user_api_id, group_api_id in db.execute(
@@ -57,11 +90,8 @@ def build_stateless_enforcer(db: Session, sub_api_id: str) -> Enforcer:
             .where(Group.api_identifier.in_(group_api_ids))
         ).all()
     }
-    for user_api_id, group_api_id in member_pairs:
-        enforcer.add_grouping_policy(user_api_id, group_api_id)
-        enforcer.add_named_grouping_policy("g2", user_api_id, group_api_id)
+    _add_g2_pairs(enforcer, member_pairs)
 
-    # g2: letter -> group
     letter_pairs = {
         (letter_api_id, group_api_id)
         for letter_api_id, group_api_id in db.execute(
@@ -70,10 +100,8 @@ def build_stateless_enforcer(db: Session, sub_api_id: str) -> Enforcer:
             .where(Group.api_identifier.in_(group_api_ids))
         ).all()
     }
-    for letter_api_id, group_api_id in letter_pairs:
-        enforcer.add_named_grouping_policy("g2", letter_api_id, group_api_id)
+    _add_g2_pairs(enforcer, letter_pairs)
 
-    # g2: question -> letter
     question_pairs = {
         (question_api_id, letter_api_id)
         for question_api_id, letter_api_id in db.execute(
@@ -83,12 +111,8 @@ def build_stateless_enforcer(db: Session, sub_api_id: str) -> Enforcer:
             .where(Group.api_identifier.in_(group_api_ids))
         ).all()
     }
-    for question_api_id, letter_api_id in question_pairs:
-        enforcer.add_named_grouping_policy(
-            "g2", question_api_id, letter_api_id
-        )
+    _add_g2_pairs(enforcer, question_pairs)
 
-    # g2: response -> question
     response_pairs = {
         (response_api_id, question_api_id)
         for response_api_id, question_api_id in db.execute(
@@ -99,15 +123,140 @@ def build_stateless_enforcer(db: Session, sub_api_id: str) -> Enforcer:
             .where(Group.api_identifier.in_(group_api_ids))
         ).all()
     }
-    for response_api_id, question_api_id in response_pairs:
-        enforcer.add_named_grouping_policy(
-            "g2", response_api_id, question_api_id
+    _add_g2_pairs(enforcer, response_pairs)
+
+
+def _prefix(api_id: str) -> str:
+    return api_id.split("_", 1)[0]
+
+
+def _load_scoped_g2(
+    enforcer: Enforcer,
+    db: Session,
+    group_api_ids: Sequence[str],
+    resource_api_ids: Sequence[str],
+) -> None:
+    """Load only g2 parent chains needed for the given resource API ids."""
+    response_ids = {
+        api_id
+        for api_id in resource_api_ids
+        if _prefix(api_id) == APIPrefix.RESPONSE.value
+    }
+    question_ids = {
+        api_id
+        for api_id in resource_api_ids
+        if _prefix(api_id) == APIPrefix.QUESTION.value
+    }
+    letter_ids = {
+        api_id
+        for api_id in resource_api_ids
+        if _prefix(api_id) == APIPrefix.LETTER.value
+    }
+    user_ids = {
+        api_id
+        for api_id in resource_api_ids
+        if _prefix(api_id) == APIPrefix.USER.value
+    }
+
+    if response_ids:
+        response_pairs = {
+            (response_api_id, question_api_id)
+            for response_api_id, question_api_id in db.execute(
+                select(Response.api_identifier, Question.api_identifier)
+                .join(Response.question)
+                .where(Response.api_identifier.in_(response_ids))
+            ).all()
+        }
+        _add_g2_pairs(enforcer, response_pairs)
+        question_ids.update(
+            question_api_id for _, question_api_id in response_pairs
         )
 
-    # p: READ on each of the subject's groups
-    for group_api_id in set(group_api_ids):
-        enforcer.add_policy(group_api_id, group_api_id, Action.READ.value)
+    if question_ids:
+        question_pairs = {
+            (question_api_id, letter_api_id)
+            for question_api_id, letter_api_id in db.execute(
+                select(Question.api_identifier, Letter.api_identifier)
+                .join(Question.letter)
+                .where(Question.api_identifier.in_(question_ids))
+            ).all()
+        }
+        _add_g2_pairs(enforcer, question_pairs)
+        letter_ids.update(letter_api_id for _, letter_api_id in question_pairs)
 
+    if letter_ids:
+        letter_pairs = {
+            (letter_api_id, group_api_id)
+            for letter_api_id, group_api_id in db.execute(
+                select(Letter.api_identifier, Group.api_identifier)
+                .join(Letter.group)
+                .where(Letter.api_identifier.in_(letter_ids))
+            ).all()
+        }
+        _add_g2_pairs(enforcer, letter_pairs)
+
+    if user_ids:
+        # Same membership scope as the full build: only subject's groups.
+        member_pairs = {
+            (user_api_id, group_api_id)
+            for user_api_id, group_api_id in db.execute(
+                select(User.api_identifier, Group.api_identifier)
+                .join(Group.members)
+                .where(User.api_identifier.in_(user_ids))
+                .where(Group.api_identifier.in_(group_api_ids))
+            ).all()
+        }
+        _add_g2_pairs(enforcer, member_pairs)
+
+
+def build_stateless_enforcer(db: Session, sub_api_id: str) -> Enforcer:
+    """Build a stateless enforcer for a request.
+
+    Loads grouping and permission policies with separate queries (no
+    letters × members × questions × responses cartesian join) and
+    deduplicates before inserting into Casbin.
+    """
+    enforcer = get_enforcer()
+
+    group_api_ids = _subject_group_api_ids(db, sub_api_id)
+    if not group_api_ids:
+        return enforcer
+
+    _add_subject_membership_policies(
+        enforcer,
+        db,
+        sub_api_id,
+        group_api_ids,
+        include_all_member_g=True,
+    )
+    _load_full_g2(enforcer, db, group_api_ids)
+    return enforcer
+
+
+def build_stateless_enforcer_for_resources(
+    db: Session,
+    sub_api_id: str,
+    resource_api_ids: Sequence[str],
+) -> Enforcer:
+    """Build a Casbin enforcer with g2 limited to candidate resource chains.
+
+    Still decides authorization via Casbin ``enforce``; only the policy corpus
+    loaded for ``g2`` is scoped to ``resource_api_ids`` (plus parent links).
+    """
+    enforcer = get_enforcer()
+
+    group_api_ids = _subject_group_api_ids(db, sub_api_id)
+    if not group_api_ids:
+        return enforcer
+
+    _add_subject_membership_policies(
+        enforcer,
+        db,
+        sub_api_id,
+        group_api_ids,
+        include_all_member_g=False,
+    )
+    _load_scoped_g2(enforcer, db, group_api_ids, resource_api_ids)
     return enforcer
 
 

--- a/ring/tests/unit/authz/test_enforcer_scoped_filter.py
+++ b/ring/tests/unit/authz/test_enforcer_scoped_filter.py
@@ -1,0 +1,175 @@
+"""Tests for candidate-scoped enforcer loading used by filter_to_authorized."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from ring.authz.authz import (
+    InaccessibleResource,
+    bulk_can_or_inaccessible,
+    can,
+    filter_to_authorized,
+)
+from ring.authz.enforcer import Action, build_stateless_enforcer
+from ring.tests.factories.letters.letter_factory import LetterFactory
+from ring.tests.factories.letters.question_factory import QuestionFactory
+from ring.tests.factories.letters.response_factory import ResponseFactory
+from ring.tests.factories.parties.group_factory import GroupFactory
+from ring.tests.factories.parties.user_factory import UserFactory
+from ring.tests.lib.utils import (
+    assert_sqlalchemy_object_list_equal_with_order_insensitive,
+)
+
+
+@pytest.fixture
+def hierarchy_fixture(db_session: Session) -> dict[str, Any]:
+    member = UserFactory.create()
+    other_member = UserFactory.create()
+    outsider = UserFactory.create()
+
+    group_a = GroupFactory.create(admin=member, members=[member, other_member])
+    letter_a = LetterFactory.create(group=group_a)
+    question_a = QuestionFactory.create(letter=letter_a)
+    response_a = ResponseFactory.create(
+        question=question_a, participant=member
+    )
+
+    group_b = GroupFactory.create(admin=outsider)
+    letter_b = LetterFactory.create(group=group_b)
+    question_b = QuestionFactory.create(letter=letter_b)
+    response_b = ResponseFactory.create(
+        question=question_b, participant=outsider
+    )
+
+    db_session.commit()
+
+    return {
+        "member": member,
+        "other_member": other_member,
+        "outsider": outsider,
+        "group_a": group_a,
+        "letter_a": letter_a,
+        "question_a": question_a,
+        "response_a": response_a,
+        "group_b": group_b,
+        "letter_b": letter_b,
+        "question_b": question_b,
+        "response_b": response_b,
+    }
+
+
+def _filter_with_full_enforcer(
+    db: Session,
+    user: Any,
+    action: Action,
+    resources: list[Any],
+) -> list[Any]:
+    """Reference filter using a fully loaded enforcer (outcome oracle)."""
+    enforcer = build_stateless_enforcer(db, user.api_identifier)
+    return [
+        resource
+        for resource in resources
+        if can(db, user, action, resource, enforcer)
+    ]
+
+
+class TestScopedFilterEquivalence:
+    def test_filter_matches_full_enforcer_mixed_resources(
+        self, db_session: Session, hierarchy_fixture: dict[str, Any]
+    ) -> None:
+        member = hierarchy_fixture["member"]
+        resources = [
+            hierarchy_fixture["group_a"],
+            hierarchy_fixture["letter_a"],
+            hierarchy_fixture["question_a"],
+            hierarchy_fixture["response_a"],
+            hierarchy_fixture["other_member"],
+            hierarchy_fixture["group_b"],
+            hierarchy_fixture["letter_b"],
+            hierarchy_fixture["question_b"],
+            hierarchy_fixture["response_b"],
+            hierarchy_fixture["outsider"],
+        ]
+
+        scoped = filter_to_authorized(
+            db_session, member, Action.READ, resources
+        )
+        full = _filter_with_full_enforcer(
+            db_session, member, Action.READ, resources
+        )
+
+        assert_sqlalchemy_object_list_equal_with_order_insensitive(
+            list(scoped), full
+        )
+
+    def test_bulk_can_or_inaccessible_matches_full_enforcer(
+        self, db_session: Session, hierarchy_fixture: dict[str, Any]
+    ) -> None:
+        member = hierarchy_fixture["member"]
+        resources = [
+            hierarchy_fixture["letter_a"],
+            hierarchy_fixture["letter_b"],
+            hierarchy_fixture["response_a"],
+            hierarchy_fixture["other_member"],
+        ]
+
+        scoped = bulk_can_or_inaccessible(
+            db_session, member, Action.READ, resources
+        )
+        enforcer = build_stateless_enforcer(db_session, member.api_identifier)
+        expected = [
+            resource
+            if can(db_session, member, Action.READ, resource, enforcer)
+            else InaccessibleResource(resource)
+            for resource in resources
+        ]
+
+        assert len(scoped) == len(expected)
+        for got, want in zip(scoped, expected, strict=True):
+            if isinstance(want, InaccessibleResource):
+                assert isinstance(got, InaccessibleResource)
+                assert got.resource is want.resource
+            else:
+                assert got is want
+
+
+class TestEmptyFilterEarlyReturn:
+    def test_empty_resources_skips_full_and_scoped_loaders(
+        self, db_session: Session
+    ) -> None:
+        user = UserFactory.create()
+        db_session.commit()
+
+        with (
+            patch("ring.authz.enforcer.build_stateless_enforcer") as full_mock,
+            patch(
+                "ring.authz.authz.build_stateless_enforcer_for_resources",
+            ) as scoped_mock,
+        ):
+            result = filter_to_authorized(db_session, user, Action.READ, [])
+
+        assert result == []
+        full_mock.assert_not_called()
+        scoped_mock.assert_not_called()
+
+    def test_empty_bulk_can_skips_loaders(self, db_session: Session) -> None:
+        user = UserFactory.create()
+        db_session.commit()
+
+        with (
+            patch("ring.authz.enforcer.build_stateless_enforcer") as full_mock,
+            patch(
+                "ring.authz.authz.build_stateless_enforcer_for_resources",
+            ) as scoped_mock,
+        ):
+            result = bulk_can_or_inaccessible(
+                db_session, user, Action.READ, []
+            )
+
+        assert result == []
+        full_mock.assert_not_called()
+        scoped_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `build_stateless_enforcer_for_resources` that loads user `g`/`p` plus only `g2` parent chains for candidate API ids
- Wire `filter_to_authorized` and `bulk_can_or_inaccessible` to the scoped builder; early-return `[]` without loading any enforcer corpus
- Decisions still go through Casbin `enforce` / `can` (no membership shortcut)
- TDD coverage: outcome equivalence vs full `build_stateless_enforcer`, empty-list loader spy

Stacked on #305 (`neil/authz-enforcer-fix-join`).

## Test plan
- [x] `pytest ring/tests/unit/authz/` — 51 passed
- [x] `ruff format` + `ruff check` on touched files


Made with [Cursor](https://cursor.com)