### PR TITLE
ci: verify alembic migrations apply from scratch

### DIFF
--- a/.github/workflows/check_migrations.yml
+++ b/.github/workflows/check_migrations.yml
@@ -1,0 +1,88 @@
+name: Check migrations
+
+# Safety gate for the CD plan (docs/continuous-deploy-plan.md): deploys run
+# `alembic upgrade head` against CockroachDB Cloud with nobody watching, and
+# the pytest suite builds its schema from ring/db/schema.sql — so without
+# this job nothing ever proves the revision chain applies.
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref / SHA to check (default: caller github.sha)"
+        required: false
+        type: string
+
+jobs:
+  migrations:
+    name: alembic upgrade head
+    runs-on: ubuntu-latest
+
+    env:
+      # Same throwaway credentials compose.test.yml gives the container.
+      TEST_DB_URL: "postgresql://ringcockroach:ringcockroach@localhost:26257/test?sslmode=require"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Sync uv
+        run: uv sync --all-extras
+
+      - name: Install project
+        run: uv pip install -e .
+
+      - name: Docker set-up
+        run: |
+          docker login ghcr.io -u neil-sriv -p ${{ secrets.GITHUB_TOKEN }}
+          docker pull ghcr.io/neil-sriv/ring/ring-test-runner:latest
+          docker tag ghcr.io/neil-sriv/ring/ring-test-runner:latest ring-test-runner:latest
+          docker rmi ghcr.io/neil-sriv/ring/ring-test-runner:latest
+          uv run ring compose any --profile test pull test-cockroach
+          docker network create ring-network
+
+      - name: Start test CockroachDB
+        run: uv run ring compose any --profile test up -d test-cockroach
+
+      # Probe with a real authenticated query. `/health?ready=1` goes green
+      # before the image finishes creating COCKROACH_USER, so waiting on it
+      # alone races into "password authentication failed".
+      - name: Wait for CockroachDB
+        run: |
+          for attempt in $(seq 1 60); do
+            if docker exec ring-test-cockroach ./cockroach sql \
+                --url "$TEST_DB_URL" -e "SELECT 1" >/dev/null 2>&1; then
+              echo "CockroachDB accepting queries after ${attempt} attempt(s)"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "CockroachDB never accepted an authenticated query" >&2
+          uv run ring compose any --profile test logs test-cockroach >&2
+          exit 1
+
+      # Cluster-level prerequisite, not something a migration can set for
+      # itself. conftest.py does the same for pytest, cloud-start.sh for dev.
+      - name: Enable vector index
+        run: |
+          docker exec ring-test-cockroach ./cockroach sql \
+            --url "$TEST_DB_URL" \
+            -e "SET CLUSTER SETTING feature.vector_index.enabled = true;"
+
+      # The test database starts empty, so this applies every revision from
+      # scratch. A broken or unapplyable migration fails here, not in prod.
+      - name: Apply migrations
+        run: uv run ring db check-migrations
+
+      # pytest builds its schema from schema.sql, so a stale dump means the
+      # suite tests a schema production does not have.
+      - name: Check schema.sql drift
+        run: uv run ring db check-schema-drift

--- a/dev_util/database.py
+++ b/dev_util/database.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import click
 
 from dev_util.compose import compose_exec
-from dev_util.dev import dev_command, dev_group
+from dev_util.dev import ROOT_DIR, dev_command, dev_group, subprocess_run
+from dev_util.schema_drift import clean_dump, compare
 
 # Prod DB is CockroachDB Cloud (cluster ring-db), not RDS. See docs/infrastructure.md.
 LOCAL_COCKROACH_URI = "postgresql://root@127.0.0.1:26257/ring"
