### PR TITLE
fix(letters): skip stale send jobs after a threshold deferral

### DIFF
--- a/ring/letters/send_threshold.py
+++ b/ring/letters/send_threshold.py
@@ -159,6 +159,17 @@ def has_send_date_arrived(letter: Letter, now: datetime | None = None) -> bool:
     return letter.send_at <= (now or datetime.now(tz=UTC))
 
 
+def is_stale_send_invocation(letter: Letter, scheduled_at: datetime) -> bool:
+    """Return True when this send job was scheduled before a later deferral.
+
+    ``Task.execute_at`` is the send deadline this invocation was queued for.
+    Postpend (or a previous send-email) may have already pushed ``letter.send_at``
+    forward; the in-progress task is not updated, so the old job must no-op
+    and leave the rescheduled send in place.
+    """
+    return letter.send_at > scheduled_at
+
+
 def defer_letter_send(db: Session, letter: Letter) -> bool:
     """Push a letter's send date out by the deferral interval.
 
@@ -207,12 +218,14 @@ def _schedule_waiting_response_email(letter_id: int) -> None:
 
 
 def defer_letter_send_if_below_threshold(db: Session, letter: Letter) -> bool:
-    """Defer a letter's send date when the responder threshold is not met.
+    """Skip sending when the responder threshold is not met.
 
-    Intended for the send-email task, which runs when the send date arrives.
+    Intended for the send-email task. Defers ``send_at`` once the deadline has
+    arrived; if another caller already pushed the deadline forward, that
+    deferral is left in place.
 
     Returns:
-        True if the send was deferred, False otherwise.
+        True if the send should be skipped, False if it may proceed.
     """
     if letter.status != LetterStatus.IN_PROGRESS:
         return False
@@ -220,7 +233,8 @@ def defer_letter_send_if_below_threshold(db: Session, letter: Letter) -> bool:
     if not is_below_send_threshold(letter):
         return False
 
-    return defer_letter_send(db, letter)
+    defer_letter_send(db, letter)
+    return True
 
 
 def hold_letter_for_send_threshold(db: Session, letter: Letter) -> bool:

--- a/ring/tasks/crud/task.py
+++ b/ring/tasks/crud/task.py
@@ -19,7 +19,10 @@ from ring.email_util import send_email
 from ring.letters.constants import LetterStatus
 from ring.letters.crud import letter as letter_crud
 from ring.letters.models.letter_model import Letter
