### PR TITLE
Run prod API from the image filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,12 +230,13 @@ SSH into the EC2 host, then:
 
 ```bash
 cd ring
-./dev_util/deploy_host.sh                  # origin/dev + :latest
-# ./dev_util/deploy_host.sh <sha>          # pin / rollback
+./dev_util/deploy_host.sh <published-sha>  # pin / rollback
 # uv run ring deploy host <sha>            # same script
 ```
 
-That syncs git, pulls the matching `ring-api` image, runs
+That syncs git (compose/nginx), pulls `ring-api:<sha>`, runs
 `uv run ring db upgrade --profile prod`, recreates Compose, and checks
-`GET /api/v1/version`. Prod still bind-mounts `./ring` with `--reload`,
-so the script checks out the SHA (it does not only swap the image).
+`GET /api/v1/version` (`image_build.sha`). Prod runs the image
+filesystem — pass a SHA that `publish_api.yml` actually tagged, not a
+docs-only `HEAD`. To roll back an image without reverting compose to a
+pre-cutover commit: `./dev_util/deploy_host.sh --skip-git <sha>`.

--- a/compose.core.yml
+++ b/compose.core.yml
@@ -18,10 +18,8 @@ services:
       # image: email_circle-api
     command: "uvicorn ring.fastapp.fast:app --proxy-headers"
     volumes:
-      - ./ring:/src/ring
-      # Live checkout SHA for GET /version (prod bind-mounts this tree with --reload).
-      - ./.git:/git:ro
       # Host-written container identity. Never mount docker.sock into the API.
+      # Code bind-mounts live in compose.dev.yml so prod runs the image filesystem.
       - ./.ring-runtime-version.json:/var/ring/runtime-version.json:ro
     environment:
       - PYTHONPATH=.

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -16,6 +16,10 @@ services:
       - RING_GIT_AUTHOR_EMAIL=${RING_GIT_AUTHOR_EMAIL:-}
       - RING_GIT_COMMITTED_AT=${RING_GIT_COMMITTED_AT:-}
       - RING_GIT_DIRTY=${RING_GIT_DIRTY:-}
+    volumes:
+      - ./ring:/src/ring
+      # Live checkout SHA for GET /version (dev only; prod uses image_build).
+      - ./.git:/git:ro
     depends_on:
       - cockroach
     links:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,7 +1,7 @@
 services:
   api:
     image: prod-ring-api
-    command: "uvicorn ring.fastapp.fast:app --proxy-headers --host 0.0.0.0 --port ${API_PORT} --reload"
+    command: "uvicorn ring.fastapp.fast:app --proxy-headers --host 0.0.0.0 --port ${API_PORT}"
     mem_limit: 300m
     expose:
       - "${API_PORT}"