+SCHEMA_SQL_PATH = Path(ROOT_DIR) / "ring" / "db" / "schema.sql"
+TEST_COCKROACH_CONTAINER = "ring-test-cockroach"
+# Credentials come from compose.test.yml; this cluster is ephemeral CI state.
+TEST_COCKROACH_URL = (
+    "postgresql://ringcockroach:ringcockroach@localhost:26257/test"
+    "?sslmode=require"
+)
 COCKROACH_CONNECTION_STRING = (
     f"{LOCAL_COCKROACH_URI}"
     "?sslcert=%2Froot%2F.cockroach-certs%2Fclient.root.crt"
@@ -52,6 +61,65 @@ def db_upgrade(
     **kwargs: dict[Any, Any],
 ) -> list[str]:
     return ["alembic", "upgrade", "head"]
+
+
+@compose_exec(
+    "check-migrations",
+    db,
+    service="test-runner",
+    directory="ring",
+    profile="test",
+    cmd="run",
+    opts=["--rm"],
+)
+def db_check_migrations(
+    ctx: click.Context,
+    *args: list[Any],
+    **kwargs: dict[Any, Any],
+) -> list[str]:
+    """Apply every migration to the empty test database.
+
+    Guards auto-deploy: prod migrations run unattended, but the test suite
+    builds its schema from db/schema.sql, so nothing else exercises the
+    revision chain.
+    """
+    return ["alembic", "upgrade", "head"]
+
+
+@dev_command("check-schema-drift", db)
+def db_check_schema_drift(
+    ctx: click.Context,
+    *args: list[Any],
+    **kwargs: dict[Any, Any],
+) -> None:
+    """Compare db/schema.sql with the migrated test database.
+
+    Run after `ring db check-migrations`, against the same container.
+    """
+    dump = subprocess_run(
+        [
+            "docker",
+            "exec",
+            TEST_COCKROACH_CONTAINER,
+            "./cockroach",
+            "sql",
+            "--url",
+            TEST_COCKROACH_URL,
+            "-e",
+            "SHOW CREATE ALL TABLES",
+        ],
+        capture_output=True,
+    ).stdout
+
+    drift = compare(clean_dump(dump), SCHEMA_SQL_PATH.read_text())
+    if drift:
+        raise click.ClickException(
+            "db/schema.sql does not match the migrated schema:\n"
+            f"{drift.report()}\n\n"
+            "Apply the migration to your dev database, then run "
+            "`ring db autogenerate-schema` and commit db/schema.sql."
+        )
+    click.echo("db/schema.sql matches the migrated schema.")
 
 
 @compose_exec("generate", db, "api", "ring")

--- a/dev_util/schema_drift.py
+++ b/dev_util/schema_drift.py
@@ -1,0 +1,116 @@
+"""Compare `ring/db/schema.sql` against a database built from migrations.
+
+pytest builds its schema from `schema.sql` while production is built by
+alembic, so the two can disagree without any existing check noticing. That
+matters most for tables and columns: a migration that adds a column without
+`ring db autogenerate-schema` leaves the suite testing a schema prod does
+not have.
+
+Only table and column *names* are compared. Column defaults, index ordering
+and sequences already diverge (migrations emit `unique_rowid()`, the
+committed dump still carries `nextval(...)` sequences), and reconciling that
+is a separate change.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# APScheduler creates its own table at runtime; no migration owns it.
+UNMIGRATED_TABLES = frozenset({"public.apscheduler_jobs"})
+
+_TABLE_RE = re.compile(r"CREATE TABLE ([^\s(]+) \((.*?)\n\);", re.S)
+_NON_COLUMN_PREFIXES = (
+    "CONSTRAINT",
+    "INDEX",
+    "UNIQUE INDEX",
+    "VECTOR INDEX",
+    "INVERTED INDEX",
+    "FAMILY",
+)
+
+
+def clean_dump(raw: str) -> str:
+    """Turn `SHOW CREATE ALL TABLES` output into plain SQL.
+
+    The CLI quotes every statement and doubles interior quotes, so unwrap via
+    a placeholder the same way `ring db autogenerate-schema` does.
+    """
+    cleaned = raw.replace('""', "%").replace('"', "").replace("%", '"')
+    lines = cleaned.split("\n")
+    if lines and "create_statement" in lines[0]:
+        lines = lines[1:]
+    return "\n".join(lines)
+
+
+def parse_tables(sql: str) -> dict[str, set[str]]:
+    """Map each `CREATE TABLE` to its set of column names."""
+    tables: dict[str, set[str]] = {}
+    for match in _TABLE_RE.finditer(sql):
+        name = match.group(1).replace('"', "")
+        columns: set[str] = set()
+        for line in match.group(2).split("\n"):
+            line = line.strip().rstrip(",")
+            if not line or line.startswith(_NON_COLUMN_PREFIXES):
+                continue
+            columns.add(line.split()[0].replace('"', ""))
+        tables[name] = columns
+    return tables
+
+
+@dataclass
+class Drift:
+    missing_from_schema_sql: set[str] = field(default_factory=set)
+    missing_from_migrations: set[str] = field(default_factory=set)
+    column_diffs: dict[str, tuple[set[str], set[str]]] = field(
+        default_factory=dict
+    )
+
+    def __bool__(self) -> bool:
+        return bool(
+            self.missing_from_schema_sql
+            or self.missing_from_migrations
+            or self.column_diffs
+        )
+
+    def report(self) -> str:
+        lines: list[str] = []
+        for table in sorted(self.missing_from_schema_sql):
+            lines.append(
+                f"  {table}: created by migrations, absent from schema.sql"
+            )
+        for table in sorted(self.missing_from_migrations):
+            lines.append(
+                f"  {table}: in schema.sql, not created by migrations"
+            )
+        for table, (only_sql, only_mig) in sorted(self.column_diffs.items()):
+            if only_sql:
+                lines.append(
+                    f"  {table}: columns only in schema.sql: "
+                    f"{sorted(only_sql)}"
+                )
+            if only_mig:
+                lines.append(
+                    f"  {table}: columns only from migrations: "
+                    f"{sorted(only_mig)}"
+                )
+        return "\n".join(lines)
+
+
+def compare(migrated_sql: str, committed_sql: str) -> Drift:
+    migrated = parse_tables(migrated_sql)
+    committed = parse_tables(committed_sql)
+
+    drift = Drift(
+        missing_from_schema_sql=set(migrated) - set(committed),
+        missing_from_migrations=(
+            set(committed) - set(migrated) - UNMIGRATED_TABLES
+        ),
+    )
+    for table in sorted(set(migrated) & set(committed)):
+        only_sql = committed[table] - migrated[table]
+        only_mig = migrated[table] - committed[table]
+        if only_sql or only_mig:
+            drift.column_diffs[table] = (only_sql, only_mig)
+    return drift


### PR DESCRIPTION
## Summary

Adds the migration safety gate that the CD plan ([#301](https://github.com/neil-sriv/ring/pull/301)) lists as unchecked under *Rules that make auto-deploy safe*. This is a **prerequisite for Phase 4** ([#334](https://github.com/neil-sriv/ring/pull/334)), where deploys run `alembic upgrade head` against CockroachDB Cloud with nobody watching.

Today nothing in CI exercises the revision chain: `ring/tests/conftest.py` builds the test schema by executing `ring/db/schema.sql`, not by running migrations. A broken revision can merge and only surface in production.

## What it does

`.github/workflows/check_migrations.yml` starts a fresh test CockroachDB and then:

1. **Applies every revision from an empty database** — `ring db check-migrations`
2. **Compares `db/schema.sql` against the migrated result** — `ring db check-schema-drift`

Runs on push to `dev` and on PRs, and is `workflow_call`-able so the deploy job gates on it in Phase 4.

## The vector index step

Building this caught a real failure on the first run:

```
sqlalchemy.exc.NotSupportedError: vector indexes are not enabled;
enable with the feature.vector_index.enabled cluster setting
[SQL: CREATE VECTOR INDEX IF NOT EXISTS embedding_vector_idx ...]
```

`alembic upgrade head` cannot succeed on a virgin cluster without that setting. It is a cluster-level prerequisite applied out of band everywhere else — `conftest.py` for pytest, `.cursor/cloud-start.sh` for dev — so the workflow does the same before migrating.

## Scope of the drift check

`dev_util/schema_drift.py` compares **table and column names**. It deliberately does not compare defaults or index ordering, because those already diverge: migrations emit `unique_rowid()` while the committed dump still carries `nextval(...)` sequences, and `apscheduler_jobs` is created by APScheduler at runtime rather than by any migration (allowlisted).

Verified against the current tree: 22 tables, **0 column-set differences**, so this passes today while catching the drift that matters — a migration that adds or removes a table/column without `ring db autogenerate-schema` leaves pytest testing a schema production does not have.

Reconciling the sequence-vs-`unique_rowid()` divergence is a separate change, noted in the plan. CockroachDB treats sequential IDs as a hotspot anti-pattern, so the migrations are likely the correct side.

## Test plan

- [x] Fresh `ring-test-cockroach`: fails without the cluster setting, applies all revisions cleanly with it
- [x] Drift check reports clean on the current tree
- [x] Drift check fails on an added column, an added table, and a stale table in `schema.sql`
- [x] `ruff check` / `ruff format --check`
- [ ] Confirm the job passes on this PR