### PR TITLE
ci: auto-deploy ring-api after publish (CD phase 4)

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -1,9 +1,13 @@
 name: Deploy ring-api
 
-# Phase 3 of the CD plan (docs/continuous-deploy-plan.md): push-button host
-# rollout. Deliberately manual — Phase 4 adds the automatic trigger after
-# several clean runs. The host script is the interface; this job only SSHs
+# Phase 4 of the CD plan (docs/continuous-deploy-plan.md): backend merges to
+# dev deploy themselves. The host script is the interface; this job only SSHs
 # and runs it.
+#
+# Triggering on workflow_run rather than `push: dev` is deliberate: the image
+# has to exist before we deploy, and a push trigger would race publish_api.
+# It also inherits that workflow's backend path filter, so docs-only merges
+# deploy nothing.
 
 on:
   workflow_dispatch:
@@ -12,6 +16,10 @@ on:
         description: Published ring-api image tag (git SHA). Empty = this ref.
         required: false
         type: string
+  workflow_run:
+    workflows: ["Publish ring-api"]
+    types: [completed]
+    branches: [dev]
 
 concurrency:
   group: prod-deploy
@@ -23,6 +31,13 @@ env:
 jobs:
   resolve:
     name: Resolve SHA
+    # A failed publish must not deploy the previous image over a newer one.
+    # DEPLOY_PAUSED freezes the automatic path during an incident; manual
+    # dispatch stays open so a rollback is still one click away.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       vars.DEPLOY_PAUSED != 'true')
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.sha.outputs.sha }}
@@ -35,7 +50,11 @@ jobs:
       - name: Pick target SHA
         id: sha
         run: |
-          sha="${{ inputs.sha }}"
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            sha="${{ github.event.workflow_run.head_sha }}"
+          else
+            sha="${{ inputs.sha }}"
+          fi
           if [[ -z "$sha" ]]; then
             sha="${{ github.sha }}"
           fi
@@ -58,9 +77,16 @@ jobs:
     with:
       ref: ${{ needs.resolve.outputs.sha }}
 
+  migrations:
+    name: Migration check
+    needs: resolve
+    uses: ./.github/workflows/check_migrations.yml
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+
   deploy:
     name: Roll out on EC2
-    needs: [resolve, test]
+    needs: [resolve, test, migrations]
     runs-on: ubuntu-latest
     steps:
       - name: SSH deploy_host.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,9 @@ Full topology, request flows, and deploy steps:
 | Container registry | ECR Public `public.ecr.aws/z2k1e8p1/` | [dev_util/docker.py](dev_util/docker.py), [dev_util/prod.sh](dev_util/prod.sh), [dev_util/deploy_host.sh](dev_util/deploy_host.sh) |
 | Frontend hosting | Cloudflare Workers Builds (`ring-frontend`), auto-deploys every push to `dev` | [react/wrangler.jsonc](react/wrangler.jsonc), [react/plugins/version-stamp.ts](react/plugins/version-stamp.ts) |
 
-Prod's two halves ship independently: the frontend redeploys itself about a
-minute after any push to `dev`, while the API only moves when someone runs
-Actions → **Deploy ring-api** or `deploy_host.sh` on the box.
+Both halves of prod deploy themselves from `dev`: the frontend about a
+minute after any push, the API about 2–3 minutes after a backend-touching
+push (Publish ring-api → Deploy ring-api). Docs-only merges deploy nothing.
 `ring deploy status` prints what each is running.
 
 Do not assume ECS, RDS, Route 53, Redis/Celery, Lambda, or Bedrock — none are

--- a/README.md
+++ b/README.md
@@ -224,19 +224,26 @@ Pushes to `dev` that touch backend paths publish `ring-api:latest` and
 prod is Cloudflare Workers; do not build `ring-frontend` unless you are
 rolling back to the nginx SPA.
 
-Laptop fallback:
+`ring deploy prod` defaults to `ring-llm` (still manual). Day-to-day
+`ring-api` publishes via CI; laptop API builds confirm first:
 
 ```bash
-ring deploy prod -t "$(git rev-parse HEAD)"   # ring-api only
+ring deploy prod -i ring-llm
+ring deploy prod -i ring-api -t "$(git rev-parse HEAD)"   # break-glass; confirms
 ```
 
 ### Deploy on the host
 
