### PR TITLE
Add push-button Actions deploy for ring-api

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -1,0 +1,81 @@
+name: Deploy ring-api
+
+# Phase 3 of the CD plan (see PR #301): push-button host rollout.
+# Does not run on push — flip that in Phase 4 after a few clean clicks.
+# The host script is the interface; this job only SSHs and runs it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Published ring-api image tag (git SHA). Empty = this ref.
+        required: false
+        type: string
+
+concurrency:
+  group: prod-deploy
+  cancel-in-progress: false
+
+env:
+  ECR_IMAGE: public.ecr.aws/z2k1e8p1/ring-api
+
+jobs:
+  resolve:
+    name: Resolve SHA
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.sha.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Pick target SHA
+        id: sha
+        run: |
+          sha="${{ inputs.sha }}"
+          if [[ -z "$sha" ]]; then
+            sha="${{ github.sha }}"
+          fi
+          sha="$(git rev-parse --verify "${sha}^{commit}")"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          echo "Deploy target ${sha}"
+
+      - name: Require published image
+        run: |
+          sha="${{ steps.sha.outputs.sha }}"
+          if ! docker manifest inspect "${{ env.ECR_IMAGE }}:${sha}" >/dev/null; then
+            echo "No ${{ env.ECR_IMAGE }}:${sha}. Wait for Publish ring-api, or pass a SHA that job tagged." >&2
+            exit 1
+          fi
+
+  test:
+    name: Backend tests
+    needs: resolve
+    uses: ./.github/workflows/run_test.yml
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+
+  deploy:
+    name: Roll out on EC2
+    needs: [resolve, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH deploy_host.sh
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.PROD_SSH_HOST }}
+          username: ${{ secrets.PROD_SSH_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          port: ${{ vars.PROD_SSH_PORT || 22 }}
+          command_timeout: 15m
+          script_stop: true
+          script: |
+            set -euo pipefail
+            APP_DIR="${{ vars.PROD_APP_DIR }}"
+            if [[ -z "$APP_DIR" ]]; then
+              APP_DIR="$HOME/ring"
+            fi
+            cd "$APP_DIR"
+            ./dev_util/deploy_host.sh --rollback-on-fail "${{ needs.resolve.outputs.sha }}"

--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -1,8 +1,8 @@
 name: Publish ring-api
 
 # Phase 2 of the CD plan (see PR #301): every backend-touching push to
-# dev publishes a SHA-tagged image. This does not restart EC2 — pull +
-# swap is still manual until Phase 3.
+# dev publishes a SHA-tagged image. This does not restart EC2 — use
+# Actions → Deploy ring-api (or ./dev_util/deploy_host.sh on the box).
 
 on:
   push:

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -6,6 +6,12 @@ on:
       - dev
   pull_request:
     # Run for all PRs regardless of base to better support stacked PRs
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref / SHA to test (default: caller github.sha)
+        required: false
+        type: string
 
 jobs:
   build:
@@ -17,6 +23,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref || github.sha }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v4

--- a/README.md
+++ b/README.md
@@ -226,7 +226,14 @@ ring deploy prod -t "$(git rev-parse HEAD)"   # ring-api only
 
 ### Deploy on the host
 
-SSH into the EC2 host, then:
+Push-button: Actions → **Deploy ring-api** (`workflow_dispatch`). That
+runs backend tests, then SSHs to EC2 and runs
+`./dev_util/deploy_host.sh --rollback-on-fail <sha>`. Needs repo secrets
+`PROD_SSH_HOST` (EC2 public IP or gray-cloud DNS — not the orange-cloud
+`ring.neilsriv.tech`), `PROD_SSH_USER`, `PROD_SSH_KEY`. Optional vars:
+`PROD_SSH_PORT` (default 22), `PROD_APP_DIR` (default `$HOME/ring`).
+
+Or SSH in yourself:
 
 ```bash
 cd ring

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -189,6 +189,16 @@ ring deploy prod -t "$(git rev-parse HEAD)"
 
 ### Deploy on the EC2 host
 
+Push-button: Actions → **Deploy ring-api**. Tests the target SHA, then
+SSHs and runs `./dev_util/deploy_host.sh --rollback-on-fail <sha>`.
+Concurrency group `prod-deploy` queues (does not cancel) so two clicks
+cannot race migrations.
+
+Secrets: `PROD_SSH_HOST` (raw EC2 IP or gray-cloud name — Cloudflare
+will not forward SSH on the orange `ring.neilsriv.tech`),
+`PROD_SSH_USER`, `PROD_SSH_KEY` (dedicated deploy key, not a laptop
+key). Optional vars: `PROD_SSH_PORT` (22), `PROD_APP_DIR` (`$HOME/ring`).
+
 Prod runs the API **image filesystem** (no `./ring` bind-mount, no
 uvicorn `--reload`). The one-shot host script still checkouts git so
 compose/nginx on disk match the deploy:
@@ -370,5 +380,6 @@ Helpful for agents so they do not assume these exist:
 | [prod.nginx.conf](../prod.nginx.conf) | Prod Nginx config (`ring.neilsriv.tech`) |
 | [dev_util/prod.sh](../dev_util/prod.sh) | Pull ECR images on the server |
 | [dev_util/deploy_host.sh](../dev_util/deploy_host.sh) | Full host rollout (git + pull + migrate + up + verify) |
+| [.github/workflows/deploy_api.yml](../.github/workflows/deploy_api.yml) | Push-button SSH deploy (`workflow_dispatch`) |
 | [dev_util/docker.py](../dev_util/docker.py) | Tag/push to ECR Public |
 | [.cursor/cloud-start.sh](../.cursor/cloud-start.sh) | Cursor Cloud Agent VM bootstrap (local Cockroach, not prod) |


### PR DESCRIPTION
## Summary
- `workflow_dispatch` **Deploy ring-api** SSHs to EC2 and runs `./dev_util/deploy_host.sh --rollback-on-fail <sha>` — the host script stays the interface.
- Concurrency group `prod-deploy` queues (does not cancel) so two deploys cannot race migrations.
- Gates on backend tests for the target SHA (`run_test.yml` is now `workflow_call`-able). Fails fast if `ring-api:<sha>` is not in ECR Public.

## Secrets / vars
Add repo secrets before the first click (dedicated deploy key, not a laptop key):
- `PROD_SSH_HOST` — EC2 public IP or gray-cloud DNS (not orange `ring.neilsriv.tech`; Cloudflare will not forward SSH)
- `PROD_SSH_USER`
- `PROD_SSH_KEY`

Optional vars: `PROD_SSH_PORT` (22), `PROD_APP_DIR` (`$HOME/ring`).

Do not flip this to `push: dev` yet (Phase 4).

## Test plan
- [ ] Add the three SSH secrets (and vars if the app dir is not `$HOME/ring`)
- [ ] Actions → Deploy ring-api, sha empty (current `dev`) or `195c464393d7bff82a239b59a3bfd21fb956d3a9`
- [ ] Tests run, then host script; `/version` `image_build.sha` matches
- [ ] A second click while the first is running queues instead of cancelling


Made with [Cursor](https://cursor.com)