### PR TITLE
fix(frontend): upgrade an http page to https when the API origin is https

### DIFF
--- a/react/src/main.tsx
+++ b/react/src/main.tsx
@@ -31,6 +31,17 @@ if (
 }
 /**/
 
+/* vite Config */
+const apiOrigin = import.meta.env.VITE_API_URL ?? ""
+
+const httpsUrl = httpsUpgradeUrl(window.location, apiOrigin)
+if (httpsUrl) {
+  window.location.replace(httpsUrl)
+  // location.replace does not stop this module; abort so the client,
+  // router, and React tree never boot on the insecure origin.
+  throw new Error("Redirecting to HTTPS")
+}
+
 /* PWA: auto-reload when a new service worker is ready after deploy.
    Skip in DEV when SW_DEV=false (cloud HTTP Vite) — VitePWA already disables
    the dev SW, but calling registerSW still races and noisy-fails. */
@@ -38,14 +49,6 @@ if (!import.meta.env.DEV || import.meta.env.VITE_SW_DEV !== "false") {
   registerSW({ immediate: true })
 }
 /**/
-
-/* vite Config */
-const apiOrigin = import.meta.env.VITE_API_URL ?? ""
-
-const httpsUrl = httpsUpgradeUrl(window.location, apiOrigin)
-if (httpsUrl) {
-  window.location.replace(httpsUrl)
-}
 
 client.setConfig({
   baseURL: apiOrigin ? `${apiOrigin}/api/v1` : "/api/v1",

--- a/react/src/main.tsx
+++ b/react/src/main.tsx
@@ -17,6 +17,7 @@ import { readUserMePartiesMeGetOptions } from "./client/@tanstack/react-query.ge
 import { client } from "./client/client.gen"
 import { initGlobalKeyboardShortcuts } from "./lib/globalKeyboardShortcuts"
 import { isPublicAuthPath } from "./util/authRoutes"
+import { httpsUpgradeUrl } from "./util/httpsUpgrade"
 
 /* Dark mode initialization */
 const savedTheme = localStorage.getItem("theme")
@@ -40,6 +41,12 @@ if (!import.meta.env.DEV || import.meta.env.VITE_SW_DEV !== "false") {
 
 /* vite Config */
 const apiOrigin = import.meta.env.VITE_API_URL ?? ""
+
+const httpsUrl = httpsUpgradeUrl(window.location, apiOrigin)
+if (httpsUrl) {
+  window.location.replace(httpsUrl)
+}
+
 client.setConfig({
   baseURL: apiOrigin ? `${apiOrigin}/api/v1` : "/api/v1",
   auth: async () => {

--- a/react/src/util/httpsUpgrade.ts
+++ b/react/src/util/httpsUpgrade.ts
@@ -1,0 +1,40 @@
+interface PageLocation {
+  protocol: string
+  host: string
+  pathname: string
+  search: string
+  hash: string
+}
+
+/**
+ * URL to send the page to when it was loaded over http but talks to an https
+ * API on the same host, or null when nothing needs to change.
+ *
+ * The build bakes an absolute API origin into the bundle, so an http page
+ * makes every API call cross-origin and the preflight is rejected. Links we
+ * emailed before the backend switched to https land users exactly there.
+ *
+ * Only the same host is upgraded: an http dev server pointed at an https API
+ * on another host is a deliberate setup and is left alone.
+ */
+export function httpsUpgradeUrl(
+  location: PageLocation,
+  apiOrigin: string,
+): string | null {
+  if (location.protocol !== "http:" || !apiOrigin.startsWith("https://")) {
+    return null
+  }
+
+  let apiHost: string
+  try {
+    apiHost = new URL(apiOrigin).host
+  } catch {
+    return null
+  }
+
+  if (apiHost !== location.host) {
+    return null
+  }
+
+  return `https://${location.host}${location.pathname}${location.search}${location.hash}`
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Companion to #315, which fixes the emailed links themselves. This one rescues the links **already sitting in people's inboxes**, which #315 cannot reach.

## Why

The build bakes an absolute API origin into the bundle — production right now serves `baseURL: "https://ring.neilsriv.tech/api/v1"`. A page loaded over `http://ring.neilsriv.tech` therefore talks to the API cross-origin, the browser preflights, and the API answers `400 Disallowed CORS origin`. That is the failure in the reported log.

Every reset and invite email sent so far links to `http://ring.neilsriv.tech/...`, so recipients land on exactly that broken origin. Changing the templates only helps mail sent from now on.

## Change

`httpsUpgradeUrl()` in `react/src/util/httpsUpgrade.ts` decides whether the current page needs upgrading, and `main.tsx` acts on it before anything touches the API client.

The guard is deliberately narrow — it fires only when the page is `http:`, the configured API origin is `https:`, **and** the API host equals the page host. An http dev server pointed at an https API on a different host is a deliberate setup (the OrbStack `VITE_API_URL=https://localhost` flow in `ring-cloud-dev`) and is left alone. Query string and hash are preserved so a reset token or `?next=` survives the upgrade.

`window.location.replace` is used rather than `href` so the broken http URL does not end up in the back-history.

## Test plan

- [x] Exercised the decision directly against every setup in the repo, including the three that must not redirect:

```
PASS  prod: emailed http link, https API same host
      http://ring.neilsriv.tech/reset-password/tok123
      -> https://ring.neilsriv.tech/reset-password/tok123

PASS  prod: already https                                    -> (no redirect)
PASS  cloud dev: http vite, same-origin API (empty VITE_API_URL) -> (no redirect)
PASS  orbstack dev: http vite, https API on another host      -> (no redirect)
PASS  workers preview: https page, https API elsewhere        -> (no redirect)

PASS  query and hash preserved
      http://ring.neilsriv.tech/login?next=%2Fgroups#top
      -> https://ring.neilsriv.tech/login?next=%2Fgroups#top
```

- [x] Browser regression check on cloud dev (`http://localhost:5173`, same-origin API): the guard does not fire, the URL stays on http, and a full password reset plus sign-in works end to end. This is the case that would break the whole app if the guard were too eager.

<a href="https://cursor.com/agents/bc-019ff134-bfc7-7a8b-ba70-06ed750a5095/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhttp_dev_unaffected_by_https_upgrade_guard.mp4"><img src="https://cursor.com/artifacts/c/art-4fdaaeac-876b-4aa4-a010-f5b64e958a6c" alt="http_dev_unaffected_by_https_upgrade_guard.mp4" /></a>

- [x] `npx tsc --noEmit`
- [x] `pnpm run lint` (Biome)
- [x] `pnpm run build`

## Note

This is a client-side safety net; it only runs once the SPA has loaded. Turning on **Always Use HTTPS** in Cloudflare for `ring.neilsriv.tech` fixes stale links at the edge for every request, and is still worth doing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff134-bfc7-7a8b-ba70-06ed750a5095?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff134-bfc7-7a8b-ba70-06ed750a5095&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