--- a/dev_util/deploy.py
+++ b/dev_util/deploy.py
@@ -189,7 +189,7 @@ def deploy_prod(
     "--rollback-on-fail/--no-rollback-on-fail",
     default=False,
     show_default=True,
-    help="Re-run against the pre-deploy SHA if version verify fails.",
+    help="Re-run against the pre-deploy image SHA if version verify fails.",
 )
 @click.argument("sha", required=False, default=None)
 def deploy_host(

--- a/dev_util/deploy_host.sh
+++ b/dev_util/deploy_host.sh
@@ -16,8 +16,9 @@
 # First apply of the image-filesystem cutover (old script still on disk):
 #   git fetch origin && git checkout -B dev <this-sha>
 #   ./dev_util/deploy_host.sh --skip-git <this-sha>
-# Do not use --rollback-on-fail with the pre-cutover script — it asserts
-# checkout git.sha, which goes away when ./.git is unmounted.
+# --rollback-on-fail captures live /version image_build.sha *before*
+# mutating. The pre-cutover script on the box still asserts git.sha and
+# rolls back to HEAD — do not use that flag until this script is on disk.
 #
 # Rollback to a pre-cutover image without remounting ./ring:
 #   ./dev_util/deploy_host.sh --skip-git <previous-image-sha>
@@ -50,7 +51,8 @@ Full host rollout: git sync, pull ECR image, migrate, compose up, verify.
   --skip-pull           Do not run prod.sh
   --skip-migrate        Do not run `uv run ring db upgrade --profile prod`
   --skip-verify         Do not curl GET /api/v1/version
-  --rollback-on-fail    On verify failure, re-run against the pre-deploy SHA
+  --rollback-on-fail    On verify failure, re-run against the pre-deploy
+                        image SHA (live image_build.sha; HEAD if probe fails)
   -h, --help            Show this help
 
 Env:
@@ -117,7 +119,80 @@ ring_cmd() {
   fi
 }
 
-previous_sha="$(git rev-parse HEAD)"
+# Cloudflare blocks the default Python-urllib User-Agent (1010 / 403).
+version_request_python() {
+  python3 - "$@" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+url = sys.argv[1]
+want = sys.argv[2] if len(sys.argv) > 2 else ""
+attempts = int(sys.argv[3]) if len(sys.argv) > 3 else 1
+sleep = float(sys.argv[4]) if len(sys.argv) > 4 else 0.0
+last_error = "no attempts"
+payload: dict[str, object] = {}
+
+for attempt in range(1, attempts + 1):
+    try:
+        request = urllib.request.Request(
+            url,
+            headers={"User-Agent": "ring-deploy-host/1.0"},
+        )
+        with urllib.request.urlopen(request, timeout=10) as response:
+            payload = json.loads(response.read().decode())
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        last_error = str(exc)
+        if sleep:
+            time.sleep(sleep)
+        continue
+
+    image = (
+        payload.get("image_build")
+        if isinstance(payload.get("image_build"), dict)
+        else {}
+    )
+    image_sha = image.get("sha")
+    if want:
+        print(json.dumps(payload, indent=2))
+        if image_sha == want:
+            sys.exit(0)
+        last_error = (
+            f"version mismatch (attempt {attempt}/{attempts}): "
+            f"image_build.sha={image_sha!r} want={want!r}"
+        )
+        if sleep:
+            time.sleep(sleep)
+        continue
+    if isinstance(image_sha, str) and image_sha.strip():
+        print(image_sha.strip())
+        sys.exit(0)
+    last_error = "image_build.sha missing from /version"
+    break
+
+print(last_error, file=sys.stderr)
+sys.exit(1)
+PY
+}
+
+read_live_image_sha() {
+  version_request_python "$VERSION_URL"
+}
+
+previous_image_sha=""
+if [[ "$ROLLBACK_ON_FAIL" -eq 1 ]]; then
+  echo "==> Capturing live image_build.sha from ${VERSION_URL}"
+  if previous_image_sha="$(read_live_image_sha)"; then
+    echo "==> Rollback target is live image ${previous_image_sha}"
+  else
+    previous_image_sha="$(git rev-parse HEAD)"
+    echo "==> /version probe failed; falling back to checkout ${previous_image_sha}" >&2
+  fi
+fi
 
 if [[ "$SKIP_GIT" -eq 0 ]]; then
   echo "==> Syncing git"
@@ -148,65 +223,16 @@ fi
 echo "==> Recreating Compose (prod)"
 ring_cmd compose any --profile prod up -d --force-recreate
 
-verify_version() {
-  local want="$1"
-  python3 - "$VERSION_URL" "$want" "$VERIFY_ATTEMPTS" "$VERIFY_SLEEP_SECS" <<'PY'
-from __future__ import annotations
-
-import json
-import sys
-import time
-import urllib.error
-import urllib.request
-
-url, want, attempts_s, sleep_s = sys.argv[1:5]
-attempts = int(attempts_s)
-sleep = float(sleep_s)
-last_error = "no attempts"
-payload: dict[str, object] = {}
-
-for attempt in range(1, attempts + 1):
-    try:
-        # Cloudflare blocks the default Python-urllib User-Agent (1010 / 403).
-        request = urllib.request.Request(
-            url,
-            headers={"User-Agent": "ring-deploy-host/1.0"},
-        )
-        with urllib.request.urlopen(request, timeout=10) as response:
-            payload = json.loads(response.read().decode())
-    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
-        last_error = str(exc)
-        time.sleep(sleep)
-        continue
-
-    image = (
-        payload.get("image_build")
-        if isinstance(payload.get("image_build"), dict)
-        else {}
-    )
-    image_sha = image.get("sha")
-    print(json.dumps(payload, indent=2))
-    # After the image-filesystem cutover, checkout git.sha tracks host
-    # git pull (or is unavailable). The running API is image_build.sha.
-    if image_sha == want:
-        sys.exit(0)
-    last_error = (
-        f"version mismatch (attempt {attempt}/{attempts}): "
-        f"image_build.sha={image_sha!r} want={want!r}"
-    )
-    time.sleep(sleep)
-
-print(last_error, file=sys.stderr)
-sys.exit(1)
-PY
-}
-
 if [[ "$SKIP_VERIFY" -eq 0 ]]; then
-  echo "==> Verifying ${VERSION_URL} == ${SHA}"
-  if ! verify_version "$SHA"; then
-    if [[ "$ROLLBACK_ON_FAIL" -eq 1 && "$previous_sha" != "$SHA" ]]; then
-      echo "==> Verify failed; rolling back to ${previous_sha}" >&2
-      "$0" --no-rollback-on-fail "$previous_sha" || true
+  echo "==> Verifying ${VERSION_URL} image_build.sha == ${SHA}"
+  if ! version_request_python "$VERSION_URL" "$SHA" \
+      "$VERIFY_ATTEMPTS" "$VERIFY_SLEEP_SECS"; then
+    if [[ "$ROLLBACK_ON_FAIL" -eq 1 && -n "$previous_image_sha" &&
+          "$previous_image_sha" != "$SHA" ]]; then
+      echo "==> Verify failed; rolling back to image ${previous_image_sha}" >&2
+      # Image-only restore: do not checkout the old SHA (that can remount
+      # ./ring or target an unpublished checkout tag).
+      "$0" --no-rollback-on-fail --skip-git "$previous_image_sha" || true
     fi
     exit 1
   fi

--- a/dev_util/deploy_host.sh
+++ b/dev_util/deploy_host.sh
@@ -2,15 +2,25 @@
 # Full backend rollout on the prod EC2 host.
 #
 # This is the one command humans and (later) Actions should run on the box.
-# prod.sh only pulls images; this script also syncs git, migrates, recreates
-# Compose, and checks GET /api/v1/version.
+# prod.sh only pulls images; this script also syncs git (compose/nginx),
+# migrates, recreates Compose, and checks GET /api/v1/version.
+# Prod runs the image filesystem (no ./ring bind-mount, no --reload).
 #
 # Usage:
-#   ./dev_util/deploy_host.sh                 # origin/dev tip + :latest
-#   ./dev_util/deploy_host.sh <git-sha>       # checkout + pull that SHA
-#   ./dev_util/deploy_host.sh --rollback-on-fail <sha>
+#   ./dev_util/deploy_host.sh <published-sha>
+#   ./dev_util/deploy_host.sh --rollback-on-fail <published-sha>
 #
-# Rollback is the same command with the previous SHA.
+# The sha must exist as public.ecr.aws/z2k1e8p1/ring-api:<sha> (a
+# publish_api.yml run). Docs-only origin/dev tips have no image tag.
+#
+# First apply of the image-filesystem cutover (old script still on disk):
+#   git fetch origin && git checkout -B dev <this-sha>
+#   ./dev_util/deploy_host.sh --skip-git <this-sha>
+# Do not use --rollback-on-fail with the pre-cutover script — it asserts
+# checkout git.sha, which goes away when ./.git is unmounted.
+#
+# Rollback to a pre-cutover image without remounting ./ring:
+#   ./dev_util/deploy_host.sh --skip-git <previous-image-sha>
 
 set -euo pipefail
 
@@ -34,8 +44,9 @@ Usage: deploy_host.sh [options] [sha]
 
 Full host rollout: git sync, pull ECR image, migrate, compose up, verify.
 
-  sha                   Commit / image tag to deploy (default: origin/dev tip)
-  --skip-git            Do not fetch/checkout
+  sha                   Published image tag / commit (default: origin/dev tip)
+  --skip-git            Do not fetch/checkout (use to roll back the image
+                        without reverting compose to a pre-cutover SHA)
   --skip-pull           Do not run prod.sh
   --skip-migrate        Do not run `uv run ring db upgrade --profile prod`
   --skip-verify         Do not curl GET /api/v1/version
@@ -47,7 +58,8 @@ Env:
   RING_DEPLOY_BRANCH    Branch to keep checked out (default: dev)
 
 Rollback:
-  ./dev_util/deploy_host.sh <previous-sha>
+  ./dev_util/deploy_host.sh <previous-published-sha>
+  ./dev_util/deploy_host.sh --skip-git <pre-cutover-image-sha>
 EOF
 }
 
