### PR TITLE
fix(frontend): sync letter cache after draft response upsert

### DIFF
--- a/react/src/components/Question/DraftQuestion.tsx
+++ b/react/src/components/Question/DraftQuestion.tsx
@@ -330,14 +330,78 @@ function DraftQuestion({
     setDeleteOpen(false)
   }
 
+  const letterQueryKey = readLetterLettersLetterLetterApiIdGetQueryKey({
+    path: { letter_api_id: loopApiId },
+  })
+
   const handleUpsert = async (responseText: string): Promise<void> => {
-    await upsertResponseQuestionsQuestionQuestionApiIdUpsertResponsePost({
-      path: { question_api_id: question.api_identifier },
-      body: {
-        response_text: responseText,
-        participant_api_identifier: currentUser.api_identifier,
-      },
-      throwOnError: true,
+    const { data: updatedQuestion } =
+      await upsertResponseQuestionsQuestionQuestionApiIdUpsertResponsePost({
+        path: { question_api_id: question.api_identifier },
+        body: {
+          response_text: responseText,
+          participant_api_identifier: currentUser.api_identifier,
+        },
+        throwOnError: true,
+      })
+
+    // Keep letter cache in sync so navigate-away → return within staleTime
+    // still shows the saved text (debounce and unmount flush).
+    queryClient.setQueryData<PublicLetter>(letterQueryKey, (oldData) => {
+      if (!oldData) {
+        return oldData
+      }
+
+      return {
+        ...oldData,
+        questions: oldData.questions.map((q) => {
+          if (q.api_identifier !== question.api_identifier) {
+            return q
+          }
+
+          const existingIdx = q.responses.findIndex(
+            (r) =>
+              r.participant.api_identifier === currentUser.api_identifier,
+          )
+          if (existingIdx >= 0) {
+            const responses = [...q.responses]
+            responses[existingIdx] = {
+              ...responses[existingIdx],
+              response_text: responseText,
+            }
+            return { ...q, responses }
+          }
+
+          const knownIds = new Set(q.responses.map((r) => r.api_identifier))
+          const created =
+            updatedQuestion?.responses.find(
+              (r) => !knownIds.has(r.api_identifier),
+            ) ??
+            updatedQuestion?.responses.find(
+              (r) => r.response_text === responseText,
+            )
+          if (!created) {
+            return q
+          }
+
+          return {
+            ...q,
+            responses: [
+              ...q.responses,
+              {
+                ...created,
+                participant: {
+                  email: currentUser.email,
+                  name: currentUser.name,
+                  api_identifier: currentUser.api_identifier,
+                  admin: currentUser.admin,
+                },
+                images: [],
+              },
+            ],
+          }
+        }),
+      }
     })
 
     // Keep letter cache in sync so navigate-away → quick return within

--- a/react/src/components/Question/DraftQuestion.tsx
+++ b/react/src/components/Question/DraftQuestion.tsx
@@ -347,6 +347,7 @@ function DraftQuestion({
 
     // Keep letter cache in sync so navigate-away → return within staleTime
     // still shows the saved text (debounce and unmount flush).
+    let didPatch = false
     queryClient.setQueryData<PublicLetter>(letterQueryKey, (oldData) => {
       if (!oldData) {
         return oldData
@@ -368,21 +369,24 @@ function DraftQuestion({
               ...responses[existingIdx],
               response_text: responseText,
             }
+            didPatch = true
             return { ...q, responses }
           }
 
+          // Upsert returns ResponseUnlinked (no participant). Require both an
+          // unknown id and matching text so we don't attach another member's
+          // response to currentUser when the letter cache lags the payload.
           const knownIds = new Set(q.responses.map((r) => r.api_identifier))
-          const created =
-            updatedQuestion?.responses.find(
-              (r) => !knownIds.has(r.api_identifier),
-            ) ??
-            updatedQuestion?.responses.find(
-              (r) => r.response_text === responseText,
-            )
+          const created = updatedQuestion?.responses.find(
+            (r) =>
+              !knownIds.has(r.api_identifier) &&
+              r.response_text === responseText,
+          )
           if (!created) {
             return q
           }
 
+          didPatch = true
           return {
             ...q,
             responses: [
@@ -402,6 +406,10 @@ function DraftQuestion({
         }),
       }
     })
+
+    if (!didPatch) {
+      await queryClient.invalidateQueries({ queryKey: letterQueryKey })
+    }
   }
 
   const newHandleUpload = async (file: File) => {

--- a/react/src/components/Question/DraftQuestion.tsx
+++ b/react/src/components/Question/DraftQuestion.tsx
@@ -402,48 +402,6 @@ function DraftQuestion({
         }),
       }
     })
-
-    // Keep letter cache in sync so navigate-away → quick return within
-    // global staleTime does not remount the textarea from pre-flush data.
-    const letterQueryKey = readLetterLettersLetterLetterApiIdGetQueryKey({
-      path: { letter_api_id: loopApiId },
-    })
-    const cachedLetter = queryClient.getQueryData<PublicLetter>(letterQueryKey)
-    const hasExistingResponse = cachedLetter?.questions
-      .find((q) => q.api_identifier === question.api_identifier)
-      ?.responses.some(
-        (r) => r.participant.api_identifier === currentUser.api_identifier,
-      )
-
-    if (hasExistingResponse) {
-      queryClient.setQueryData<PublicLetter>(letterQueryKey, (oldData) => {
-        if (!oldData) {
-          return oldData
-        }
-        return {
-          ...oldData,
-          questions: oldData.questions.map((q) => {
-            if (q.api_identifier !== question.api_identifier) {
-              return q
-            }
-            return {
-              ...q,
-              responses: q.responses.map((r) => {
-                if (
-                  r.participant.api_identifier !== currentUser.api_identifier
-                ) {
-                  return r
-                }
-                return { ...r, response_text: responseText }
-              }),
-            }
-          }),
-        }
-      })
-    } else {
-      // First answer: no ResponseWithParticipant in cache yet — refetch.
-      await queryClient.invalidateQueries({ queryKey: letterQueryKey })
-    }
   }
 
   const newHandleUpload = async (file: File) => {

--- a/react/src/components/Question/DraftQuestion.tsx
+++ b/react/src/components/Question/DraftQuestion.tsx
@@ -360,8 +360,7 @@ function DraftQuestion({
           }
 
           const existingIdx = q.responses.findIndex(
-            (r) =>
-              r.participant.api_identifier === currentUser.api_identifier,
+            (r) => r.participant.api_identifier === currentUser.api_identifier,
           )
           if (existingIdx >= 0) {
             const responses = [...q.responses]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #311. Successful draft upserts (debounce and unmount/`pagehide` flush) wrote to the API but left the letter React Query cache stale. With global `staleTime: 30_000` and the loop route’s `ensureQueryData`, navigating away and returning within ~30s could still show the pre-flush textarea even though the upsert landed.

## Changes

- **`DraftQuestion.handleUpsert`**: after a successful upsert, patch `readLetterLettersLetterLetterApiIdGetQueryKey` with the new `response_text` (update existing participant response, or seed from the upsert payload on first create) so remounts within `staleTime` show the saved draft without refetching on every keystroke.

## Test plan

- [ ] Type a draft answer, navigate Home before “Saved”, return within 30s — textarea shows flushed text (not empty/old)
- [ ] Debounced in-page saves still show quiet save-status UX
- [ ] `tsc --noEmit` clean for changed frontend
- [ ] CI / review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64bf445d-fc4f-437a-9307-cfd5642c46a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64bf445d-fc4f-437a-9307-cfd5642c46a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

