### PR TITLE
Email non-responders when a letter send is deferred

### DIFF
--- a/ring/letters/send_threshold.py
+++ b/ring/letters/send_threshold.py
@@ -164,7 +164,8 @@ def defer_letter_send(db: Session, letter: Letter) -> bool:
 
     Idempotent across callers that may both run at the same deadline moment
     (send-email task and postpend): once ``send_at`` is in the future, further
-    calls are a no-op.
+    calls are a no-op. A successful deferral also schedules a one-shot email
+    to participants who have not yet responded.
 
     Returns:
         True if the send date was deferred, False if it had not yet arrived
@@ -187,7 +188,22 @@ def defer_letter_send(db: Session, letter: Letter) -> bool:
         )
     )
     letter_crud.edit_letter(db, letter, send_at=new_send_at)
+    _schedule_waiting_response_email(letter.id)
     return True
+
+
+def _schedule_waiting_response_email(letter_id: int) -> None:
+    """Queue a one-shot job to email participants who have not responded.
+
+    Imported lazily because ``ring.tasks.crud.task`` imports this module.
+    """
+    from ring.async_scheduler.scheduler import scheduler
+    from ring.tasks.crud.task import send_waiting_response_email
+
+    scheduler.add_job(
+        send_waiting_response_email,
+        args=[letter_id],
+    )
 
 
 def defer_letter_send_if_below_threshold(db: Session, letter: Letter) -> bool:

--- a/ring/tasks/crud/task.py
+++ b/ring/tasks/crud/task.py
@@ -26,6 +26,11 @@ from ring.tasks.crud.response_open_email_task import (
     construct_response_open_email,
 )
 from ring.tasks.crud.send_email_task import construct_send_letter_email
