### PR TITLE
Stamp the frontend build so prod deploys are visible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,11 @@ Full topology, request flows, and deploy steps:
 | CDN | `du32exnxihxuf.cloudfront.net` | [ring/s3/models/s3_model.py](ring/s3/models/s3_model.py) `qualified_s3_url` |
 | Email (SES) | `us-east-1`, sender `ring@neilsriv.tech` | [ring/email_util.py](ring/email_util.py) |
 | Container registry | ECR Public `public.ecr.aws/z2k1e8p1/` | [dev_util/docker.py](dev_util/docker.py), [dev_util/prod.sh](dev_util/prod.sh), [dev_util/deploy_host.sh](dev_util/deploy_host.sh) |
+| Frontend hosting | Cloudflare Workers Builds (`ring-frontend`), auto-deploys every push to `dev` | [react/wrangler.jsonc](react/wrangler.jsonc), [react/plugins/version-stamp.ts](react/plugins/version-stamp.ts) |
+
+Prod's two halves ship independently: the frontend redeploys itself about a
+minute after any push to `dev`, while the API only moves when someone runs
+`deploy_host.sh`. `ring deploy status` prints what each is running.
 
 Do not assume ECS, RDS, Route 53, Redis/Celery, Lambda, or Bedrock — none are
 in the current prod path. Embeddings go through the optional `ring-llm`

--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ Public** (`public.ecr.aws/z2k1e8p1/`); the database is **CockroachDB Cloud**
 (`ring-db`). See [docs/infrastructure.md](docs/infrastructure.md) for the full
 topology (S3, CloudFront, SES, request flows).
 
+### Deploy the frontend
+
+Nothing to run: Cloudflare Workers Builds redeploys the frontend on every
+push to `dev`, live about a minute later. Watch the **Workers Builds:
+ring-frontend** check on the commit.
+
 ### Publish API images
 
 Pushes to `dev` that touch backend paths publish `ring-api:latest` and
@@ -240,3 +246,15 @@ That syncs git (compose/nginx), pulls `ring-api:<sha>`, runs
 filesystem — pass a SHA that `publish_api.yml` actually tagged, not a
 docs-only `HEAD`. To roll back an image without reverting compose to a
 pre-cutover commit: `./dev_util/deploy_host.sh --skip-git <sha>`.
+
+### See what is live
+
+```bash
+ring deploy status
+# frontend   d615e40  dev  deployed 3m ago    up to date with origin/dev  via workers_ci
+# api        195c464  dev  committed 8h ago   1 commit behind origin/dev  via image_env
+```
+
+Frontend and API report themselves at `/version.json` and
+`/api/v1/version`; the app shows the same thing under
+**Settings → Build**.

--- a/dev_util/deploy.py
+++ b/dev_util/deploy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from typing import Any
@@ -7,6 +8,13 @@ from typing import Any
 import click
 
 from dev_util.compose import compose_starter
