### PR TITLE
fix(email): link to the app over https so emailed links stay same-origin

### DIFF
--- a/ring/fastapp/config.py
+++ b/ring/fastapp/config.py
@@ -42,6 +42,8 @@ class RingConfig(BaseSettings):
         JWT_SIGNING_ALGORITHM (str): Algorithm used for JWT signing
         VAPID_PRIVATE_KEY (str): Private key for VAPID web push notifications
         root_path (str): Base path for API routes (default: "/api/v1")
+        APP_BASE_URL (str): Public origin the web app is served on, used to
+            build links in outbound email
         BUCKET_NAME (str): S3 bucket name for file storage (default: "rings3files")
         DISABLE_SCHEDULER (bool): Skip APScheduler lifespan start/shutdown
         BACKEND_CORS_ORIGINS (list[AnyUrl] | str): List of allowed CORS origins
@@ -56,6 +58,10 @@ class RingConfig(BaseSettings):
     JWT_SIGNING_ALGORITHM: str
     VAPID_PRIVATE_KEY: str
     root_path: str = "/api/v1"
+    # Must stay on the scheme and host the frontend is served from: the build
+    # bakes in an absolute VITE_API_URL, so a link on a different origin makes
+    # every API call from that page cross-origin.
+    APP_BASE_URL: str = "https://ring.neilsriv.tech"
     BUCKET_NAME: str = "rings3files"
     # When true, skip APScheduler start/shutdown (used by cloud-prod-db mode so a
     # local API pointed at Cockroach Cloud does not run prod scheduled jobs).

--- a/ring/lib/app_links.py
+++ b/ring/lib/app_links.py
@@ -1,0 +1,23 @@
+"""Absolute links into the web app, for use in outbound email."""
+
+from __future__ import annotations
+
+from ring.fastapp.config import get_config
+
+
+def app_url(path: str) -> str:
+    """Build an absolute URL into the web app.
+
+    Emailed links have to use the scheme the app is actually served on. The
+    frontend build bakes in an absolute API origin (`VITE_API_URL`), so a link
+    on the wrong scheme drops the recipient on an origin where every API call
+    is cross-origin and the CORS preflight is rejected.
+
+    Args:
+        path (str): Path within the app, with or without a leading slash
+
+    Returns:
+        str: Absolute URL, e.g. `https://ring.neilsriv.tech/loops/lttr_abc123`
+    """
+    base = get_config().APP_BASE_URL.rstrip("/")
+    return f"{base}/{path.lstrip('/')}"

--- a/ring/parties/crud/authn.py
+++ b/ring/parties/crud/authn.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 
 from ring.async_scheduler.scheduler import job_factory
 from ring.email_util import CHARSET, EmailDraft, send_email
+from ring.lib.app_links import app_url
 from ring.parties.models.user_model import User
 from ring.security import get_password_hash
 