-Push-button: Actions → **Deploy ring-api** (`workflow_dispatch`, optional
-SHA input). It resolves the SHA, fails fast if `ring-api:<sha>` is not in
-ECR Public, runs the backend tests, then SSHs to EC2 and runs
-`deploy_host.sh --rollback-on-fail`. The `prod-deploy` concurrency group
-queues runs so two deploys cannot race migrations.
+Automatic: a backend merge to `dev` publishes an image, and a successful
+publish runs **Deploy ring-api** — backend tests, migration check, then SSH
+to EC2 and `deploy_host.sh --rollback-on-fail`. The `prod-deploy`
+concurrency group queues runs so two deploys cannot race migrations.
+
+The same workflow is a `workflow_dispatch` button (optional SHA input) for
+manual deploys and rollbacks.
+
+To freeze automatic deploys during an incident, set the repo variable
+`DEPLOY_PAUSED=true`. Manual runs still work, so rollback stays available.
 
 Needs repo secrets `PROD_SSH_HOST` (EC2 public IP or gray-cloud DNS —
 Cloudflare will not forward SSH on the orange `ring.neilsriv.tech`),

--- a/dev_util/deploy.py
+++ b/dev_util/deploy.py
@@ -27,7 +27,7 @@ from dev_util.frontend import fe_build
 DEFAULT_VITE_API_URL = "https://ring.neilsriv.tech"
 DEFAULT_AWS_REGION = "us-east-1"
 ECR_PUBLIC_REGISTRY = "public.ecr.aws"
-DEFAULT_DEPLOY_IMAGES = ("ring-api",)
+MANUAL_DEPLOY_IMAGES = ("ring-llm",)
 DEPLOY_HOST_SCRIPT = Path(ROOT_DIR) / "dev_util" / "deploy_host.sh"
 
 
@@ -110,8 +110,8 @@ def _build_llm_image() -> None:
     "-i",
     type=click.Choice(IMAGE_TAG_NAMES),
     multiple=True,