+from dev_util.deploy_status import (
+    DEFAULT_BASE_URL,
+    as_dict,
+    collect,
+    commits_behind,
+    format_component,
+)
 from dev_util.dev import ROOT_DIR, dev_command, dev_group, subprocess_run
 from dev_util.docker import (
     COMPOSE_SERVICE_BY_IMAGE,
@@ -158,6 +166,73 @@ def deploy_prod(
 
     ctx.invoke(tag, image=images, extra_tag=extra_tag)
     ctx.invoke(push, image=images, extra_tag=extra_tag)
+
+
+@dev_command("status", deploy)
+@click.option(
+    "--base-url",
+    type=str,
+    default=DEFAULT_BASE_URL,
+    show_default=True,
+    help="Origin to probe.",
+)
+@click.option(
+    "--ref",
+    type=str,
+    default="origin/dev",
+    show_default=True,
+    help="Git ref to measure deployed commits against.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON instead of a table.",
+)
+def deploy_status(
+    ctx: click.Context,
+    base_url: str,
+    ref: str,
+    as_json: bool,
+    *args: list[Any],
+    **kwargs: dict[Any, Any],
+) -> None:
+    """Show which commit is live on prod, and how long ago it shipped.
+
+    The frontend deploys itself on every push to dev (Cloudflare Workers
+    Builds); the API only moves when someone runs `ring deploy host`. This
+    is how you tell the two apart.
+    """
+    components = collect(base_url)
+    behind_by_name = {
+        component.name: (
+            commits_behind(component.sha, ref) if component.sha else None
+        )
+        for component in components
+    }
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "base_url": base_url,
+                    "ref": ref,
+                    "components": [
+                        as_dict(component, behind_by_name[component.name])
+                        for component in components
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    click.echo(f"Deployed at {base_url}")
+    for component in components:
+        click.echo(
+            f"  {format_component(component, behind_by_name[component.name], ref)}"
+        )
 
 
 @dev_command("host", deploy)

--- a/dev_util/deploy_status.py
+++ b/dev_util/deploy_status.py
@@ -85,22 +85,26 @@ def parse_frontend(payload: dict) -> Component:
 
 
 def parse_api(payload: dict) -> Component:
-    """Read image_build out of the API's /version response."""
-    image = payload.get("image_build")
-    if not isinstance(image, dict):
-        return Component(name="api", error="/version has no image_build")
-    component = Component(
-        name="api",
-        sha=image.get("sha"),
-        branch=image.get("branch"),
-        timestamp=image.get("committed_at"),
-        timestamp_label="committed",
-        source=image.get("source"),
-        detail=image.get("subject"),
-    )
-    if component.sha is None:
-        component.error = "API is running an image with no commit stamped"
-    return component
+    """Read the commit out of the API's /version response.
+
+    Prod runs the image filesystem with no `.git`, so `image_build` is the
+    only truthful source there; a bind-mounted dev container is the other
+    way round.
+    """
+    for key in ("image_build", "git"):
+        block = payload.get(key)
+        if not isinstance(block, dict) or not block.get("sha"):
+            continue
+        return Component(
+            name="api",
+            sha=block.get("sha"),
+            branch=block.get("branch"),
+            timestamp=block.get("committed_at"),
+            timestamp_label="committed",
+            source=block.get("source"),
+            detail=block.get("subject"),
+        )
+    return Component(name="api", error="/version reports no commit")
 
 
 def collect(base_url: str = DEFAULT_BASE_URL) -> list[Component]:

--- a/dev_util/deploy_status.py
+++ b/dev_util/deploy_status.py
@@ -1,0 +1,223 @@
+"""Read what is actually deployed, for `ring deploy status`.
+
+The frontend ships from Cloudflare Workers Builds and the API from a
+SHA-tagged ECR image, so the two halves of prod move independently. Both
+publish their commit: the frontend as a static `/version.json` written at
+build time, the API as `GET /api/v1/version`.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from dev_util.dev import ROOT_DIR
+
+DEFAULT_BASE_URL = "https://ring.neilsriv.tech"
+FRONTEND_VERSION_PATH = "/version.json"
+API_VERSION_PATH = "/api/v1/version"
+# Cloudflare answers the default Python-urllib User-Agent with 1010 / 403.
+USER_AGENT = "ring-deploy-status/1.0"
+REQUEST_TIMEOUT_SECONDS = 10.0
+HTML_RESPONSE = "served HTML, not JSON"
+NO_STAMP = "no /version.json — this deploy predates the build stamp"
+
+
+@dataclass
+class Component:
+    """One deployed piece of prod, as it reports itself."""
+
+    name: str
+    sha: str | None = None
+    branch: str | None = None
+    timestamp: str | None = None
+    timestamp_label: str = ""
+    source: str | None = None
+    detail: str | None = None
+    error: str | None = None
+
+
+def fetch_json(url: str, timeout: float = REQUEST_TIMEOUT_SECONDS) -> dict:
+    """GET a URL and parse JSON, raising ValueError on anything else.
+
+    The Worker serves index.html for unknown paths (SPA fallback), so a
+    frontend without a build stamp returns HTML with a 200.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode()
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise ValueError(str(exc)) from exc
+    if body.lstrip().startswith("<"):
+        raise ValueError(HTML_RESPONSE)
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"response was not JSON ({exc})") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("response was not a JSON object")
+    return payload
+
+
+def parse_frontend(payload: dict) -> Component:
+    """Read the build stamp emitted by react/plugins/version-stamp.ts."""
+    source = payload.get("source")
+    component = Component(
+        name="frontend",
+        sha=payload.get("sha"),
+        branch=payload.get("branch"),
+        timestamp=payload.get("built_at"),
+        timestamp_label="built",
+        source=source if isinstance(source, str) else None,
+    )
+    build_uuid = payload.get("build_uuid")
+    if isinstance(build_uuid, str) and build_uuid:
+        component.detail = f"build {build_uuid}"
+    if component.sha is None:
+        component.error = "build stamp has no commit"
+    return component
+
+
+def parse_api(payload: dict) -> Component:
+    """Read image_build out of the API's /version response."""
+    image = payload.get("image_build")
+    if not isinstance(image, dict):
+        return Component(name="api", error="/version has no image_build")
+    component = Component(
+        name="api",
+        sha=image.get("sha"),
+        branch=image.get("branch"),
+        timestamp=image.get("committed_at"),
+        timestamp_label="committed",
+        source=image.get("source"),
+        detail=image.get("subject"),
+    )
+    if component.sha is None:
+        component.error = "API is running an image with no commit stamped"
+    return component
+
+
+def collect(base_url: str = DEFAULT_BASE_URL) -> list[Component]:
+    """Probe both halves of prod, tolerating either being unreachable."""
+    base = base_url.rstrip("/")
+    components: list[Component] = []
+    for name, path, parse in (
+        ("frontend", FRONTEND_VERSION_PATH, parse_frontend),
+        ("api", API_VERSION_PATH, parse_api),
+    ):
+        try:
+            components.append(parse(fetch_json(f"{base}{path}")))
+        except ValueError as exc:
+            # The Worker's SPA fallback answers unknown paths with
+            # index.html, so HTML here means the stamp is simply absent.
+            missing = name == "frontend" and str(exc) == HTML_RESPONSE
+            components.append(
+                Component(name=name, error=NO_STAMP if missing else str(exc))
+            )
+    return components
+
+
+def _git(
+    *args: str, repo_root: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root or ROOT_DIR), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def commits_behind(sha: str, ref: str = "origin/dev") -> int | None:
+    """Count commits on `ref` that `sha` does not have.
+
+    Returns None when the commit or ref is missing from the local clone,
+    which means a stale checkout rather than a bad deploy.
+    """
+    result = _git("rev-list", "--count", f"{sha}..{ref}")
+    if result.returncode != 0:
+        return None
+    try:
+        return int(result.stdout.strip())
+    except ValueError:
+        return None
+
+
+def age(timestamp: str | None, now: datetime | None = None) -> str | None:
+    """Render an ISO-8601 timestamp as a compact age like `2h 5m ago`."""
+    if not timestamp:
+        return None
+    text = timestamp.replace("Z", "+00:00")
+    try:
+        moment = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    reference = now or datetime.now(timezone.utc)
+    seconds = int((reference - moment).total_seconds())
+    if seconds < 0:
+        return "in the future"
+    if seconds < 60:
+        return f"{seconds}s ago"
+    minutes, seconds = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m ago"
+    hours, minutes = divmod(minutes, 60)
+    if hours < 24:
+        return f"{hours}h {minutes}m ago"
+    days, hours = divmod(hours, 24)
+    return f"{days}d {hours}h ago"
+
+
+def format_component(
+    component: Component,
+    behind: int | None = None,
+    ref: str = "origin/dev",
+) -> str:
+    """Render one line of the human-readable status table."""
+    if component.error and component.sha is None:
+        return "  ".join([f"{component.name:<9}", "unknown", component.error])
+
+    parts = [f"{component.name:<9}"]
+    parts.append((component.sha or "")[:7] or "-------")
+    parts.append(component.branch or "-")
+
+    when = age(component.timestamp)
+    if when:
+        parts.append(f"{component.timestamp_label} {when}")
+    elif component.timestamp:
+        parts.append(f"{component.timestamp_label} {component.timestamp}")
+
+    if behind == 0:
+        parts.append(f"up to date with {ref}")
+    elif behind is not None:
+        plural = "" if behind == 1 else "s"
+        parts.append(f"{behind} commit{plural} behind {ref}")
+
+    if component.source:
+        parts.append(f"via {component.source}")
+    return "  ".join(parts)
+
+
+def as_dict(component: Component, behind: int | None = None) -> dict:
+    """Serialize one component for `--json`."""
+    return {
+        "name": component.name,
+        "sha": component.sha,
+        "branch": component.branch,
+        "timestamp": component.timestamp,
+        "timestamp_kind": component.timestamp_label or None,
+        "age": age(component.timestamp),
+        "commits_behind": behind,
+        "source": component.source,
+        "detail": component.detail,
+        "error": component.error,
+    }

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -166,8 +166,31 @@ Embedding generation → ring-llm microservice (not AWS Bedrock)
 Roadmap: [PR #301](https://github.com/neil-sriv/ring/pull/301) — frontend
 via Cloudflare Workers Routes, backend via CI-built SHA-tagged images.
 Frontend prod traffic already hits the Worker (`/*`); `/api/*` and
-`/.well-known/*` still pass through to this nginx. The steps below are
-the current backend flow.
+`/.well-known/*` still pass through to this nginx.
+
+The two halves ship on **different triggers**, so their commits routinely
+differ:
+
+| | Trigger | Push → live |
+|---|---------|-------------|
+| Frontend | Automatic, every push to `dev` | ~1 minute |
+| API | Manual `deploy_host.sh` on EC2 | whenever someone runs it |
+
+### Deploy the frontend (automatic)
+
+Cloudflare Workers Builds rebuilds and deploys the `ring-frontend` Worker
+on **every** push to `dev` — there is no path filter, so a backend-only
+commit still redeploys an identical bundle. Measured push-to-live across
+recent `dev` pushes: 56s, 57s, 59s, 59s, 65s, 93s.
+
+Nothing to run. To watch one:
+
+- The **Workers Builds: ring-frontend** check on the commit in GitHub. Its
+  summary links to the Cloudflare build and version. The check reports a
+  zero duration (Cloudflare posts it once, on completion), so use its
+  timestamp as the "live at" time, not as a build time.
+- [Cloudflare dashboard](https://dash.cloudflare.com/) → Compute →
+  `ring-frontend` → Builds, for logs and per-step timing.
 
 ### Publish API images (CI)
 
@@ -205,19 +228,36 @@ The sha must exist as `ring-api:<sha>` (a **Publish ring-api** run).
 `image_build.sha` **before** git/image/compose mutate and restores that
 image (`--skip-git`) if verify fails — not `git rev-parse HEAD`.
 
-Confirm what is actually running (no auth):
+Compose files: `compose.core.yml` + `compose.prod.yml` (+ `llm/compose.prod.llm.yml` if LLM is enabled).
+
+### Confirm what is live
 
 ```bash
-curl -sS -A 'ring-deploy-host/1.0' https://ring.neilsriv.tech/api/v1/version
+ring deploy status          # both halves, with age and lag vs origin/dev
+ring deploy status --json
 ```
 
-`image_build` is metadata baked into the API image (this is the running
-code). `git` is unavailable in prod after the cutover (no `./.git`
-mount). `docker.containers[].image_id` / `image_digest` come from a
-host-written snapshot (`.ring-runtime-version.json`, mounted read-only).
-The API does not talk to the Docker Engine.
+It reads two unauthenticated endpoints, either of which you can curl
+directly (Cloudflare rejects the default Python-urllib User-Agent with
+1010 / 403, hence the `-A`):
 
-Compose files: `compose.core.yml` + `compose.prod.yml` (+ `llm/compose.prod.llm.yml` if LLM is enabled).
+```bash
+curl -sS -A 'ring/1.0' https://ring.neilsriv.tech/version.json      # frontend
+curl -sS -A 'ring/1.0' https://ring.neilsriv.tech/api/v1/version    # API
+```
+
+`version.json` is written into the bundle at build time by
+[react/plugins/version-stamp.ts](../react/plugins/version-stamp.ts), from
+`WORKERS_CI_*` on Cloudflare, `RING_GIT_*` in the Docker image build, or
+the git CLI locally. Unknown paths fall through to the SPA's
+`index.html`, so an HTML body means that deploy predates the stamp. The
+same data renders in the app under **Settings → Build**.
+
+For the API, `image_build` is metadata baked into the image (this is the
+running code). `git` is unavailable in prod after the cutover (no
+`./.git` mount). `docker.containers[].image_id` / `image_digest` come
+from a host-written snapshot (`.ring-runtime-version.json`, mounted
+read-only). The API does not talk to the Docker Engine.
 
 ---
 
@@ -228,9 +268,9 @@ Cloudflare's 2026 dashboard is **Workers-first**. The create flow is
 "Connect to Git / Build output directory" form. Use Workers Builds.
 
 The React app is built on every PR and served at a `*.workers.dev`
-preview URL, pointed at the **production API** over CORS. Production
-traffic still serves the static build from nginx on EC2 (see topology
-above). Cloudflare is previews-only unless/until we cut prod over.
+preview URL, pointed at the **production API** over CORS. The same
+project also serves production `/*` from the `dev` branch (see
+[Deployment](#deployment)); the nginx SPA on EC2 is the rollback path.
 
 ### How it fits together
 

--- a/react/client.Dockerfile
+++ b/react/client.Dockerfile
@@ -16,6 +16,10 @@ RUN pnpm install
 
 ARG VITE_API_URL=${VITE_API_URL}
 ARG VITE_MAINTENANCE_MODE=${VITE_MAINTENANCE_MODE}
+# Read by plugins/version-stamp.ts to stamp dist/version.json.
+ARG RING_GIT_SHA
+ARG RING_GIT_SHORT_SHA
+ARG RING_GIT_BRANCH
 RUN pnpm run build
 
 # FROM base as runner

--- a/react/plugins/version-stamp.ts
+++ b/react/plugins/version-stamp.ts
@@ -102,25 +102,34 @@ export function resolveBuildVersion(
  * dev server serves an equivalent response from memory.
  */
 export function versionStamp(): Plugin {
+  // Resolved once so `built_at` names a build, not the moment of the
+  // request — the same thing it means on a real deploy.
   let payload = ""
+  const stamp = () => {
+    if (!payload) {
+      payload = `${JSON.stringify(resolveBuildVersion(), null, 2)}\n`
+    }
+    return payload
+  }
 
   return {
     name: "ring-version-stamp",
     buildStart() {
-      payload = `${JSON.stringify(resolveBuildVersion(), null, 2)}\n`
+      payload = ""
+      stamp()
     },
     generateBundle() {
       this.emitFile({
         type: "asset",
         fileName: VERSION_FILE_NAME,
-        source: payload,
+        source: stamp(),
       })
     },
     configureServer(server) {
       server.middlewares.use(`/${VERSION_FILE_NAME}`, (_req, res) => {
         res.setHeader("Content-Type", "application/json")
         res.setHeader("Cache-Control", "no-store")
-        res.end(`${JSON.stringify(resolveBuildVersion(), null, 2)}\n`)
+        res.end(stamp())
       })
     },
   }

--- a/react/plugins/version-stamp.ts
+++ b/react/plugins/version-stamp.ts
@@ -1,0 +1,127 @@
+import { execFileSync } from "node:child_process"
+import type { Plugin } from "vite"
+import { type BuildVersion, VERSION_FILE_NAME } from "../src/util/buildVersion"
+
+export { VERSION_FILE_NAME }
+
+export interface GitFields {
+  sha: string
+  short_sha: string
+  branch: string | null
+}
+
+function readEnv(environ: NodeJS.ProcessEnv, name: string): string | undefined {
+  const value = environ[name]?.trim()
+  return value ? value : undefined
+}
+
+function readGitFromCli(): GitFields | null {
+  const git = (...args: string[]): string | null => {
+    try {
+      return execFileSync("git", args, {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 5000,
+      }).trim()
+    } catch {
+      return null
+    }
+  }
+  const sha = git("rev-parse", "HEAD")
+  if (!sha) {
+    return null
+  }
+  const branch = git("rev-parse", "--abbrev-ref", "HEAD")
+  return {
+    sha,
+    short_sha: git("rev-parse", "--short", "HEAD") ?? sha.slice(0, 7),
+    // Detached-HEAD CI checkouts report "HEAD", which names no branch.
+    branch: branch && branch !== "HEAD" ? branch : null,
+  }
+}
+
+/**
+ * Identify the commit this bundle was built from.
+ *
+ * Cloudflare Workers Builds clones without a usable git history for our
+ * purposes but injects WORKERS_CI_*, so that wins. The Docker frontend
+ * image passes RING_GIT_* as build args. A laptop build falls back to the
+ * git CLI.
+ */
+export function resolveBuildVersion(
+  environ: NodeJS.ProcessEnv = process.env,
+  now: Date = new Date(),
+  readGit: () => GitFields | null = readGitFromCli,
+): BuildVersion {
+  const built_at = now.toISOString()
+
+  const workersSha = readEnv(environ, "WORKERS_CI_COMMIT_SHA")
+  if (workersSha) {
+    return {
+      sha: workersSha,
+      short_sha: workersSha.slice(0, 7),
+      branch: readEnv(environ, "WORKERS_CI_BRANCH") ?? null,
+      built_at,
+      source: "workers_ci",
+      build_uuid: readEnv(environ, "WORKERS_CI_BUILD_UUID") ?? null,
+    }
+  }
+
+  const envSha = readEnv(environ, "RING_GIT_SHA")
+  if (envSha) {
+    return {
+      sha: envSha,
+      short_sha: readEnv(environ, "RING_GIT_SHORT_SHA") ?? envSha.slice(0, 7),
+      branch: readEnv(environ, "RING_GIT_BRANCH") ?? null,
+      built_at,
+      source: "env",
+      build_uuid: null,
+    }
+  }
+
+  const git = readGit()
+  if (git) {
+    return { ...git, built_at, source: "git", build_uuid: null }
+  }
+
+  return {
+    sha: null,
+    short_sha: null,
+    branch: null,
+    built_at,
+    source: "unavailable",
+    build_uuid: null,
+  }
+}
+
+/**
+ * Emit `version.json` next to the bundle so a deployed frontend can say
+ * which commit it is and when it was built.
+ *
+ * Cloudflare Workers serves it as a static asset at `/version.json`; the
+ * dev server serves an equivalent response from memory.
+ */
+export function versionStamp(): Plugin {
+  let payload = ""
+
+  return {
+    name: "ring-version-stamp",
+    buildStart() {
+      payload = `${JSON.stringify(resolveBuildVersion(), null, 2)}\n`
+    },
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: VERSION_FILE_NAME,
+        source: payload,
+      })
+    },
+    configureServer(server) {
+      server.middlewares.use(`/${VERSION_FILE_NAME}`, (_req, res) => {
+        res.setHeader("Content-Type", "application/json")
+        res.setHeader("Cache-Control", "no-store")
+        res.end(`${JSON.stringify(resolveBuildVersion(), null, 2)}\n`)
+      })
+    },
+  }
+}

--- a/react/src/components/UserSettings/BuildInfo.tsx
+++ b/react/src/components/UserSettings/BuildInfo.tsx
@@ -1,0 +1,123 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { Badge } from "@/components/ui/badge"
+import { readVersionOptions } from "../../client/@tanstack/react-query.gen"
+import {
+  GITHUB_COMMIT_URL,
+  fetchBuildVersion,
+  formatAge,
+} from "../../util/buildVersion"
+
+interface DeployRowProps {
+  label: string
+  sha: string | null | undefined
+  branch: string | null | undefined
+  timestampLabel: string
+  timestamp: string | null | undefined
+  note?: string | null
+  error?: string | null
+}
+
+function DeployRow({
+  label,
+  sha,
+  branch,
+  timestampLabel,
+  timestamp,
+  note,
+  error,
+}: DeployRowProps) {
+  const age = formatAge(timestamp)
+
+  return (
+    <div className="flex flex-col gap-1 py-3 first:pt-0 last:pb-0">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm font-medium text-foreground">{label}</span>
+        {sha ? (
+          <a
+            href={`${GITHUB_COMMIT_URL}/${sha}`}
+            target="_blank"
+            rel="noreferrer"
+            className="font-mono text-sm text-primary underline underline-offset-2"
+          >
+            {sha.slice(0, 7)}
+          </a>
+        ) : (
+          <span className="text-sm text-muted-foreground">
+            {error ?? "unknown"}
+          </span>
+        )}
+        {branch ? <Badge variant="secondary">{branch}</Badge> : null}
+      </div>
+      {timestamp ? (
+        <span className="text-xs text-muted-foreground">
+          {timestampLabel} {age ?? timestamp}
+          {age ? ` · ${timestamp}` : ""}
+        </span>
+      ) : null}
+      {note ? (
+        <span className="text-xs text-muted-foreground">{note}</span>
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * Show which commit each half of the app is running.
+ *
+ * The frontend redeploys itself on every push (Cloudflare Workers Builds)
+ * while the API only moves on an explicit host rollout, so the two shas
+ * routinely differ.
+ */
+const BuildInfo = () => {
+  const frontend = useQuery({
+    queryKey: ["buildVersion"],
+    queryFn: fetchBuildVersion,
+    retry: false,
+    staleTime: 60_000,
+  })
+  const api = useQuery({ ...readVersionOptions(), retry: false })
+  const apiBuild = api.data?.image_build
+
+  return (
+    <div className="w-full">
+      <div className="flex flex-col gap-6">
+        <h3 className="text-sm font-semibold text-foreground">Build</h3>
+        <div className="rounded-xl border bg-card p-6 shadow-sm">
+          <div className="divide-y">
+            <DeployRow
+              label="Frontend"
+              sha={frontend.data?.sha}
+              branch={frontend.data?.branch}
+              timestampLabel="Deployed"
+              timestamp={frontend.data?.built_at}
+              note={
+                frontend.data?.build_uuid
+                  ? `Cloudflare build ${frontend.data.build_uuid}`
+                  : null
+              }
+              error={
+                frontend.isPending
+                  ? "loading…"
+                  : frontend.error?.message ?? "unknown"
+              }
+            />
+            <DeployRow
+              label="API"
+              sha={apiBuild?.sha}
+              branch={apiBuild?.branch}
+              timestampLabel="Committed"
+              timestamp={apiBuild?.committed_at}
+              note={apiBuild?.subject}
+              error={
+                api.isPending ? "loading…" : api.error?.message ?? "unknown"
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default BuildInfo

--- a/react/src/components/UserSettings/BuildInfo.tsx
+++ b/react/src/components/UserSettings/BuildInfo.tsx
@@ -77,7 +77,12 @@ const BuildInfo = () => {
     staleTime: 60_000,
   })
   const api = useQuery({ ...readVersionOptions(), retry: false })
-  const apiBuild = api.data?.image_build
+  // Prod runs the image filesystem with no .git, so image_build is the
+  // only truthful source there; a bind-mounted dev container is the
+  // other way round.
+  const apiBuild = api.data?.image_build.sha
+    ? api.data.image_build
+    : api.data?.git
 
   return (
     <div className="w-full">

--- a/react/src/routes/_layout/settings.tsx
+++ b/react/src/routes/_layout/settings.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router"
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import Appearance from "../../components/UserSettings/Appearance"
+import BuildInfo from "../../components/UserSettings/BuildInfo"
 import ChangePassword from "../../components/UserSettings/ChangePassword"
 import DeleteAccount from "../../components/UserSettings/DeleteAccount"
 import UserInformation from "../../components/UserSettings/UserInformation"
@@ -10,6 +11,7 @@ const tabsConfig = [
   { title: "My profile", component: UserInformation, value: "profile" },
   { title: "Password", component: ChangePassword, value: "password" },
   { title: "Appearance", component: Appearance, value: "appearance" },
+  { title: "Build", component: BuildInfo, value: "build" },
   { title: "Danger zone", component: DeleteAccount, value: "danger" },
 ]
 

--- a/react/src/util/buildVersion.ts
+++ b/react/src/util/buildVersion.ts
@@ -1,0 +1,72 @@
+/**
+ * The frontend's build stamp: which commit this bundle came from, and when
+ * it was built.
+ *
+ * `react/plugins/version-stamp.ts` writes it into the bundle at build time
+ * and `dev_util/deploy_status.py` reads it back off a deployed origin.
+ * Field names mirror the backend's GET /api/v1/version payload.
+ */
+
+export const VERSION_FILE_NAME = "version.json"
+
+export type BuildVersionSource = "workers_ci" | "env" | "git" | "unavailable"
+
+export interface BuildVersion {
+  sha: string | null
+  short_sha: string | null
+  branch: string | null
+  built_at: string
+  source: BuildVersionSource
+  build_uuid: string | null
+}
+
+export const GITHUB_COMMIT_URL = "https://github.com/neil-sriv/ring/commit"
+
+/**
+ * Read the stamp the running frontend was served with.
+ *
+ * Unknown paths fall through to the SPA's index.html rather than 404ing,
+ * so a non-JSON body means this deploy has no stamp.
+ */
+export async function fetchBuildVersion(): Promise<BuildVersion> {
+  const response = await fetch(`/${VERSION_FILE_NAME}`, { cache: "no-store" })
+  if (!response.ok) {
+    throw new Error(`version stamp request failed (${response.status})`)
+  }
+  const body = await response.text()
+  if (body.trimStart().startsWith("<")) {
+    throw new Error("no version stamp on this deploy")
+  }
+  return JSON.parse(body) as BuildVersion
+}
+
+/** Render an ISO-8601 timestamp as a compact age like `2h 5m ago`. */
+export function formatAge(
+  timestamp: string | null | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (!timestamp) {
+    return null
+  }
+  const moment = new Date(timestamp)
+  if (Number.isNaN(moment.getTime())) {
+    return null
+  }
+  const seconds = Math.floor((now.getTime() - moment.getTime()) / 1000)
+  if (seconds < 0) {
+    return "just now"
+  }
+  if (seconds < 60) {
+    return `${seconds}s ago`
+  }
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) {
+    return `${minutes}m ago`
+  }
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) {
+    return `${hours}h ${minutes % 60}m ago`
+  }
+  const days = Math.floor(hours / 24)
+  return `${days}d ${hours % 24}h ago`
+}

--- a/react/tsconfig.node.json
+++ b/react/tsconfig.node.json
@@ -7,5 +7,5 @@
     "allowSyntheticDefaultImports": true,
     "strict": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "plugins/**/*.ts"]
 }

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from "vite"
 import { VitePWA, type VitePWAOptions } from "vite-plugin-pwa"
 import topLevelAwait from "vite-plugin-top-level-await"
 import wasm from "vite-plugin-wasm"
+import { VERSION_FILE_NAME, versionStamp } from "./plugins/version-stamp"
 
 const pwaOptions: Partial<VitePWAOptions> = {
   mode: "development",
@@ -46,6 +47,8 @@ const pwaOptions: Partial<VitePWAOptions> = {
   },
   injectManifest: {
     maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
+    // A precached build stamp would keep reporting the previous deploy.
+    globIgnores: ["**/node_modules/**/*", `**/${VERSION_FILE_NAME}`],
   },
 }
 
@@ -92,6 +95,7 @@ export default defineConfig({
     VitePWA({ ...pwaOptions, registerType: "autoUpdate" }),
     wasm(),
     topLevelAwait(),
+    versionStamp(),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Cloudflare Workers Builds redeploys the frontend on **every** push to `dev` (no path filter), and it is live about a minute later. Measured push-to-live across the six `dev` pushes since the Worker was connected: 56s, 57s, 59s, 59s, 65s, 93s. This PR's own preview build took 58s.

Nothing recorded that. The only trace is the `Workers Builds: ring-frontend` check on the commit, which Cloudflare posts once on completion with `started_at == completed_at`, so GitHub shows a zero-second build and no record of what is currently serving. The API already answers this for itself at `GET /api/v1/version`; the frontend had no equivalent.

## What

- `react/plugins/version-stamp.ts` — a Vite plugin that emits `dist/version.json` with the commit, branch, build time, and Cloudflare build UUID. Sources, in order: `WORKERS_CI_*` (Workers Builds), `RING_GIT_*` (Docker image build), then the local git CLI. Excluded from the service worker precache so it never reports the previous deploy, and served from memory by the dev server.
- `ring deploy status` — probes `/version.json` and `/api/v1/version`, printing what each half is running, how long ago, and how far behind `origin/dev`. `--json` for scripts.
- **Settings → Build** — the same two commits in the app, each linking to its GitHub commit.
- `client.Dockerfile` passes `RING_GIT_*` into the build stage so the nginx rollback path stamps too.
- Docs: `docs/infrastructure.md` gains a frontend-deploy section with the measured timing and where to look; the "Cloudflare is previews-only" paragraph was stale and now matches reality.

The two halves of prod ship on different triggers, so their commits routinely differ — that is the thing this makes legible.

## Verification

**Real Cloudflare deploy.** This PR's own preview Worker serves the stamp, with the `build_uuid` matching the build linked from the GitHub check:

```
$ curl -sS https://neil-cursor-deploy-version-visibility-1a87-ring-frontend.neil-srivastava1.workers.dev/version.json
{
  "sha": "2ce8c56168213f299ae1a543e3ca071d6f02244c",
  "short_sha": "2ce8c56",
  "branch": "neil/cursor/deploy-version-visibility-1a87",
  "built_at": "2026-08-11T15:47:57.020Z",
  "source": "workers_ci",
  "build_uuid": "09c9ebb2-90ee-40c9-8274-f5d733f26888"
}
```

Served as `content-type: application/json` with `cache-control: public, max-age=0, must-revalidate`, so it cannot go stale.

**`ring deploy status`** against that preview and against live prod (which predates the stamp, exercising the missing-stamp path):

```
$ ring deploy status --base-url https://neil-cursor-...workers.dev
  frontend   2ce8c56  neil/cursor/deploy-version-visibility-1a87  built 3m ago  up to date with origin/dev  via workers_ci
  api        unknown  served HTML, not JSON

$ ring deploy status
  frontend   unknown  no /version.json — this deploy predates the build stamp
  api        195c464  dev  committed 8h 58m ago  1 commit behind origin/dev  via image_env
```

**The other two stamp sources**, driven by env:

```
WORKERS_CI_COMMIT_SHA=... → "source": "workers_ci"
RING_GIT_SHA=...          → "source": "env"
(neither set)             → "source": "git"
```

**Gates.** `ring check lint` clean, `npx tsc --noEmit` clean, `pnpm run lint` clean, `ring test run` 333 passed.

**Settings → Build**, showing both commits with the frontend deploy time:

![Settings Build tab showing frontend and API commits](https://cursor.com/artifacts/c/art-1cbc0ad9-c0e1-40b6-a681-317c188b6193)

<a href="https://cursor.com/agents/bc-019ff165-72e9-7db3-9b93-27d5cce71a87/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_build_tab_shows_deployed_commits.mp4"><img src="https://cursor.com/artifacts/c/art-991fcfe8-bbd7-455e-bf0a-a0d6e07c92c5" alt="settings_build_tab_shows_deployed_commits.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff165-72e9-7db3-9b93-27d5cce71a87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff165-72e9-7db3-9b93-27d5cce71a87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