@@ -57,13 +58,13 @@ def construct_password_reset_email(
     <spacer type="" size="">
     <span>Click the link below to reset your password.</span>
     <spacer type="" size="">
-    <h3>Please use this custom URL to reset your password: <a href="http://ring.neilsriv.tech/reset-password/{token}">http://ring.neilsriv.tech/reset-password/{token}</a></h2>
+    <h3>Please use this custom URL to reset your password: <a href="{reset_url}">{reset_url}</a></h2>
     <p>
     A password reset was requested for your Ring account. If you did not request this, please ignore this email.
     </p>
     </body>
     </html>
-                """.format(token=token)
+                """.format(reset_url=app_url(f"reset-password/{token}"))
     return EmailDraft(
         destination={"ToAddresses": [recipient]},
         message={

--- a/ring/parties/crud/invite.py
+++ b/ring/parties/crud/invite.py
@@ -13,6 +13,7 @@ from sqlalchemy import select
 from ring.api_identifier import util as api_identifier_crud
 from ring.async_scheduler.scheduler import job_factory
 from ring.email_util import CHARSET, EmailDraft, send_email
+from ring.lib.app_links import app_url
 from ring.parties.crud.one_time_token import generate_token, validate_token
 from ring.parties.crud.user import get_user_by_email
 from ring.parties.models.group_model import Group
@@ -195,13 +196,15 @@ def construct_invite_email(
     <spacer type="" size="">
     <span>Click the link below to join the group and start creating newsletters!</span>
     <spacer type="" size="">
-    <h3>Please use this custom URL to create an account: <a href="http://ring.neilsriv.tech/register/{token}">http://ring.neilsriv.tech/register/{token}</a></h2>
+    <h3>Please use this custom URL to create an account: <a href="{register_url}">{register_url}</a></h2>
     <p>
     You've been invited to join a Ring Newsletter! Ring is a custom newsletter platform made by Neil Srivastava that allows you to create newsletters with your friends.
     </p>
     </body>
     </html>
-                """.format(group_name=group.name, token=token)
+                """.format(
+        group_name=group.name, register_url=app_url(f"register/{token}")
+    )
     return EmailDraft(
         destination={"ToAddresses": [recipient]},
         message={

--- a/ring/tasks/crud/reminder_email_task.py
+++ b/ring/tasks/crud/reminder_email_task.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from ring.email_util import EmailDraft, construct_email_draft
 from ring.letters.constants import LetterStatus
+from ring.lib.app_links import app_url
 
 
 def construct_reminder_email(
@@ -51,14 +52,14 @@ def construct_reminder_email(
     <head></head>
     <body>
     <h1>Ring Reminder: Last day to {subject_text} for {group_name}</h1>
-    <h2>Check out the newsletter online at <a href="http://ring.neilsriv.tech/loops/{letter_api_id}">http://ring.neilsriv.tech</a></h2>
+    <h2>Check out the newsletter online at <a href="{letter_url}">{letter_url}</a></h2>
     <p>Today is the last day to {subject_text} for the newsletter. Please visit the link above to {subject_text}.</p>
     </body>
     </html>
                 """.format(
         subject_text=subject_text,
         group_name=group_name,
-        letter_api_id=letter_api_id,
+        letter_url=app_url(f"loops/{letter_api_id}"),
     )
 
     # Try to send the email.

--- a/ring/tasks/crud/response_open_email_task.py
+++ b/ring/tasks/crud/response_open_email_task.py
@@ -8,6 +8,7 @@ from UPCOMING to IN_PROGRESS status).
 from __future__ import annotations
 
 from ring.email_util import EmailDraft, construct_email_draft
+from ring.lib.app_links import app_url
 
 
 def construct_response_open_email(
@@ -36,11 +37,11 @@ def construct_response_open_email(
 
 The newsletter {letter_title} is now ready for your responses. Head over to Ring to share your answers to this week's questions.
 
-Visit: http://ring.neilsriv.tech/loops/{letter_api_id}
+Visit: {letter_url}
 """.format(
         group_name=group_name,
         letter_title=letter_title,
-        letter_api_id=letter_api_id,
+        letter_url=app_url(f"loops/{letter_api_id}"),
     )
 
     # The HTML body of the email.
@@ -48,14 +49,14 @@ Visit: http://ring.neilsriv.tech/loops/{letter_api_id}
     <head></head>
     <body>
     <h1>Ring Newsletter for {group_name} is now open for responses!</h1>
-    <h2>Check out the newsletter online at <a href="http://ring.neilsriv.tech/loops/{letter_api_id}">http://ring.neilsriv.tech</a></h2>
+    <h2>Check out the newsletter online at <a href="{letter_url}">{letter_url}</a></h2>
     <p>The newsletter <strong>{letter_title}</strong> is now ready for your responses.</p>
     <p>Head over to Ring to share your answers to this week's questions!</p>
     </body>
     </html>
                 """.format(
         group_name=group_name,
-        letter_api_id=letter_api_id,
+        letter_url=app_url(f"loops/{letter_api_id}"),
         letter_title=letter_title,
     )
 

--- a/ring/tasks/crud/send_email_task.py
+++ b/ring/tasks/crud/send_email_task.py
@@ -11,6 +11,7 @@ import html
 import re
 
 from ring.email_util import EmailDraft, construct_email_draft
+from ring.lib.app_links import app_url
 
 _URL_RE = re.compile(r"https?://[^\s<>\"]+")
 
@@ -195,7 +196,7 @@ def construct_send_letter_email(
                   You can also read and share this newsletter online:
                 </p>
                 <p style="margin:0 0 4px;">
-                  <a href="http://ring.neilsriv.tech/loops/{letter_api_id}" style="color:#2b6cb0; text-decoration:underline; font-size:14px;">http://ring.neilsriv.tech/loops/{letter_api_id}</a>
+                  <a href="{letter_url}" style="color:#2b6cb0; text-decoration:underline; font-size:14px;">{letter_url}</a>
                 </p>
               </td>
             </tr>
@@ -219,7 +220,7 @@ def construct_send_letter_email(
 </html>
 """.format(
         title=title,
-        letter_api_id=letter_api_id,
+        letter_url=app_url(f"loops/{letter_api_id}"),
         question_html=question_html,
     )
 

--- a/ring/tests/unit/lib/app_links_test.py
+++ b/ring/tests/unit/lib/app_links_test.py
@@ -1,0 +1,99 @@
+"""Tests for the app links embedded in outbound email.
+
+Emailed links have to stay on the origin the frontend is served from. The
+frontend build bakes in an absolute `VITE_API_URL`, so a link on a different
+scheme lands the recipient on an origin where every API call is cross-origin
+and the CORS preflight is rejected - an `http://` reset link is what broke
+password resets in production.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from ring.email_util import EmailDraft
+from ring.letters.constants import LetterStatus
+from ring.lib.app_links import app_url
+from ring.parties.crud.authn import construct_password_reset_email
+from ring.parties.crud.invite import construct_invite_email
+from ring.tasks.crud.reminder_email_task import construct_reminder_email
+from ring.tasks.crud.response_open_email_task import (
+    construct_response_open_email,
+)
+from ring.tasks.crud.send_email_task import construct_send_letter_email
+from ring.tests.factories.parties.group_factory import GroupFactory
+
+
+def _bodies(draft: EmailDraft) -> list[str]:
+    return [part["Data"] for part in draft.message["Body"].values()]
+
+
+class TestAppUrl:
+    """Test suite for building absolute links into the web app."""
+
+    def test_builds_an_https_url_for_a_path(self) -> None:
+        url = app_url("loops/lttr_abc123")
+
+        assert url.startswith("https://")
+        assert url.endswith("/loops/lttr_abc123")
+
+    def test_leading_slash_does_not_double_up(self) -> None:
+        assert app_url("/loops/lttr_abc123") == app_url("loops/lttr_abc123")
+
+
+class TestOutboundEmailLinks:
+    """Every email that links into the app must link to it over https."""
+
+    def test_emails_link_to_the_app_over_https(
+        self, db_session: Session
+    ) -> None:
+        group = GroupFactory.create()
+        db_session.commit()
+        letter_api_id = "lttr_abc123"
+        letter_url = app_url(f"loops/{letter_api_id}")
+
+        drafts_and_links: list[tuple[EmailDraft, str]] = [
+            (
+                construct_password_reset_email(
+                    "user@example.com", "reset-token"
+                ),
+                app_url("reset-password/reset-token"),
+            ),
+            (
+                construct_invite_email(
+                    "user@example.com", group, "invite-token"
+                ),
+                app_url("register/invite-token"),
+            ),
+            (
+                construct_send_letter_email(
+                    ["user@example.com"],
+                    "Ring Newsletter #1",
+                    letter_api_id,
+                    {"Favorite memory?": [("Dana: A good one", [])]},
+                ),
+                letter_url,
+            ),
+            (
+                construct_response_open_email(
+                    ["user@example.com"], group.name, letter_api_id, "#1"
+                ),
+                letter_url,
+            ),
+            (
+                construct_reminder_email(
+                    ["user@example.com"],
+                    group.name,
+                    letter_api_id,
+                    LetterStatus.IN_PROGRESS,
+                ),
+                letter_url,
+            ),
+        ]
+
+        insecure_base = app_url("").replace("https://", "http://", 1)
+        for draft, expected_link in drafts_and_links:
+            bodies = _bodies(draft)
+            assert any(expected_link in body for body in bodies), expected_link
+            for body in bodies:
+                assert insecure_base not in body, expected_link

--- a/ring/tests/unit/tasks/crud/response_open_email_task_test.py
+++ b/ring/tests/unit/tasks/crud/response_open_email_task_test.py
@@ -7,6 +7,7 @@ open for responses.
 
 from __future__ import annotations
 
+from ring.lib.app_links import app_url
 from ring.tasks.crud.response_open_email_task import (
     construct_response_open_email,
 )
@@ -49,7 +50,7 @@ class TestResponseOpenEmailTask:
         assert group_name in html_body
         assert letter_api_id in html_body
         assert letter_title in html_body
-        assert "http://ring.neilsriv.tech/loops/" in html_body
+        assert app_url(f"loops/{letter_api_id}") in html_body
 
         # Check plain text body
         text_body = email_draft.message["Body"]["Text"]["Data"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This is the actual cause of the reported password reset failures — the `OPTIONS ... 400` in the API log. My earlier PRs (#312, #313) fixed real but different problems and would not have moved this.

## What the 400 is

A 400 on an `OPTIONS` request is Starlette's `CORSMiddleware` rejecting a preflight. The body says so:

```
$ curl -X OPTIONS https://ring.neilsriv.tech/api/v1/reset-password/faketoken123 \
    -H 'Origin: http://ring.neilsriv.tech' \
    -H 'Access-Control-Request-Method: POST' \
    -H 'Access-Control-Request-Headers: content-type'
Disallowed CORS origin
```

## Why a preflight happens at all

The deployed bundle hardcodes the API origin — from `/assets/index-BZq43jft.js` on production right now:

```js
hR = "https://ring.neilsriv.tech"
...
baseURL: `${hR}/api/v1`
```

Meanwhile every outbound email linked to `http://ring.neilsriv.tech/...`. So a recipient who clicks a link in an email loads the app on the **http** origin, and from there the baked-in `https://` API base is cross-origin (scheme mismatch). The reset POST carries `Content-Type: application/json`, so the browser preflights it, the API rejects the `http://` origin, and the POST never runs. Nothing reaches the endpoint, which is why the reset silently fails.

Users who reach the app the normal way — typing or bookmarking `https://ring.neilsriv.tech` — are same-origin and never exercise CORS at all, which is why only the email-driven flows broke.

Two supporting details worth knowing:

- Cloudflare fronts the domain and serves plain HTTP with a `200` rather than upgrading, so the recipient really does stay on `http://`. `prod.nginx.conf` has an http→https redirect, but Cloudflare answers first.
- Production's CORS allow-list currently matches nothing relevant: preflights from `https://ring.neilsriv.tech`, `https://www.ring.neilsriv.tech`, `http://localhost:5173` and the Workers preview origins all return `Disallowed CORS origin`. That has been invisible because prod is normally same-origin.

`/reset-password` was the loudest casualty, but `construct_invite_email`, `construct_send_letter_email`, `construct_response_open_email` and `construct_reminder_email` all had the same `http://` link, so invite registration and "read it online" links were breaking the same way once the user landed on http.

## Change

- `RingConfig.APP_BASE_URL`, defaulting to `https://ring.neilsriv.tech`. The default matches production, so **no prod `.env` change is required to deploy this**.
- `ring/lib/app_links.py` with `app_url(path)`, so the host is written once instead of being pasted into six templates.
- All five email builders now link through `app_url`.

No schema, API surface or frontend change.

## Test plan

- [x] New `ring/tests/unit/lib/app_links_test.py` asserts every email builder emits its https link and that no email body contains a plain-http link to the app host — the invariant that broke here.
- [x] Updated `response_open_email_task_test.py`, which asserted the `http://` URL.
- [x] `ring test run` — 336 passed.
- [x] `ring check lint`
- [x] Rendered the emails from the running API to confirm the links:

```
password reset link: https://ring.neilsriv.tech/reset-password/n_2CcfWgC6ZbPAwV1O1a8ksWCsoTekbfc5joW4TU0s8
letter link (html):  https://ring.neilsriv.tech/loops/lttr_abc123
letter link (text):  Visit: https://ring.neilsriv.tech/loops/lttr_abc123
```

- [x] Confirmed the before/after against production:

```
OLD email link -> page origin http://ring.neilsriv.tech, API base https://ring.neilsriv.tech (cross-origin)
  preflight OPTIONS  -> 400 Disallowed CORS origin
  (browser blocks the POST, endpoint never runs)

NEW email link -> page origin https://ring.neilsriv.tech = API origin (same-origin, no preflight)
  POST               -> {"detail":"Invalid token"} 400
  (request reaches the endpoint; 400 here is the app rejecting a fake token)
```

## Emails already in inboxes

This fixes links sent from now on. Reset emails already delivered still carry `http://` links and will keep failing. Two things fix those, and neither is code in this PR:

1. Turn on **Always Use HTTPS** in Cloudflare for `ring.neilsriv.tech` (SSL/TLS → Edge Certificates). That upgrades every stale link, including ones that predate this change. Recommended regardless.
2. Add the app's own origin to `BACKEND_CORS_ORIGINS` in the server `.env` so cross-origin calls are not a hard failure. Worth doing for the Workers preview deploys described in `docs/infrastructure.md`, but do not add the `http://` origin — upgrading the scheme is the right fix, not blessing plaintext.

I am also opening a small frontend PR that upgrades an `http://` page to `https://` when the API base is https on the same host, which rescues the already-sent links without waiting on the Cloudflare toggle.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff134-bfc7-7a8b-ba70-06ed750a5095?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff134-bfc7-7a8b-ba70-06ed750a5095&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

