### PR TITLE
fix(auth): scope one-time token lookup to the expected token type

### DIFF
--- a/ring/auth/api/authn.py
+++ b/ring/auth/api/authn.py
@@ -171,7 +171,7 @@ async def reset_password(
     Raises:
         HTTPException: 400 if token is invalid, expired, or already used
     """
-    ott = get_ott_by_token(req_dep.db, token)
+    ott = get_ott_by_token(req_dep.db, token, TokenType.PASSWORD_RESET)
     if not ott:
         raise HTTPException(status_code=400, detail="Invalid token")
     try:

--- a/ring/parties/crud/one_time_token.py
+++ b/ring/parties/crud/one_time_token.py
@@ -26,12 +26,19 @@ class TokenAlreadyUsedError(Exception):
     pass
 
 
-def get_ott_by_token(db: Session, token: str) -> OneTimeToken | None:
-    """Get a one-time token by its token string.
+def get_ott_by_token(
+    db: Session, token: str, type: TokenType
+) -> OneTimeToken | None:
+    """Get a one-time token by its token string and type.
+
+    A token only counts for the flow that minted it: an invite token is emailed
+    to an address before that account exists, so honouring it as a password
+    reset would hand anyone holding the invite link the resulting account.
 
     Args:
         db (Session): Database session
         token (str): Token string to look up
+        type (TokenType): Type the token must have to match
 
     Returns:
         OneTimeToken | None: Found token or None
@@ -39,6 +46,7 @@ def get_ott_by_token(db: Session, token: str) -> OneTimeToken | None:
     return db.scalar(
         select(OneTimeToken).filter(
             OneTimeToken.token == token,
+            OneTimeToken.type == type,
         )
     )
 

--- a/ring/tests/unit/auth/api/authn_test.py
+++ b/ring/tests/unit/auth/api/authn_test.py
@@ -3,6 +3,14 @@
 from __future__ import annotations
 
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from ring.parties.models.one_time_token_model import TokenType
+from ring.security import verify_password
+from ring.tests.factories.parties.one_time_token_factory import (
+    OneTimeTokenFactory,
+)
+from ring.tests.factories.parties.user_factory import UserFactory
 
 
 class TestAuthnAPI:
@@ -23,3 +31,52 @@ class TestAuthnAPI:
                 response.json()["detail"]
                 == "This endpoint is deprecated and not implemented"
             )
+
+    def test_reset_password_accepts_password_reset_token(
+        self, unauthenticated_client: TestClient, db_session: Session
+    ) -> None:
+        """A token minted for a password reset sets the new password."""
+        user = UserFactory.create(password="original-password")
+        ott = OneTimeTokenFactory.create(
+            type=TokenType.PASSWORD_RESET, email=user.email
+        )
+        db_session.commit()
+
+        response = unauthenticated_client.post(
+            f"/reset-password/{ott.token}",
+            json={"new_password": "brand-new-password"},
+        )
+
+        assert response.status_code == 200
+        db_session.refresh(user)
+        db_session.refresh(ott)
+        assert ott.used
+        assert verify_password("brand-new-password", user.hashed_password)
+
+    def test_reset_password_rejects_invite_token(
+        self, unauthenticated_client: TestClient, db_session: Session
+    ) -> None:
+        """An invite token must not double as a password reset token.
+
+        Invites are emailed before the account exists and are not consumed
+        unless that specific link is used to register, so accepting one here
+        would let anyone holding an outstanding invite link take the account
+        over once it is created.
+        """
+        user = UserFactory.create(password="original-password")
+        ott = OneTimeTokenFactory.create(
+            type=TokenType.INVITE, email=user.email
+        )
+        db_session.commit()
+
+        response = unauthenticated_client.post(
+            f"/reset-password/{ott.token}",
+            json={"new_password": "attacker-password"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid token"
+        db_session.refresh(user)
+        db_session.refresh(ott)
+        assert not ott.used
+        assert verify_password("original-password", user.hashed_password)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the password reset investigation in #312 (that PR is the frontend fix and is independent of this one).

## Problem

`get_ott_by_token` matched on the token string alone, and `POST /reset-password/{token}` was its only caller. Both invite and password-reset tokens live in the same `one_time_token` table, so a token minted for a group invite was accepted as a password reset token.

That is an account takeover path, not just untidiness:

- Invite links are emailed to an address *before* that account exists, and they stay valid for the full week-long TTL.
- `register_user` only marks the token it was given as used, so any other outstanding invite for the same address stays unused and valid.
- `invite_users` only skips addresses that already have a user *at invite time*, so the same address can accumulate invites from several groups before it registers.

Once that address has an account, anyone holding one of the unconsumed invite links — a forwarded invite email, a shared inbox, a mailing list archive — could POST it to `/reset-password/{token}` and set the password. `ott.email` is the invited address, so the user lookup in the endpoint resolves, and the reset succeeds.

`get_invite_by_token` already filters on `TokenType.INVITE`, so the reverse direction was never possible. This makes the reset side symmetric.

## Change

`get_ott_by_token` now takes the expected `TokenType` and filters on it. The argument is required rather than an optional filter so any future caller has to state which flow it is honouring; there is one call site today and it passes `TokenType.PASSWORD_RESET`.

No schema or API surface change, so no migration and no `ring fe regen`.

## Test plan

- [x] Two tests added to `ring/tests/unit/auth/api/authn_test.py`: an invite-typed token is rejected with `Invalid token`, leaving the password and the token's `used` flag untouched; a password-reset-typed token still resets the password and is marked used.
- [x] Confirmed the new test actually catches the bug — with the type filter reverted it fails on `assert 200 == 400`, i.e. the invite token really did reset the password before this change.
- [x] `ring test run` — 335 passed, including the existing invite registration tests.
- [x] `ring check lint`
- [x] Verified against the running dev API: an `invite`-typed row for an existing user's address returns 400 and leaves the account on its original password, while the normal request-then-reset flow still returns 200 and the new password logs in.

```
=== reset attempt with an INVITE token (should be rejected) ===
{"detail":"Invalid token"} [400]
=== account untouched? login with original password ===
original password -> 200
attacker password -> 400
=== genuine reset flow still works ===
{"message":"Password updated successfully"} [200]
login after genuine reset -> 200
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff134-bfc7-7a8b-ba70-06ed750a5095?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff134-bfc7-7a8b-ba70-06ed750a5095&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

