### PR TITLE
fix(auth): let expired sessions reach the password reset and invite pages

### DIFF
--- a/react/src/hooks/useAuth.ts
+++ b/react/src/hooks/useAuth.ts
@@ -18,10 +18,6 @@ export interface AuthContext {
   user: UserLinked | undefined
 }
 
-const isLoggedIn = () => {
-  return localStorage.getItem("access_token") !== null
-}
-
 const useAuth = (next?: string) => {
   const [error, setError] = useState<string | null>(null)
   const navigate = useNavigate()
@@ -80,5 +76,4 @@ const useAuth = (next?: string) => {
   }
 }
 
-export { isLoggedIn }
 export default useAuth

--- a/react/src/main.tsx
+++ b/react/src/main.tsx
@@ -16,6 +16,7 @@ import { registerSW } from "virtual:pwa-register"
 import { readUserMePartiesMeGetOptions } from "./client/@tanstack/react-query.gen"
 import { client } from "./client/client.gen"
 import { initGlobalKeyboardShortcuts } from "./lib/globalKeyboardShortcuts"
+import { isPublicAuthPath } from "./util/authRoutes"
 
 /* Dark mode initialization */
 const savedTheme = localStorage.getItem("theme")
@@ -53,14 +54,15 @@ client.instance.interceptors.response.use(
   (error) => {
     if (error.response?.status === 401) {
       localStorage.removeItem("access_token")
-      const currentPath =
-        window.location.pathname + window.location.search + window.location.hash
-      // Only add next parameter if we're not already on the login page
-      if (window.location.pathname !== "/login") {
+      // Login, reset-password and register pages need the stale token cleared,
+      // but navigating away would discard the one-time token in their URL.
+      if (!isPublicAuthPath(window.location.pathname)) {
+        const currentPath =
+          window.location.pathname +
+          window.location.search +
+          window.location.hash
         const nextParam = encodeURIComponent(currentPath)
         window.location.href = `/login?next=${nextParam}`
-      } else {
-        window.location.href = "/login"
       }
     }
     return Promise.reject(error)

--- a/react/src/routes/register/$token.tsx
+++ b/react/src/routes/register/$token.tsx
@@ -17,14 +17,15 @@ import {
   validateTokenInvitesTokenTokenGetOptions,
   validateTokenInvitesTokenTokenGetQueryKey,
 } from "../../client/@tanstack/react-query.gen"
-import { isLoggedIn } from "../../hooks/useAuth"
 import useRegister from "../../hooks/useRegister"
 import { emailPattern } from "../../util/misc"
 
 export const Route = createFileRoute("/register/$token")({
   component: Register,
-  beforeLoad: async () => {
-    if (isLoggedIn()) {
+  beforeLoad: async ({ context }) => {
+    // Gate on a verified session, not on a leftover localStorage token, so an
+    // expired session cannot swallow the invite token in the URL.
+    if (context.auth.isAuthenticated) {
       throw redirect({
         to: "/groups",
       })

--- a/react/src/routes/reset-password.tsx
+++ b/react/src/routes/reset-password.tsx
@@ -15,7 +15,6 @@ import { Label } from "@/components/ui/label"
 import type { AxiosError } from "axios"
 import type { ResetPasswordRequestResetPasswordRequestEmailPostError } from "../client"
 import { resetPasswordRequestResetPasswordRequestEmailPost } from "../client/sdk.gen"
-import { isLoggedIn } from "../hooks/useAuth"
 import useCustomToast from "../hooks/useCustomToast"
 import { emailPattern, formatApiErrorDetail } from "../util/misc"
 
@@ -25,8 +24,10 @@ interface FormData {
 
 export const Route = createFileRoute("/reset-password")({
   component: ResetPasswordRequest,
-  beforeLoad: async () => {
-    if (isLoggedIn()) {
+  beforeLoad: async ({ context }) => {
+    // Gate on a verified session, not on a leftover localStorage token: users
+    // who need this page usually have an expired one sitting there.
+    if (context.auth.isAuthenticated) {
       throw redirect({
         to: "/",
       })

--- a/react/src/routes/reset-password_/$token.tsx
+++ b/react/src/routes/reset-password_/$token.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query"
-import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Loader2 } from "lucide-react"
 import { type SubmitHandler, useForm } from "react-hook-form"
 
@@ -19,7 +19,6 @@ import type {
   ResetPasswordResetPasswordTokenPostError,
 } from "../../client"
 import { resetPasswordResetPasswordTokenPostMutation } from "../../client/@tanstack/react-query.gen"
-import { isLoggedIn } from "../../hooks/useAuth"
 import useCustomToast from "../../hooks/useCustomToast"
 import {
   confirmPasswordRules,
@@ -33,13 +32,6 @@ interface NewPasswordForm extends NewPassword {
 
 export const Route = createFileRoute("/reset-password/$token")({
   component: ResetPassword,
-  beforeLoad: async () => {
-    if (isLoggedIn()) {
-      throw redirect({
-        to: "/",
-      })
-    }
-  },
 })
 
 function ResetPassword() {

--- a/react/src/util/authRoutes.ts
+++ b/react/src/util/authRoutes.ts
@@ -1,0 +1,17 @@
+/**
+ * Paths that a signed-out user has to be able to reach, including the
+ * one-time-token links we email out for password resets and invites.
+ *
+ * A leftover `access_token` in localStorage (expired sessions are never cleared
+ * until a request fails) must not gate or redirect away from these paths, or
+ * the emailed token is dropped before the user can use it.
+ */
+const PUBLIC_AUTH_PATH_PATTERNS = [
+  /^\/login\/?$/,
+  /^\/reset-password(\/.*)?$/,
+  /^\/register\/.+$/,
+]
+
+export function isPublicAuthPath(pathname: string): boolean {
+  return PUBLIC_AUTH_PATH_PATTERNS.some((pattern) => pattern.test(pathname))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Report

"Password reset is not working."

## Root cause

The backend reset flow is fine — request, token validation, expiry, reuse and the actual password change all behave correctly (verified against the live API, see test plan). The break is in the frontend route guards.

`isLoggedIn()` returned `localStorage.getItem("access_token") !== null`, i.e. "there is *a* token", not "the session is valid". Access tokens live for a week (`ACCESS_TOKEN_TTL` in `ring/security.py`) and are only removed when a request comes back 401, so any returning user still has an expired token sitting in localStorage — and "returning user who hasn't logged in for a while" describes almost everyone who needs a password reset.

For that user, clicking the reset link in their email did this:

1. `/reset-password/$token` `beforeLoad` saw a non-empty token, treated them as logged in, and redirected to `/`.
2. The `/parties/me` bootstrap query (enabled whenever a token exists) came back 401.
3. The axios 401 interceptor hard-navigated to `/login?next=%2F`.

They landed on the login page, the one-time token was gone from the URL, and `next` pointed at `/` so even logging in would not bring them back. The reset form was never rendered. Same trap on `/reset-password` (the "Forgot password?" link) and on `/register/$token` for invited users.

Reproduced with a correctly-signed but expired JWT in localStorage, opening a valid reset link — the address bar ends up at `/login?next=%2F` and `/parties/me` shows the 401 that caused it:

![Before the fix: opening a valid reset link with an expired session lands on /login?next=%2F](https://cursor.com/artifacts/c/art-d82ea7f9-3fd6-4bdd-a2e8-0233160026a0)

## Changes

- `react/src/util/authRoutes.ts` (new): `isPublicAuthPath()` — the paths a signed-out user must be able to reach, including the emailed one-time-token links.
- `react/src/main.tsx`: the 401 interceptor still clears the stale token, but no longer navigates away when the user is on a public auth page. This also removes a pointless `window.location.href = "/login"` reload when already on `/login`.
- `react/src/routes/reset-password_/$token.tsx`: guard dropped. Someone who clicked an emailed reset link should always get the form.
- `react/src/routes/reset-password.tsx` and `react/src/routes/register/$token.tsx`: gate on `context.auth.isAuthenticated` (a verified `/parties/me` response, the pattern `login.tsx` already uses) instead of the raw localStorage value.
- `react/src/hooks/useAuth.ts`: `isLoggedIn` removed; it had no remaining callers and existed only to conflate "token present" with "signed in".

Frontend only, no API or schema change, so no `ring fe regen`.

## Verification

Same expired JWT, same reset link, after the fix: the form renders and stays, the password is updated, and the user signs in with the new password. `/parties/me` still 401s in the background and still clears the stale token — it just no longer hijacks the page.

<a href="https://cursor.com/agents/bc-019ff134-bfc7-7a8b-ba70-06ed750a5095/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpassword_reset_works_with_expired_session.mp4"><img src="https://cursor.com/artifacts/c/art-e4bbad74-9cf6-4a7b-b0a5-6f5ec452f573" alt="password_reset_works_with_expired_session.mp4" /></a>

## Test plan

- [x] Repro before the fix (expired JWT planted, valid reset link → bounced to `/login?next=%2F`, form never rendered). Control with no token → form rendered.
- [x] End-to-end after the fix, recording above.
- [x] Backend flow verified directly against the running API: request → token → reset → login with the new password, plus already-used (`Token already used`), expired (`Token expired`), unknown token (`Invalid token`) and unknown email (`User with this email does not exist`) all returning the right 400s.
- [x] `npx tsc --noEmit`
- [x] `pnpm run lint` (Biome)
- [x] `pnpm run build`
- [x] `ring check lint`

## Follow-up (not in this PR)

`get_ott_by_token` in `ring/parties/crud/one_time_token.py` does not filter on `TokenType`, so the reset endpoint accepts a token minted for an invite. `get_invite_by_token` does filter. Worth tightening separately.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff134-bfc7-7a8b-ba70-06ed750a5095?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff134-bfc7-7a8b-ba70-06ed750a5095&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

