### PR TITLE
fix(deploy): force-checkout on host so dirty uv.lock cannot block deploys

### DIFF
--- a/dev_util/deploy_host.sh
+++ b/dev_util/deploy_host.sh
@@ -14,7 +14,7 @@
 # publish_api.yml run). Docs-only origin/dev tips have no image tag.
 #
 # First apply of the image-filesystem cutover (old script still on disk):
-#   git fetch origin && git checkout -B dev <this-sha>
+#   git fetch origin && git checkout -f -B dev <this-sha>
 #   ./dev_util/deploy_host.sh --skip-git <this-sha>
 # --rollback-on-fail captures live /version image_build.sha *before*
 # mutating. The pre-cutover script on the box still asserts git.sha and
@@ -203,7 +203,10 @@ if [[ "$SKIP_GIT" -eq 0 ]]; then
     SHA="$(git rev-parse --verify "${SHA}^{commit}")"
   fi
   # Stay on a named branch so later `git pull` still works.
-  git checkout -B "$BRANCH" "$SHA"
+  # -f: discard local edits to tracked files (e.g. a host-side `uv`
+  # rewriting uv.lock). Untracked files like .env are left alone. Prod
+  # runs the image filesystem; the checkout only supplies compose/nginx.
+  git checkout -f -B "$BRANCH" "$SHA"
 else
   if [[ -z "$SHA" ]]; then
     SHA="$(git rev-parse HEAD)"


### PR DESCRIPTION
## Summary
- `deploy_host.sh` now uses `git checkout -f -B` so local edits to tracked files on EC2 (e.g. a host-side `uv` rewriting `uv.lock`) cannot abort the deploy
- Untracked files like `.env` are still left alone; prod runs the image filesystem, and the checkout only supplies compose/nginx

## Context
The first **Deploy ring-api** run failed after SSH succeeded:

```
error: Your local changes to the following files would be overwritten by checkout:
	uv.lock
```

## Test plan
- [ ] On EC2 once (chicken-and-egg for the first apply): `git checkout -- uv.lock` so the *current* on-disk script can proceed
- [ ] Re-run Actions → **Deploy ring-api**; confirm checkout succeeds
- [ ] Optionally dirty `uv.lock` on the host again and re-deploy a SHA that includes this commit — should no longer fail

Made with [Cursor](https://cursor.com)