@@ -167,20 +179,20 @@ for attempt in range(1, attempts + 1):
         time.sleep(sleep)
         continue
 
-    git = payload.get("git") if isinstance(payload.get("git"), dict) else {}
     image = (
         payload.get("image_build")
         if isinstance(payload.get("image_build"), dict)
         else {}
     )
-    git_sha = git.get("sha")
     image_sha = image.get("sha")
     print(json.dumps(payload, indent=2))
-    if git_sha == want and image_sha == want:
+    # After the image-filesystem cutover, checkout git.sha tracks host
+    # git pull (or is unavailable). The running API is image_build.sha.
+    if image_sha == want:
         sys.exit(0)
     last_error = (
         f"version mismatch (attempt {attempt}/{attempts}): "
-        f"git.sha={git_sha!r} image_build.sha={image_sha!r} want={want!r}"
+        f"image_build.sha={image_sha!r} want={want!r}"
     )
     time.sleep(sleep)
 

--- a/dev_util/prod.sh
+++ b/dev_util/prod.sh
@@ -6,9 +6,9 @@
 #   ./dev_util/prod.sh <git-sha>        # ring-api:<sha> (deps / image pin)
 #   ./dev_util/prod.sh --image ring-api --image ring-frontend <sha>
 #
-# This only swaps the image (deps + RING_BUILD_GIT_*). Prod still
-# bind-mounts ./ring with --reload, so running Python comes from the
-# host checkout. Image-only SHA pull is not a code rollback.
+# This only swaps the image (deps + RING_BUILD_GIT_* + baked Python).
+# Prod no longer bind-mounts ./ring, so a SHA pull is a code rollback.
+# Prefer deploy_host.sh so migrate / compose / verify stay in lockstep.
 
 set -euo pipefail
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -189,29 +189,29 @@ ring deploy prod -t "$(git rev-parse HEAD)"
 
 ### Deploy on the EC2 host
 