-    default=DEFAULT_DEPLOY_IMAGES,
-    help="Images to build and push (default: ring-api).",
+    default=MANUAL_DEPLOY_IMAGES,
+    help="Images to build and push (default: ring-llm only).",
 )
 @click.option(
     "--extra-tag",
@@ -134,11 +134,22 @@ def deploy_prod(
 ) -> None:
     """Build, tag, and push production images to public ECR.
 
-    Default is ring-api only. Frontend prod is Cloudflare; ring-llm is
-    manual. Laptop builds are the fallback — CI publishes SHA tags on
-    push to dev.
+    ring-api publishes via CI on push to dev and deploys via Deploy ring-api.
+    Frontend prod is Cloudflare. Only ring-llm still uses laptop builds.
     """
-    images = list(image) or list(DEFAULT_DEPLOY_IMAGES)
+    images = list(image) or list(MANUAL_DEPLOY_IMAGES)
+    # Kept usable on purpose: if CI or ECR is down, a laptop build is the
+    # only way to ship. Confirm rather than block.
+    for retired, reason in (
+        ("ring-api", "CI publishes it on every push to dev"),
+        ("ring-frontend", "prod frontend is Cloudflare Workers"),
+    ):
+        if retired in images:
+            click.confirm(
+                f"{retired} is no longer built from a laptop ({reason}). "
+                "Continue anyway?",
+                abort=True,
+            )
     compose_services = [
         COMPOSE_SERVICE_BY_IMAGE[name]
         for name in images
@@ -201,8 +212,8 @@ def deploy_status(
     """Show which commit is live on prod, and how long ago it shipped.
 
     The frontend deploys itself on every push to dev (Cloudflare Workers
-    Builds); the API only moves when someone runs `ring deploy host`. This
-    is how you tell the two apart.
+    Builds). The API auto-deploys after Publish ring-api on dev (Deploy
+    ring-api); manual fallback is `ring deploy host` / deploy_host.sh.
     """
     components = collect(base_url)
     behind_by_name = {

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -174,10 +174,11 @@ differ:
 | | Trigger | Push → live |
 |---|---------|-------------|
 | Frontend | Automatic, every push to `dev` | ~1 minute |
-| API | Actions → **Deploy ring-api**, or `deploy_host.sh` on EC2 | whenever someone runs it |
+| API | Automatic, after **Publish ring-api** succeeds on `dev` | ~2–3 minutes |
 
-Making the API half automatic is Phase 4 of the CD plan; see
-[continuous-deploy-plan.md](continuous-deploy-plan.md).
+Both halves are automatic; see
+[continuous-deploy-plan.md](continuous-deploy-plan.md). Docs-only merges
+deploy nothing, because publishing is path-filtered to backend paths.
 
 ### Deploy the frontend (automatic)
 
@@ -207,28 +208,38 @@ Requires repo secrets `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` with
 push access to that registry. Use a dedicated IAM user for GitHub Actions,
 not laptop keys.
 
-Laptop fallback (API only by default):
+`ring deploy prod` defaults to `ring-llm`. Day-to-day `ring-api` is CI;
+laptop API builds are break-glass and confirm before building:
 
 ```bash
-ring deploy prod -t "$(git rev-parse HEAD)"
+ring deploy prod -i ring-llm
+ring deploy prod -i ring-api -t "$(git rev-parse HEAD)"
 ```
 
 ### Deploy on the EC2 host
 
-Push-button: Actions → **Deploy ring-api**. It resolves the target SHA,
-fails fast if `ring-api:<sha>` is missing from ECR Public, runs the
-backend tests for that SHA (`run_test.yml` via `workflow_call`), then
-SSHs and runs `./dev_util/deploy_host.sh --rollback-on-fail <sha>`.
-Concurrency group `prod-deploy` queues (does not cancel) so two runs
-cannot race migrations.
+**Deploy ring-api** runs automatically once **Publish ring-api** succeeds
+on `dev`, and is also available as a `workflow_dispatch` button for manual
+deploys and rollbacks. It resolves the target SHA, fails fast if
+`ring-api:<sha>` is missing from ECR Public, runs the backend tests and the
+migration check for that SHA, then SSHs and runs
+`./dev_util/deploy_host.sh --rollback-on-fail <sha>`. Concurrency group
+`prod-deploy` queues (does not cancel) so two runs cannot race migrations.
+
+A failed publish never deploys: the job is gated on
+`workflow_run.conclusion == 'success'`.
+
+**Freezing deploys during an incident.** Set the repo variable
+`DEPLOY_PAUSED=true` (Settings → Secrets and variables → Actions →
+Variables). Automatic deploys stop; merges to `dev` still publish images,
+they just do not roll out. Manual **Deploy ring-api** runs are deliberately
+*not* blocked, so you can still deploy a fix or roll back while paused.
+Delete the variable, or set it to anything other than `true`, to resume.
 
 Secrets: `PROD_SSH_HOST` (raw EC2 IP or gray-cloud name — Cloudflare
 will not forward SSH on the orange `ring.neilsriv.tech`),
 `PROD_SSH_USER`, `PROD_SSH_KEY` (dedicated deploy key, not a laptop
 key). Optional vars: `PROD_SSH_PORT` (22), `PROD_APP_DIR` (`$HOME/ring`).
-
-The job is deliberately `workflow_dispatch` only. Flipping it to run
-automatically is Phase 4.
 
 Prod runs the API **image filesystem** (no `./ring` bind-mount, no
 uvicorn `--reload`). The one-shot host script still checkouts git so

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12.1"
 
 [manifest]
@@ -1038,7 +1038,7 @@ wheels = [
 [[package]]
 name = "llm"
 version = "0.1.0"
-source = { editable = "llm" }
+source = { virtual = "llm" }
 dependencies = [
     { name = "fastapi", extra = ["all"] },
     { name = "google-genai" },


### PR DESCRIPTION
## Summary

Phase 4 of the CD plan ([#301](https://github.com/neil-sriv/ring/pull/301)) — a backend merge to `dev` reaches production on its own.

**Prerequisites done:** [#332](https://github.com/neil-sriv/ring/pull/332) and [#333](https://github.com/neil-sriv/ring/pull/333) merged, SSH secrets set, one clean **Deploy ring-api** run succeeded, [#335](https://github.com/neil-sriv/ring/pull/335) force-checkout fix merged. Rebased onto current `dev`.

## What changes

- **Auto-trigger** — `workflow_run` on *Publish ring-api* completing on `dev`. `workflow_dispatch` stays for manual deploys and rollbacks.
- **Migration gate** — deploy waits on `check_migrations.yml` as well as backend tests.
- **Escape hatch** — repo variable `DEPLOY_PAUSED=true` freezes automatic deploys. Manual dispatch stays open so rollback still works while paused.
- **`ring deploy prod`** — defaults to `ring-llm`; `ring-api` / `ring-frontend` confirm rather than hard-error.

## Trigger note

Uses `workflow_run` (not `push: dev`) so deploy starts only after the image exists and inherits the backend path filter. Docs-only merges deploy nothing. Failed publishes cannot deploy.

## After merge

1. Next backend-touching push to `dev` → Publish ring-api → Deploy ring-api automatically.
2. Optional: set `DEPLOY_PAUSED=true` once to confirm auto path skips while manual still works, then clear it.
3. Watch `/api/v1/version` `image_build.sha` match the published commit.

## Test plan

- [x] Rebased onto `dev` (includes #335)
- [x] One clean manual Deploy ring-api run
- [ ] Merge this PR
- [ ] Watch the next backend merge auto-deploy end to end
- [ ] (Optional) Verify `DEPLOY_PAUSED=true` skips auto while manual still works