-from ring.letters.send_threshold import defer_letter_send_if_below_threshold
+from ring.letters.send_threshold import (
+    defer_letter_send_if_below_threshold,
+    is_stale_send_invocation,
+)
 from ring.lib.util import RegistrationDict
 from ring.tasks.crud.reminder_email_task import construct_reminder_email
 from ring.tasks.crud.response_open_email_task import (
@@ -123,6 +126,18 @@ def execute_send_email_task(
         group = task.schedule.group
         letter_to_send = group.in_progress_letters[0]
     assert letter_to_send
+
+    if is_stale_send_invocation(letter_to_send, task.execute_at):
+        logger.info(
+            "Skipping stale send for letter {}: task scheduled at {}, "
+            "send_at is {}".format(
+                letter_to_send.id,
+                task.execute_at,
+                letter_to_send.send_at,
+            )
+        )
+        db.commit()
+        return
 
     if defer_letter_send_if_below_threshold(db, letter_to_send):
         db.commit()

--- a/ring/tests/unit/letters/crud/postpend_letter_test.py
+++ b/ring/tests/unit/letters/crud/postpend_letter_test.py
@@ -183,6 +183,44 @@ class TestPostpendLetters:
             days=LETTER_SEND_DEFERRAL_DAYS
         )
 
+    def test_postpend_then_send_email_defers_send_date_once(
+        self, db_session: Session
+    ) -> None:
+        """Postpend-first (the live job order) must not send or stack days."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        send_at = datetime.now(tz=UTC) - timedelta(minutes=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        db_session.commit()
+
+        with (
+            run_scheduled_jobs_inline(db_session),
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
+            assert hold_letter_for_send_threshold(db_session, letter) is True
+            assert (
+                defer_letter_send_if_below_threshold(db_session, letter)
+                is True
+            )
+
+        mock_send_email.assert_called_once()
+        assert is_waiting_response_email(mock_send_email)
+        db_session.refresh(letter)
+
+        assert letter.status == LetterStatus.IN_PROGRESS
+        assert letter.send_at == send_at + timedelta(
+            days=LETTER_SEND_DEFERRAL_DAYS
+        )
+
     def test_postpend_marks_sent_when_threshold_met(
         self, db_session: Session
     ) -> None:

--- a/ring/tests/unit/letters/send_threshold_test.py
+++ b/ring/tests/unit/letters/send_threshold_test.py
@@ -14,6 +14,7 @@ from ring.letters.send_threshold import (
     GROUP_SETTING_MIN_RESPONDERS_KEY,
     effective_send_threshold_ratio,
     get_group_min_responder_ratio,
+    is_stale_send_invocation,
     minimum_responders_required,
     parse_positive_int,
     parse_ratio,
@@ -65,6 +66,22 @@ class TestParseHelpers:
     )
     def test_parse_ratio(self, value: object, expected: float | None) -> None:
         assert parse_ratio(value) == expected
+
+
+class TestStaleSendInvocation:
+    """Tests for treating task.execute_at as a send-deadline generation token."""
+
+    def test_current_deadline_is_not_stale(self, db_session: Session) -> None:
+        send_at = datetime.now(tz=UTC)
+        letter = LetterFactory.create(send_at=send_at)
+        db_session.commit()
+        assert is_stale_send_invocation(letter, send_at) is False
+
+    def test_deferred_deadline_is_stale(self, db_session: Session) -> None:
+        send_at = datetime.now(tz=UTC)
+        letter = LetterFactory.create(send_at=send_at + timedelta(days=1))
+        db_session.commit()
+        assert is_stale_send_invocation(letter, send_at) is True
 
 
 class TestSendThresholdPolicy:

--- a/ring/tests/unit/tasks/crud/task_test.py
+++ b/ring/tests/unit/tasks/crud/task_test.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ring.letters.constants import LetterStatus
+from ring.letters.crud import letter as letter_crud
 from ring.letters.send_threshold import (
     GROUP_SETTING_MIN_RESPONDER_RATIO_KEY,
     GROUP_SETTING_MIN_RESPONDERS_KEY,
@@ -368,3 +369,97 @@ class TestTaskCrud:
             )
 
         mock_send_email.assert_not_called()
+
+    def test_execute_send_email_task_skips_after_postpend_deferral(
+        self, db_session: Session
+    ) -> None:
+        """A send job queued for the old deadline must not send after deferral."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        send_at = datetime.now(tz=UTC) - timedelta(minutes=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        db_session.commit()
+
+        send_task = db_session.scalars(
+            select(Task).where(
+                Task.schedule_id == group.schedule.id,
+                Task.type == TaskType.SEND_EMAIL,
+                Task.arguments == {"letter_id": letter.id},
+            )
+        ).one()
+        send_task.status = TaskStatus.IN_PROGRESS
+        db_session.commit()
+
+        with (
+            run_scheduled_jobs_inline(db_session),
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
+            letter_crud.postpend_upcoming_letters_with_session(
+                db_session, [letter.id]
+            )
+            task_crud.execute_send_email_task(db_session, send_task)
+
+        mock_send_email.assert_called_once()
+        assert is_waiting_response_email(mock_send_email)
+        db_session.refresh(letter)
+        assert letter.status == LetterStatus.IN_PROGRESS
+        assert letter.send_at == send_at + timedelta(
+            days=LETTER_SEND_DEFERRAL_DAYS
+        )
+
+    def test_execute_send_email_task_skips_stale_task_even_if_threshold_met(
+        self, db_session: Session
+    ) -> None:
+        """Deferral invalidates this job even if answers arrive before it runs."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        send_at = datetime.now(tz=UTC) - timedelta(minutes=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        db_session.commit()
+
+        send_task = db_session.scalars(
+            select(Task).where(
+                Task.schedule_id == group.schedule.id,
+                Task.type == TaskType.SEND_EMAIL,
+                Task.arguments == {"letter_id": letter.id},
+            )
+        ).one()
+        send_task.status = TaskStatus.IN_PROGRESS
+        db_session.commit()
+
+        with (
+            run_scheduled_jobs_inline(db_session),
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
+            letter_crud.postpend_upcoming_letters_with_session(
+                db_session, [letter.id]
+            )
+            ResponseFactory.create(question=question, participant=members[1])
+            db_session.commit()
+            task_crud.execute_send_email_task(db_session, send_task)
+
+        mock_send_email.assert_called_once()
+        assert is_waiting_response_email(mock_send_email)
+        db_session.refresh(letter)
+        assert letter.status == LetterStatus.IN_PROGRESS
+        assert letter.send_at == send_at + timedelta(
+            days=LETTER_SEND_DEFERRAL_DAYS
+        )


### PR DESCRIPTION
## Summary
- Treat a send-email task's `execute_at` as a generation token: if postpend (or a prior send) already pushed `letter.send_at` forward, the in-flight job no-ops instead of sending.
- Below-threshold always skips the send, even when deferral is a no-op because the deadline was already moved.
- Adds coverage for the live job order (postpend, then send-email) and for answers arriving after deferral but before the stale job runs.

## Test plan
- [ ] `ring test run -- ring/tests/unit/tasks/crud/task_test.py ring/tests/unit/letters/crud/postpend_letter_test.py ring/tests/unit/letters/send_threshold_test.py`
- [ ] Confirm a group below the response threshold still defers by one day and does not email when both jobs fire
- [ ] Confirm a group that meets the threshold still sends on schedule


Made with [Cursor](https://cursor.com)