### PR TITLE
ci: add push-button Deploy ring-api workflow (CD phase 3)

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -1,0 +1,82 @@
+name: Deploy ring-api
+
+# Phase 3 of the CD plan (docs/continuous-deploy-plan.md): push-button host
+# rollout. Deliberately manual — Phase 4 adds the automatic trigger after
+# several clean runs. The host script is the interface; this job only SSHs
+# and runs it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Published ring-api image tag (git SHA). Empty = this ref.
+        required: false
+        type: string
+
+concurrency:
+  group: prod-deploy
+  cancel-in-progress: false
+
+env:
+  ECR_IMAGE: public.ecr.aws/z2k1e8p1/ring-api
+
+jobs:
+  resolve:
+    name: Resolve SHA
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.sha.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Pick target SHA
+        id: sha
+        run: |
+          sha="${{ inputs.sha }}"
+          if [[ -z "$sha" ]]; then
+            sha="${{ github.sha }}"
+          fi
+          sha="$(git rev-parse --verify "${sha}^{commit}")"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          echo "Deploy target ${sha}"
+
+      - name: Require published image
+        run: |
+          sha="${{ steps.sha.outputs.sha }}"
+          if ! docker manifest inspect "${{ env.ECR_IMAGE }}:${sha}" >/dev/null; then
+            echo "No ${{ env.ECR_IMAGE }}:${sha}. Wait for Publish ring-api, or pass a SHA that job tagged." >&2
+            exit 1
+          fi
+
+  test:
+    name: Backend tests
+    needs: resolve
+    uses: ./.github/workflows/run_test.yml
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+
+  deploy:
+    name: Roll out on EC2
+    needs: [resolve, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH deploy_host.sh
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.PROD_SSH_HOST }}
+          username: ${{ secrets.PROD_SSH_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          port: ${{ vars.PROD_SSH_PORT || 22 }}
+          command_timeout: 15m
+          script_stop: true
+          script: |
+            set -euo pipefail
+            APP_DIR="${{ vars.PROD_APP_DIR }}"
+            if [[ -z "$APP_DIR" ]]; then
+              APP_DIR="$HOME/ring"
+            fi
+            cd "$APP_DIR"
+            ./dev_util/deploy_host.sh --rollback-on-fail "${{ needs.resolve.outputs.sha }}"

--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -1,8 +1,8 @@
 name: Publish ring-api
 
-# Phase 2 of the CD plan (see PR #301): every backend-touching push to
-# dev publishes a SHA-tagged image. This does not restart EC2 — pull +
-# swap is still manual until Phase 3.
+# Phase 2 of the CD plan (docs/continuous-deploy-plan.md): every
+# backend-touching push to dev publishes a SHA-tagged image. This does not
+# restart EC2 — use Actions → Deploy ring-api (or deploy_host.sh on the box).
 
 on:
   push:

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -6,6 +6,12 @@ on:
       - dev
   pull_request:
     # Run for all PRs regardless of base to better support stacked PRs
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref / SHA to test (default: caller github.sha)"
+        required: false
+        type: string
 
 jobs:
   build:
@@ -17,6 +23,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref || github.sha }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,8 @@ Full topology, request flows, and deploy steps:
 
 Prod's two halves ship independently: the frontend redeploys itself about a
 minute after any push to `dev`, while the API only moves when someone runs
-`deploy_host.sh`. `ring deploy status` prints what each is running.
+Actions → **Deploy ring-api** or `deploy_host.sh` on the box.
+`ring deploy status` prints what each is running.
 
 Do not assume ECS, RDS, Route 53, Redis/Celery, Lambda, or Bedrock — none are
 in the current prod path. Embeddings go through the optional `ring-llm`

--- a/README.md
+++ b/README.md
@@ -232,7 +232,19 @@ ring deploy prod -t "$(git rev-parse HEAD)"   # ring-api only
 
 ### Deploy on the host
 
-SSH into the EC2 host, then:
+Push-button: Actions → **Deploy ring-api** (`workflow_dispatch`, optional
+SHA input). It resolves the SHA, fails fast if `ring-api:<sha>` is not in
+ECR Public, runs the backend tests, then SSHs to EC2 and runs
+`deploy_host.sh --rollback-on-fail`. The `prod-deploy` concurrency group
+queues runs so two deploys cannot race migrations.
+
+Needs repo secrets `PROD_SSH_HOST` (EC2 public IP or gray-cloud DNS —
+Cloudflare will not forward SSH on the orange `ring.neilsriv.tech`),
+`PROD_SSH_USER`, `PROD_SSH_KEY` (dedicated deploy key, not a laptop key).
+Optional repo variables: `PROD_SSH_PORT` (22), `PROD_APP_DIR`
+(`$HOME/ring`).
+
+Or SSH in yourself:
 
 ```bash
 cd ring

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -174,7 +174,10 @@ differ:
 | | Trigger | Push → live |
 |---|---------|-------------|
 | Frontend | Automatic, every push to `dev` | ~1 minute |
-| API | Manual `deploy_host.sh` on EC2 | whenever someone runs it |
+| API | Actions → **Deploy ring-api**, or `deploy_host.sh` on EC2 | whenever someone runs it |
+
+Making the API half automatic is Phase 4 of the CD plan; see
+[continuous-deploy-plan.md](continuous-deploy-plan.md).
 
 ### Deploy the frontend (automatic)
 
@@ -211,6 +214,21 @@ ring deploy prod -t "$(git rev-parse HEAD)"
 ```
 
 ### Deploy on the EC2 host
+
+Push-button: Actions → **Deploy ring-api**. It resolves the target SHA,
+fails fast if `ring-api:<sha>` is missing from ECR Public, runs the
+backend tests for that SHA (`run_test.yml` via `workflow_call`), then
+SSHs and runs `./dev_util/deploy_host.sh --rollback-on-fail <sha>`.
+Concurrency group `prod-deploy` queues (does not cancel) so two runs
+cannot race migrations.
+
+Secrets: `PROD_SSH_HOST` (raw EC2 IP or gray-cloud name — Cloudflare
+will not forward SSH on the orange `ring.neilsriv.tech`),
+`PROD_SSH_USER`, `PROD_SSH_KEY` (dedicated deploy key, not a laptop
+key). Optional vars: `PROD_SSH_PORT` (22), `PROD_APP_DIR` (`$HOME/ring`).
+
+The job is deliberately `workflow_dispatch` only. Flipping it to run
+automatically is Phase 4.
 
 Prod runs the API **image filesystem** (no `./ring` bind-mount, no
 uvicorn `--reload`). The one-shot host script still checkouts git so


### PR DESCRIPTION
## Summary

Phase 3 of the CD plan ([#301](https://github.com/neil-sriv/ring/pull/301)): deploying the API becomes one click instead of an SSH session. **Supersedes [#310](https://github.com/neil-sriv/ring/pull/310)**, which I am closing.

Deliberately `workflow_dispatch` only. The plan calls for flipping to automatic *"after several clean push-button runs"*, and the `PROD_SSH_*` secrets are not configured yet, so this job has never executed. Phase 4 is a separate PR held back until this one has real runs behind it.

## What it does

`.github/workflows/deploy_api.yml`:

1. Resolves the target SHA (input, or this ref)
2. Fails fast if `public.ecr.aws/z2k1e8p1/ring-api:<sha>` does not exist
3. Runs the backend tests for that SHA
4. SSHs to EC2 and runs `./dev_util/deploy_host.sh --rollback-on-fail <sha>`

The host script stays the interface — Actions does not run a pile of remote commands. Concurrency group `prod-deploy` queues rather than cancels, so two deploys cannot race migrations. `run_test.yml` gains `workflow_call` with a `ref` input.

## Fixes a YAML bug from #310

That branch's `run_test.yml` input description is an unquoted scalar containing `: `:

```
description: Git ref / SHA to test (default: caller github.sha)
```

`yaml.safe_load` rejects it (`mapping values are not allowed here`, line 12), which would have broken the entire test workflow, not just the new input. Quoted here.

## Before merging

Add repo secrets — use a dedicated deploy key, not a laptop key:

| Secret | Value |
|---|---|
| `PROD_SSH_HOST` | EC2 public IP or gray-cloud DNS. **Not** `ring.neilsriv.tech` — Cloudflare will not forward SSH |
| `PROD_SSH_USER` | deploy user |
| `PROD_SSH_KEY` | private key |

Optional variables: `PROD_SSH_PORT` (22), `PROD_APP_DIR` (`$HOME/ring`).

## Test plan

- [x] All three workflow files parse under `yaml.safe_load`
- [ ] Add the SSH secrets
- [ ] Actions → Deploy ring-api against a published SHA; `/api/v1/version` `image_build.sha` matches
- [ ] Second click while the first runs queues instead of cancelling
- [ ] A rollback drill before Phase 4 flips this to automatic

Made with [Cursor](https://cursor.com)