+from ring.tasks.crud.waiting_response_email_task import (
+    construct_waiting_response_email,
+    letter_display_title,
+    letter_non_responder_emails,
+)
 from ring.tasks.models.task_model import (
     ReminderEmailTask,
     SendEmailTask,
@@ -262,6 +267,44 @@ def send_response_open_email(db: Session, letter_id: int) -> None:
     if message_id:
         logger.info(
             f"Sent response open email for letter {letter_id} to {recipients}"
+        )
+
+
+@job_factory("send_waiting_response_email")
+def send_waiting_response_email(db: Session, letter_id: int) -> None:
+    """Email participants who have not yet answered a deferred letter.
+
+    Triggered once when a letter send is deferred because too few people
+    have responded. Recipients are letter participants minus responders.
+    No-ops if that list is empty.
+
+    Args:
+        db: Database session
+        letter_id: ID of the deferred letter
+    """
+    letter = db.scalars(
+        sqlalchemy.select(Letter).where(Letter.id == letter_id)
+    ).one()
+
+    recipients = letter_non_responder_emails(letter)
+    if not recipients:
+        logger.info(
+            f"No non-responders for waiting-response email for letter {letter_id}"
+        )
+        return
+
+    email_draft = construct_waiting_response_email(
+        recipients,
+        letter.group.name,
+        letter.api_identifier,
+        letter_display_title(letter),
+    )
+    message_id = send_email(email_draft)
+    if message_id:
+        logger.info(
+            "Sent waiting-response email for letter {} to {}".format(
+                letter_id, recipients
+            )
         )
 
 

--- a/ring/tasks/crud/waiting_response_email_task.py
+++ b/ring/tasks/crud/waiting_response_email_task.py
@@ -1,0 +1,86 @@
+"""Utilities for constructing waiting-response emails.
+
+These emails notify participants who have not yet answered that a letter
+send was deferred because the issue is waiting for their response.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ring.email_util import EmailDraft, construct_email_draft
+from ring.lib.app_links import app_url
+
+if TYPE_CHECKING:
+    from ring.letters.models.letter_model import Letter
+
+
+def letter_non_responder_emails(letter: Letter) -> list[str]:
+    """Return emails of participants who have not submitted any response."""
+    responder_ids = {user.id for user in letter.responders}
+    return [
+        user.email
+        for user in letter.participants
+        if user.id not in responder_ids
+    ]
+
+
+def letter_display_title(letter: Letter) -> str:
+    """Return a human-readable letter title or number for email copy."""
+    if letter.title:
+        return letter.title
+    return f"#{letter.number}"
+
+
+def construct_waiting_response_email(
+    recipients: list[str],
+    group_name: str,
+    letter_api_id: str,
+    letter_title: str,
+) -> EmailDraft:
+    """Construct an email telling a participant the issue is waiting on them.
+
+    The issue has not been sent yet because too few people have answered.
+    This email is sent only to people who have not responded. It does not
+    imply a hard last-day deadline; send will be retried later if the
+    responder threshold is still unmet.
+
+    Args:
+        recipients: Email addresses of participants who have not responded
+        group_name: Name of the group
+        letter_api_id: API identifier of the letter
+        letter_title: Title or number of the letter for display
+
+    Returns:
+        EmailDraft: A draft email ready to be sent
+    """
+    letter_url = app_url(f"loops/{letter_api_id}")
+
+    BODY_TEXT = """The latest Ring issue for {group_name} has not been sent yet because it is waiting for your response.
+
+{letter_title} needs your answers before it can go out to the group.
+
+Visit: {letter_url}
+""".format(
+        group_name=group_name,
+        letter_title=letter_title,
+        letter_url=letter_url,
+    )
+
+    BODY_HTML = """<html>
+    <head></head>
+    <body>
+    <h1>Ring: {letter_title} is waiting for your response</h1>
+    <h2>Check out the issue online at <a href="{letter_url}">{letter_url}</a></h2>
+    <p>The latest issue for <strong>{group_name}</strong> has not been sent yet because it is waiting for your response.</p>
+    <p>Please visit the link above to add your answers to <strong>{letter_title}</strong>.</p>
+    </body>
+    </html>
+                """.format(
+        group_name=group_name,
+        letter_url=letter_url,
+        letter_title=letter_title,
+    )
+
+    subject = "Ring: {} is waiting for your response".format(letter_title)
+    return construct_email_draft(recipients, subject, BODY_HTML, BODY_TEXT)

--- a/ring/tests/lib/utils.py
+++ b/ring/tests/lib/utils.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any, Sequence
+from unittest.mock import MagicMock, patch
 
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
 
 from ring.ring_pydantic.pydantic_model import PydanticModel
 from ring.sqlalchemy_base import Base
@@ -68,4 +72,52 @@ def assert_sqlalchemy_object_list_equal_with_order_insensitive(
 ) -> None:
     assert sorted(list1, key=lambda x: x.id) == sorted(
         list2, key=lambda x: x.id
+    )
+
+
+@contextmanager
+def run_scheduled_jobs_inline(db: Session) -> Iterator[MagicMock]:
+    """Run ``scheduler.add_job`` callbacks against the test session.
+
+    Production one-shot jobs use APScheduler with their own DB session.
+    Unit tests share a rolled-back transaction, so jobs are invoked
+    immediately with the test session instead.
+    """
+    from ring.async_scheduler.job_registry import JOB_REGISTRY
+
+    def _add_job(job: Any, *args: Any, **kwargs: Any) -> None:
+        job_args = list(kwargs.get("args") or [])
+        name = getattr(job, "name", None)
+        if name and name in JOB_REGISTRY:
+            JOB_REGISTRY[name].job_function(db, *job_args)
+            return
+        raise AssertionError(f"Unregistered job scheduled: {job!r}")
+
+    with patch(
+        "ring.async_scheduler.scheduler.scheduler.add_job",
+        side_effect=_add_job,
+    ) as mock_add_job:
+        yield mock_add_job
+
+
+def email_draft_recipients(
+    mock_send_email: MagicMock, call_index: int = 0
+) -> list[str]:
+    draft = mock_send_email.call_args_list[call_index].args[0]
+    return list(draft.destination["ToAddresses"])
+
+
+def email_draft_subject(
+    mock_send_email: MagicMock, call_index: int = 0
+) -> str:
+    draft = mock_send_email.call_args_list[call_index].args[0]
+    return draft.message["Subject"]["Data"]
+
+
+def is_waiting_response_email(
+    mock_send_email: MagicMock, call_index: int = 0
+) -> bool:
+    return (
+        "waiting for your response"
+        in email_draft_subject(mock_send_email, call_index).lower()
     )

--- a/ring/tests/unit/letters/crud/postpend_letter_test.py
+++ b/ring/tests/unit/letters/crud/postpend_letter_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
 from sqlalchemy.orm import Session
 
@@ -18,6 +19,11 @@ from ring.tests.factories.letters.question_factory import QuestionFactory
 from ring.tests.factories.letters.response_factory import ResponseFactory
 from ring.tests.factories.parties.group_factory import GroupFactory
 from ring.tests.factories.parties.user_factory import UserFactory
+from ring.tests.lib.utils import (
+    email_draft_recipients,
+    is_waiting_response_email,
+    run_scheduled_jobs_inline,
+)
 
 
 class TestPostpendLetters:
@@ -47,7 +53,21 @@ class TestPostpendLetters:
         ResponseFactory.create(question=question, participant=members[0])
         db_session.commit()
 
-        self.run_postpend_job(db_session, [letter.id])
+        with (
+            run_scheduled_jobs_inline(db_session),
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
+            self.run_postpend_job(db_session, [letter.id])
+
+        mock_send_email.assert_called_once()
+        assert is_waiting_response_email(mock_send_email)
+        assert set(email_draft_recipients(mock_send_email)) == {
+            member.email for member in members[1:]
+        }
+        assert members[0].email not in email_draft_recipients(mock_send_email)
+
         db_session.refresh(letter)
 
         assert letter.status == LetterStatus.IN_PROGRESS
@@ -72,7 +92,16 @@ class TestPostpendLetters:
         ResponseFactory.create(question=question, participant=members[0])
         db_session.commit()
 
-        self.run_postpend_job(db_session, [letter.id])
+        with (
+            run_scheduled_jobs_inline(db_session) as mock_add_job,
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
+            self.run_postpend_job(db_session, [letter.id])
+
+        mock_add_job.assert_not_called()
+        mock_send_email.assert_not_called()
         db_session.refresh(letter)
 
         assert letter.status == LetterStatus.IN_PROGRESS
@@ -95,8 +124,17 @@ class TestPostpendLetters:
         ResponseFactory.create(question=question, participant=members[0])
         db_session.commit()
 
-        for _ in range(3):
-            self.run_postpend_job(db_session, [letter.id])
+        with (
+            run_scheduled_jobs_inline(db_session),
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
+            for _ in range(3):
+                self.run_postpend_job(db_session, [letter.id])
+
+        mock_send_email.assert_called_once()
+        assert is_waiting_response_email(mock_send_email)
         db_session.refresh(letter)
 
         assert letter.status == LetterStatus.IN_PROGRESS
@@ -121,8 +159,23 @@ class TestPostpendLetters:
         ResponseFactory.create(question=question, participant=members[0])
         db_session.commit()
 
-        assert defer_letter_send_if_below_threshold(db_session, letter) is True
-        assert hold_letter_for_send_threshold(db_session, letter) is True
+        with (
+            run_scheduled_jobs_inline(db_session),
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
+            assert (
+                defer_letter_send_if_below_threshold(db_session, letter)
+                is True
+            )
+            assert hold_letter_for_send_threshold(db_session, letter) is True
+
+        mock_send_email.assert_called_once()
+        assert is_waiting_response_email(mock_send_email)
+        assert set(email_draft_recipients(mock_send_email)) == {
+            member.email for member in members[1:]
+        }
         db_session.refresh(letter)
 
         assert letter.status == LetterStatus.IN_PROGRESS
@@ -148,7 +201,16 @@ class TestPostpendLetters:
         ResponseFactory.create(question=question, participant=members[1])
         db_session.commit()
 
-        self.run_postpend_job(db_session, [letter.id])
+        with (
+            run_scheduled_jobs_inline(db_session) as mock_add_job,
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
+            self.run_postpend_job(db_session, [letter.id])
+
+        mock_add_job.assert_not_called()
+        mock_send_email.assert_not_called()
         db_session.refresh(letter)
 
         assert letter.status == LetterStatus.SENT

--- a/ring/tests/unit/lib/app_links_test.py
+++ b/ring/tests/unit/lib/app_links_test.py
@@ -21,6 +21,9 @@ from ring.tasks.crud.response_open_email_task import (
     construct_response_open_email,
 )
 from ring.tasks.crud.send_email_task import construct_send_letter_email
+from ring.tasks.crud.waiting_response_email_task import (
+    construct_waiting_response_email,
+)
 from ring.tests.factories.parties.group_factory import GroupFactory
 
 
@@ -86,6 +89,15 @@ class TestOutboundEmailLinks:
                     group.name,
                     letter_api_id,
                     LetterStatus.IN_PROGRESS,
+                ),
+                letter_url,
+            ),
+            (
+                construct_waiting_response_email(
+                    ["user@example.com"],
+                    group.name,
+                    letter_api_id,
+                    "#1",
                 ),
                 letter_url,
             ),

--- a/ring/tests/unit/tasks/crud/task_test.py
+++ b/ring/tests/unit/tasks/crud/task_test.py
@@ -13,6 +13,8 @@ from ring.letters.send_threshold import (
     GROUP_SETTING_MIN_RESPONDER_RATIO_KEY,
     GROUP_SETTING_MIN_RESPONDERS_KEY,
     LETTER_SEND_DEFERRAL_DAYS,
+    defer_letter_send,
+    defer_letter_send_if_below_threshold,
 )
 from ring.tasks.crud import task as task_crud
 from ring.tasks.models.task_model import Task, TaskStatus, TaskType
@@ -21,6 +23,11 @@ from ring.tests.factories.letters.question_factory import QuestionFactory
 from ring.tests.factories.letters.response_factory import ResponseFactory
 from ring.tests.factories.parties.group_factory import GroupFactory
 from ring.tests.factories.parties.user_factory import UserFactory
+from ring.tests.lib.utils import (
+    email_draft_recipients,
+    is_waiting_response_email,
+    run_scheduled_jobs_inline,
+)
 
 
 class TestTaskCrud:
@@ -29,7 +36,7 @@ class TestTaskCrud:
     def test_execute_send_email_task_defers_when_responders_below_threshold(
         self, db_session: Session
     ) -> None:
-        """Defer send by one day when too few participants have responded."""
+        """Defer send by one day and email only people who have not answered."""
         admin = UserFactory.create()
         members = [admin] + [UserFactory.create() for _ in range(3)]
         group = GroupFactory.create(admin=admin, members=members)
@@ -53,12 +60,20 @@ class TestTaskCrud:
         send_task.status = TaskStatus.IN_PROGRESS
         db_session.commit()
 
-        with patch(
-            "ring.tasks.crud.task.send_email", return_value="message-id"
-        ) as mock_send_email:
+        with (
+            run_scheduled_jobs_inline(db_session),
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
             task_crud.execute_send_email_task(db_session, send_task)
 
-        mock_send_email.assert_not_called()
+        mock_send_email.assert_called_once()
+        assert is_waiting_response_email(mock_send_email)
+        recipients = email_draft_recipients(mock_send_email)
+        assert set(recipients) == {member.email for member in members[1:]}
+        assert members[0].email not in recipients
+
         db_session.refresh(letter)
 
         expected_send_at = send_at + timedelta(days=LETTER_SEND_DEFERRAL_DAYS)
@@ -75,6 +90,41 @@ class TestTaskCrud:
             )
         ).one_or_none()
         assert rescheduled_send_task is not None
+
+    def test_second_deferral_caller_does_not_send_waiting_response_email(
+        self, db_session: Session
+    ) -> None:
+        """Idempotent deferral must not email non-responders a second time."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        send_at = datetime.now(tz=UTC) - timedelta(minutes=1)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=send_at,
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        db_session.commit()
+
+        with (
+            run_scheduled_jobs_inline(db_session),
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
+            assert (
+                defer_letter_send_if_below_threshold(db_session, letter)
+                is True
+            )
+            assert defer_letter_send(db_session, letter) is False
+
+        mock_send_email.assert_called_once()
+        assert is_waiting_response_email(mock_send_email)
+        assert set(email_draft_recipients(mock_send_email)) == {
+            member.email for member in members[1:]
+        }
 
     def test_execute_send_email_task_sends_when_responders_meet_threshold(
         self, db_session: Session
@@ -102,12 +152,19 @@ class TestTaskCrud:
             )
         ).one()
 
-        with patch(
-            "ring.tasks.crud.task.send_email", return_value="message-id"
-        ) as mock_send_email:
+        with (
+            run_scheduled_jobs_inline(db_session),
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
             task_crud.execute_send_email_task(db_session, send_task)
 
         mock_send_email.assert_called_once()
+        assert not is_waiting_response_email(mock_send_email)
+        assert set(email_draft_recipients(mock_send_email)) == {
+            member.email for member in members
+        }
         db_session.refresh(letter)
         assert letter.status == LetterStatus.SENT
         assert letter.send_at == send_at
@@ -141,12 +198,20 @@ class TestTaskCrud:
         send_task.status = TaskStatus.IN_PROGRESS
         db_session.commit()
 
-        with patch(
-            "ring.tasks.crud.task.send_email", return_value="message-id"
-        ) as mock_send_email:
+        with (
+            run_scheduled_jobs_inline(db_session),
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
             task_crud.execute_send_email_task(db_session, send_task)
 
-        mock_send_email.assert_not_called()
+        mock_send_email.assert_called_once()
+        assert is_waiting_response_email(mock_send_email)
+        assert set(email_draft_recipients(mock_send_email)) == {
+            members[2].email,
+            members[3].email,
+        }
         db_session.refresh(letter)
         assert letter.send_at == send_at + timedelta(
             days=LETTER_SEND_DEFERRAL_DAYS
@@ -181,12 +246,16 @@ class TestTaskCrud:
             )
         ).one()
 
-        with patch(
-            "ring.tasks.crud.task.send_email", return_value="message-id"
-        ) as mock_send_email:
+        with (
+            run_scheduled_jobs_inline(db_session),
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
             task_crud.execute_send_email_task(db_session, send_task)
 
         mock_send_email.assert_called_once()
+        assert not is_waiting_response_email(mock_send_email)
         db_session.refresh(letter)
         assert letter.status == LetterStatus.SENT
 
@@ -219,12 +288,16 @@ class TestTaskCrud:
         send_task.status = TaskStatus.IN_PROGRESS
         db_session.commit()
 
-        with patch(
-            "ring.tasks.crud.task.send_email", return_value="message-id"
-        ) as mock_send_email:
+        with (
+            run_scheduled_jobs_inline(db_session),
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
             task_crud.execute_send_email_task(db_session, send_task)
 
-        mock_send_email.assert_not_called()
+        mock_send_email.assert_called_once()
+        assert is_waiting_response_email(mock_send_email)
         db_session.refresh(letter)
         assert letter.send_at == send_at + timedelta(
             days=LETTER_SEND_DEFERRAL_DAYS
@@ -255,11 +328,43 @@ class TestTaskCrud:
             )
         ).one()
 
-        with patch(
-            "ring.tasks.crud.task.send_email", return_value="message-id"
-        ) as mock_send_email:
+        with (
+            run_scheduled_jobs_inline(db_session),
+            patch(
+                "ring.tasks.crud.task.send_email", return_value="message-id"
+            ) as mock_send_email,
+        ):
             task_crud.execute_send_email_task(db_session, send_task)
 
         mock_send_email.assert_called_once()
+        assert not is_waiting_response_email(mock_send_email)
         db_session.refresh(letter)
         assert letter.status == LetterStatus.SENT
+
+    def test_send_waiting_response_email_noops_without_non_responders(
+        self, db_session: Session
+    ) -> None:
+        """Skip sending when every participant has already answered."""
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=datetime.now(tz=UTC) - timedelta(minutes=1),
+        )
+        question = QuestionFactory.create(letter=letter)
+        for member in members:
+            ResponseFactory.create(question=question, participant=member)
+        db_session.commit()
+
+        with patch(
+            "ring.tasks.crud.task.send_email", return_value="message-id"
+        ) as mock_send_email:
+            from ring.async_scheduler.job_registry import JOB_REGISTRY
+
+            JOB_REGISTRY["send_waiting_response_email"].job_function(
+                db_session, letter.id
+            )
+
+        mock_send_email.assert_not_called()

--- a/ring/tests/unit/tasks/crud/waiting_response_email_task_test.py
+++ b/ring/tests/unit/tasks/crud/waiting_response_email_task_test.py
@@ -1,0 +1,135 @@
+"""Tests for waiting-response email construction."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from ring.letters.constants import LetterStatus
+from ring.lib.app_links import app_url
+from ring.tasks.crud.waiting_response_email_task import (
+    construct_waiting_response_email,
+    letter_display_title,
+    letter_non_responder_emails,
+)
+from ring.tests.factories.letters.letter_factory import LetterFactory
+from ring.tests.factories.letters.question_factory import QuestionFactory
+from ring.tests.factories.letters.response_factory import ResponseFactory
+from ring.tests.factories.parties.group_factory import GroupFactory
+from ring.tests.factories.parties.user_factory import UserFactory
+
+
+class TestWaitingResponseEmailTask:
+    """Test suite for waiting-response email construction."""
+
+    def test_construct_waiting_response_email(self) -> None:
+        """Draft includes group, letter, link, and waiting-response copy."""
+        recipients = ["user1@example.com", "user2@example.com"]
+        group_name = "Test Group"
+        letter_api_id = "lttr_123abc"
+        letter_title = "#5"
+
+        email_draft = construct_waiting_response_email(
+            recipients,
+            group_name,
+            letter_api_id,
+            letter_title,
+        )
+
+        assert email_draft.destination["ToAddresses"] == recipients
+
+        subject = email_draft.message["Subject"]["Data"]
+        assert letter_title in subject
+        assert "waiting for your response" in subject.lower()
+        assert "last day" not in subject.lower()
+
+        html_body = email_draft.message["Body"]["Html"]["Data"]
+        text_body = email_draft.message["Body"]["Text"]["Data"]
+        letter_url = app_url(f"loops/{letter_api_id}")
+        for body in (html_body, text_body):
+            assert group_name in body
+            assert letter_title in body
+            assert letter_url in body
+            assert "has not been sent" in body
+            assert "waiting for your response" in body
+            assert "last day" not in body.lower()
+
+    def test_construct_waiting_response_email_with_custom_title(self) -> None:
+        """Custom letter titles appear in subject and body."""
+        email_draft = construct_waiting_response_email(
+            ["user@example.com"],
+            "Friends Newsletter",
+            "lttr_xyz789",
+            "Summer Edition",
+        )
+
+        subject = email_draft.message["Subject"]["Data"]
+        html_body = email_draft.message["Body"]["Html"]["Data"]
+        text_body = email_draft.message["Body"]["Text"]["Data"]
+
+        assert "Summer Edition" in subject
+        assert "Summer Edition" in html_body
+        assert "Summer Edition" in text_body
+
+
+class TestWaitingResponseRecipients:
+    """Helpers for choosing waiting-response email recipients and titles."""
+
+    def test_letter_non_responder_emails_excludes_responders(
+        self, db_session: Session
+    ) -> None:
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=datetime.now(tz=UTC) + timedelta(days=1),
+        )
+        question = QuestionFactory.create(letter=letter)
+        ResponseFactory.create(question=question, participant=members[0])
+        db_session.commit()
+
+        assert set(letter_non_responder_emails(letter)) == {
+            member.email for member in members[1:]
+        }
+
+    def test_letter_non_responder_emails_empty_when_everyone_answered(
+        self, db_session: Session
+    ) -> None:
+        admin = UserFactory.create()
+        members = [admin] + [UserFactory.create() for _ in range(3)]
+        group = GroupFactory.create(admin=admin, members=members)
+        letter = LetterFactory.create(
+            group=group,
+            status=LetterStatus.IN_PROGRESS,
+            send_at=datetime.now(tz=UTC) + timedelta(days=1),
+        )
+        question = QuestionFactory.create(letter=letter)
+        for member in members:
+            ResponseFactory.create(question=question, participant=member)
+        db_session.commit()
+
+        assert letter_non_responder_emails(letter) == []
+
+    def test_letter_display_title_prefers_custom_title(
+        self, db_session: Session
+    ) -> None:
+        letter = LetterFactory.create(
+            status=LetterStatus.IN_PROGRESS,
+            send_at=datetime.now(tz=UTC) + timedelta(days=1),
+            title="Summer Edition",
+        )
+        db_session.commit()
+        assert letter_display_title(letter) == "Summer Edition"
+
+    def test_letter_display_title_falls_back_to_number(
+        self, db_session: Session
+    ) -> None:
+        letter = LetterFactory.create(
+            status=LetterStatus.IN_PROGRESS,
+            send_at=datetime.now(tz=UTC) + timedelta(days=1),
+        )
+        db_session.commit()
+        assert letter_display_title(letter) == f"#{letter.number}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When a letter send is deferred because too few people have answered, Ring now emails **only participants who have not responded**, telling them the issue is waiting for their response.

## Why

Send already waits one day when a letter is below its responder threshold, but nobody was notified. People who already answered should not get another ping; people who have not answered should know the issue has not gone out yet.

## What changed

- New waiting-response email (plain text + HTML) with group name, letter title/number, and a link to the letter. Copy does **not** imply a hard last-day deadline.
- One-shot job `send_waiting_response_email`, following `send_response_open_email`.
- Job is scheduled from `defer_letter_send` **only when `send_at` actually moves**. A second caller at the same deadline (send-email task + postpend poll) is a no-op, so the email fires once.
- Recipients = `letter.participants` minus `letter.responders`. Empty list → no email.
- Existing 8-day / 1-day reminders still go to all participants.

## Test plan

- [x] `ring check lint`
- [x] Unit tests (55 passed) covering:
  - Deferral with 1/4 responders emails the 3 non-responders, not the person who answered
  - Second deferral caller at the same deadline does not send again
  - Threshold met → letter send proceeds; no waiting-response email
  - Threshold disabled (ratio 0) → send on schedule; no waiting-response email
  - Postpend path does not double-send with the send-email task
  - Constructor / recipient helpers / https app links

Backend only. No API / OpenAPI / frontend changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb20fb54-68af-4cf5-a45f-c92fef295caa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb20fb54-68af-4cf5-a45f-c92fef295caa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