-The API bind-mounts `./ring` and runs uvicorn `--reload`, so **the
-checkout on disk is the running API code**. Use the one-shot host
-script (keeps `dev` checked out so later `git pull` still works):
+Prod runs the API **image filesystem** (no `./ring` bind-mount, no
+uvicorn `--reload`). The one-shot host script still checkouts git so
+compose/nginx on disk match the deploy:
 
 ```bash
 cd ring
-./dev_util/deploy_host.sh                 # origin/dev + ring-api:latest
-# ./dev_util/deploy_host.sh <git-sha>     # checkout + matching image
-# ./dev_util/deploy_host.sh --rollback-on-fail <git-sha>
+./dev_util/deploy_host.sh <published-sha>
+# ./dev_util/deploy_host.sh --rollback-on-fail <published-sha>
+# ./dev_util/deploy_host.sh --skip-git <pre-cutover-image-sha>
 ```
 
-`prod.sh` is the image-pull step only. Image-only SHA pull becomes a
-real code rollback in Phase 4 when the bind-mount and `--reload` go
-away.
+The sha must exist as `ring-api:<sha>` (a **Publish ring-api** run).
+`prod.sh` is the image-pull step only.
 
 Confirm what is actually running (no auth):
 
 ```bash
-curl -sS https://ring.neilsriv.tech/api/v1/version
+curl -sS -A 'ring-deploy-host/1.0' https://ring.neilsriv.tech/api/v1/version
 ```
 
-`git` is the host checkout, `image_build` is metadata baked into the API
-image, and `docker.containers[].image_id` / `image_digest` come from a
+`image_build` is metadata baked into the API image (this is the running
+code). `git` is unavailable in prod after the cutover (no `./.git`
+mount). `docker.containers[].image_id` / `image_digest` come from a
 host-written snapshot (`.ring-runtime-version.json`, mounted read-only).
 The API does not talk to the Docker Engine.
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -201,7 +201,9 @@ cd ring
 ```
 
 The sha must exist as `ring-api:<sha>` (a **Publish ring-api** run).
-`prod.sh` is the image-pull step only.
+`prod.sh` is the image-pull step only. `--rollback-on-fail` reads live
+`image_build.sha` **before** git/image/compose mutate and restores that
+image (`--skip-git`) if verify fails — not `git rev-parse HEAD`.
 
 Confirm what is actually running (no auth):
 


### PR DESCRIPTION
## Summary
- Stop mounting `./ring` and `./.git` into the prod API container (those bind-mounts stay in `compose.dev.yml` for local reload).
- Drop uvicorn `--reload` in `compose.prod.yml` so prod runs baked image Python and saves RAM on the t2.micro.
- `deploy_host.sh` now gates on `image_build.sha` only. Pass a SHA that `publish_api.yml` actually tagged.

## First apply on EC2
The script currently on the box still asserts checkout `git.sha`. Load this commit first, then deploy (do **not** use `--rollback-on-fail` with the old script):

```bash
git fetch origin
git checkout -B dev <this-sha>
./dev_util/deploy_host.sh --skip-git <this-sha>
```

Wait for **Publish ring-api** to finish so `ring-api:<this-sha>` exists. Afterward `/version` should show `image_build.sha` = this commit and `git.source` unavailable.

Rollback to a pre-cutover image without remounting `./ring`:

```bash
./dev_util/deploy_host.sh --skip-git 60ca61b4547f4ef0c35bd77f8ebd2e1b6b2f0d6c
```

## Test plan
- [ ] `docker compose -f compose.core.yml -f compose.prod.yml config` has no `./ring` or `./.git` mount and no `--reload`
- [ ] Local `ring compose up` still bind-mounts `./ring` and `--reload` (dev profile)
- [ ] After merge, Publish ring-api produces `ring-api:<sha>`
- [ ] First EC2 apply as above; `GET /api/v1/version` matches `image_build.sha`
- [ ] Optional: `--skip-git` rollback to `60ca61b` still serves that image


Made with [Cursor](https://cursor.com)