### PR TITLE
Show API image sha alongside git sha in settings Build section

### DIFF
--- a/react/src/components/UserSettings/BuildInfo.tsx
+++ b/react/src/components/UserSettings/BuildInfo.tsx
@@ -6,6 +6,7 @@ import {
   GITHUB_COMMIT_URL,
   fetchBuildVersion,
   formatAge,
+  shortImageSha,
 } from "../../util/buildVersion"
 
 interface DeployRowProps {
@@ -14,6 +15,7 @@ interface DeployRowProps {
   branch: string | null | undefined
   timestampLabel: string
   timestamp: string | null | undefined
+  imageSha?: string | null
   note?: string | null
   error?: string | null
 }
@@ -24,6 +26,7 @@ function DeployRow({
   branch,
   timestampLabel,
   timestamp,
+  imageSha,
   note,
   error,
 }: DeployRowProps) {
@@ -48,6 +51,14 @@ function DeployRow({
           </span>
         )}
         {branch ? <Badge variant="secondary">{branch}</Badge> : null}
+        {imageSha ? (
+          <span
+            className="font-mono text-xs text-muted-foreground"
+            title={imageSha}
+          >
+            image {shortImageSha(imageSha)}
+          </span>
+        ) : null}
       </div>
       {timestamp ? (
         <span className="text-xs text-muted-foreground">
@@ -83,6 +94,12 @@ const BuildInfo = () => {
   const apiBuild = api.data?.image_build.sha
     ? api.data.image_build
     : api.data?.git
+  // The registry digest pins the exact image prod pulled; a locally built
+  // image has no RepoDigest, so fall back to the local image id.
+  const apiContainer = api.data?.docker.containers?.find(
+    (container) => container.service === "api" || container.name === "ring-api",
+  )
+  const apiImageSha = apiContainer?.image_digest ?? apiContainer?.image_id
 
   return (
     <div className="w-full">
@@ -113,6 +130,7 @@ const BuildInfo = () => {
               branch={apiBuild?.branch}
               timestampLabel="Committed"
               timestamp={apiBuild?.committed_at}
+              imageSha={apiImageSha}
               note={apiBuild?.subject}
               error={
                 api.isPending ? "loading…" : api.error?.message ?? "unknown"

--- a/react/src/util/buildVersion.ts
+++ b/react/src/util/buildVersion.ts
@@ -40,6 +40,24 @@ export async function fetchBuildVersion(): Promise<BuildVersion> {
   return JSON.parse(body) as BuildVersion
 }
 
+/**
+ * Shorten a Docker image identifier for display.
+ *
+ * Accepts both local ids (`sha256:...`) and registry digests
+ * (`repo@sha256:...`) and reduces them to `sha256:` plus 12 hex chars,
+ * mirroring how `docker images` abbreviates ids.
+ */
+export function shortImageSha(value: string | null | undefined): string | null {
+  if (!value) {
+    return null
+  }
+  const match = value.match(/sha256:([0-9a-f]+)/i)
+  if (!match) {
+    return value
+  }
+  return `sha256:${match[1].slice(0, 12)}`
+}
+
 /** Render an ISO-8601 timestamp as a compact age like `2h 5m ago`. */
 export function formatAge(
   timestamp: string | null | undefined,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The "Build" section in user settings now shows which Docker image the API is running, next to its git sha.

- `BuildInfo.tsx` picks the API container out of the `/version` payload's `docker.containers` list (compose service `api` / container `ring-api`) and renders its image sha on the API row.
- Prefers the registry digest (`image_digest`, i.e. what prod actually pulled) and falls back to the local image id for locally built images.
- New `shortImageSha` helper in `react/src/util/buildVersion.ts` abbreviates `sha256:` digests to 12 hex chars (matching `docker images` output); the full value is available via the `title` tooltip.

No backend changes — the image identity was already exposed by `GET /api/v1/version` via the host-written runtime snapshot.

## Testing

- `cd react && pnpm run lint`, `npx tsc --noEmit`, `pnpm run build` all pass.
- Verified in the cloud VM browser: logged in, opened Settings → Build, and confirmed the API row shows `image sha256:9f0219aabfa6` (matching the `image_id` reported by `/api/v1/version`) with the full digest in the hover tooltip.

![Settings Build section showing API image sha with tooltip](https://cursor.com/artifacts/c/art-fa402f91-d278-42bb-b0c1-6477f6908c1b)

<a href="https://cursor.com/agents/bc-d3216e0e-39fe-42ac-b5ad-4e6778fee97d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_build_section_image_sha_demo.mp4"><img src="https://cursor.com/artifacts/c/art-3dadc6c2-1ea8-4f71-b8c0-a5e20fc6d1f6" alt="settings_build_section_image_sha_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3216e0e-39fe-42ac-b5ad-4e6778fee97d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3216e0e-39fe-42ac-b5ad-4e6778fee97d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

