### PR TITLE
docs: continuous deploy as the live prod path

### DIFF
--- a/.github/workflows/check_migrations.yml
+++ b/.github/workflows/check_migrations.yml
@@ -1,6 +1,6 @@
 name: Check migrations
 
-# Safety gate for the CD plan (docs/continuous-deploy-plan.md): deploys run
+# Safety gate for continuous deploy (docs/continuous-deploy.md): deploys run
 # `alembic upgrade head` against CockroachDB Cloud with nobody watching, and
 # the pytest suite builds its schema from ring/db/schema.sql — so without
 # this job nothing ever proves the revision chain applies.

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -1,8 +1,8 @@
 name: Deploy ring-api
 
-# Phase 4 of the CD plan (docs/continuous-deploy-plan.md): backend merges to
-# dev deploy themselves. The host script is the interface; this job only SSHs
-# and runs it.
+# Phase 4 of continuous deploy (docs/continuous-deploy.md): backend merges
+# to `dev` deploy themselves. The host script is the interface; this job
+# only SSHs and runs it.
 #
 # Triggering on workflow_run rather than `push: dev` is deliberate: the image
 # has to exist before we deploy, and a push trigger would race publish_api.

--- a/.github/workflows/publish_api.yml
+++ b/.github/workflows/publish_api.yml
@@ -1,8 +1,8 @@
 name: Publish ring-api
 
-# Phase 2 of the CD plan (docs/continuous-deploy-plan.md): every
-# backend-touching push to dev publishes a SHA-tagged image. This does not
-# restart EC2 — use Actions → Deploy ring-api (or deploy_host.sh on the box).
+# Continuous deploy (docs/continuous-deploy.md): every backend-touching push
+# to `dev` publishes a SHA-tagged image. A successful run triggers Deploy
+# ring-api.
 
 on:
   push:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,9 @@ used only by tooling (e.g. OpenAPI spec fetching).
 
 Local dev uses Docker Compose with a local CockroachDB container. **Production**
 is a single EC2 host running the same Compose stack, plus managed services below.
-Full topology, request flows, and deploy steps:
-[docs/infrastructure.md](docs/infrastructure.md).
+Full topology, request flows, and Cloudflare/EC2 wiring:
+[docs/infrastructure.md](docs/infrastructure.md). Continuous deploy path:
+[docs/continuous-deploy.md](docs/continuous-deploy.md).
 
 | Service | Identifier / endpoint | Code / config |
 |---------|----------------------|---------------|
@@ -46,12 +47,43 @@ Full topology, request flows, and deploy steps:
 
 Both halves of prod deploy themselves from `dev`: the frontend about a
 minute after any push, the API about 2–3 minutes after a backend-touching
-push (Publish ring-api → Deploy ring-api). Docs-only merges deploy nothing.
-`ring deploy status` prints what each is running.
+push (Publish ring-api → Deploy ring-api). Docs-only merges deploy nothing
+for the API. `ring deploy status` prints what each is running.
+
+Canonical deploy doc: [docs/continuous-deploy.md](docs/continuous-deploy.md).
+Topology: [docs/infrastructure.md](docs/infrastructure.md).
 
 Do not assume ECS, RDS, Route 53, Redis/Celery, Lambda, or Bedrock — none are
 in the current prod path. Embeddings go through the optional `ring-llm`
 microservice; background work uses in-process APScheduler, not Celery.
+
+### Continuous deploy (agents)
+
+Merges to `dev` ship themselves. Treat every backend-touching PR as a
+prod deploy:
+
+- **Additive migrations only.** Auto-deploy runs `alembic upgrade head`
+  against CockroachDB Cloud with nobody watching. Drops/renames are
+  two-step. CI gate: `.github/workflows/check_migrations.yml` (also
+  `ring db check-migrations` / `ring db check-schema-drift` locally).
+  After a migration that changes tables/columns, refresh
+  `ring/db/schema.sql` with `ring db autogenerate-schema` — pytest builds
+  from that dump, not from Alembic.
+- **Backend-first PRs** ([`ring-split-pr`](.cursor/skills/ring-split-pr/SKILL.md)).
+  Frontend deploys within minutes of merge; OpenAPI-consuming UI must
+  land only after the API change is live (check
+  `https://ring.neilsriv.tech/api/v1/version` / `ring deploy status`).
+- **Do not invent laptop `ring deploy prod` for `ring-api`.** CI publishes
+  images. That command defaults to `ring-llm` and confirms before
+  building `ring-api` / `ring-frontend`. Host rollout is
+  `deploy_host.sh` / Actions → **Deploy ring-api**.
+- **Incident freeze:** repo variable `DEPLOY_PAUSED=true` stops automatic
+  EC2 rollouts; manual Deploy still works for rollback.
+- **Never** build images on the EC2 host or attach `ring.neilsriv.tech`
+  as a Cloudflare Worker custom domain (use Workers Routes with `/api/*`
+  and `/.well-known/*` passthrough — see continuous-deploy.md).
+- Bundler / `vite.config.ts` build changes need a `vite preview` browser
+  check; `pnpm run build` alone has shipped a blank runtime page.
 
 ## Codebase map
 
@@ -176,15 +208,21 @@ this mode.
 | TypeScript           | `cd react && npx tsc --noEmit`                                 |
 | Frontend build       | `cd react && pnpm run build`                                   |
 | Backend tests        | `ring test run` (Compose `compose.test.yml`, profile `test`)   |
+| Migrations (CD gate) | `ring db check-migrations` then `ring db check-schema-drift`   |
 
 Backend tests run inside a dedicated `ring-test-runner` container against a
-separate CockroachDB instance on port 8008.
+separate CockroachDB instance on port 8008. The migration gate applies every
+Alembic revision to an empty test DB (CI: `check_migrations.yml`) — required
+because pytest builds schema from `ring/db/schema.sql`, not Alembic.
 
 ## Design preferences
 
 - **Split big changes into PRs.** Land backend (models, migrations, API,
   tests, OpenAPI) first; follow with `ring fe regen` + UI in a second PR. Each
-  PR should pass `ring check lint` and the relevant tests on its own.
+  PR should pass `ring check lint` and the relevant tests on its own. Under
+  continuous deploy this is load-bearing: the frontend half of a stacked
+  change can reach prod minutes after merge while the API half is still
+  rolling (or paused).
 - **Prefer existing timeout mechanisms.** For operational resilience (e.g.
   long-running image uploads), use Nginx proxy timeouts and the
   botocore/boto3 / FastAPI built-in timeouts rather than rolling custom

--- a/README.md
+++ b/README.md
@@ -206,10 +206,10 @@ ring run shell      # Start a shell
 
 ## Deployment
 
-Prod runs Docker Compose on a single EC2 instance. Images are stored in **ECR
-Public** (`public.ecr.aws/z2k1e8p1/`); the database is **CockroachDB Cloud**
-(`ring-db`). See [docs/infrastructure.md](docs/infrastructure.md) for the full
-topology (S3, CloudFront, SES, request flows).
+Prod deploys continuously from `dev`. See
+[docs/continuous-deploy.md](docs/continuous-deploy.md) for the full path
+(workflows, secrets, rollback, safety rules) and
+[docs/infrastructure.md](docs/infrastructure.md) for topology.
 
 ### Deploy the frontend
 
@@ -220,9 +220,8 @@ ring-frontend** check on the commit.
 ### Publish API images
 
 Pushes to `dev` that touch backend paths publish `ring-api:latest` and
-`ring-api:<sha>` to ECR Public (Actions → **Publish ring-api**). Frontend
-prod is Cloudflare Workers; do not build `ring-frontend` unless you are
-rolling back to the nginx SPA.
+`ring-api:<sha>` to ECR Public (Actions → **Publish ring-api**). A
+successful publish auto-triggers **Deploy ring-api**.
 
 `ring deploy prod` defaults to `ring-llm` (still manual). Day-to-day
 `ring-api` publishes via CI; laptop API builds confirm first:
@@ -234,22 +233,9 @@ ring deploy prod -i ring-api -t "$(git rev-parse HEAD)"   # break-glass; confirm
 
 ### Deploy on the host
 
-Automatic: a backend merge to `dev` publishes an image, and a successful
-publish runs **Deploy ring-api** — backend tests, migration check, then SSH
-to EC2 and `deploy_host.sh --rollback-on-fail`. The `prod-deploy`
-concurrency group queues runs so two deploys cannot race migrations.
-
-The same workflow is a `workflow_dispatch` button (optional SHA input) for
-manual deploys and rollbacks.
-
-To freeze automatic deploys during an incident, set the repo variable
-`DEPLOY_PAUSED=true`. Manual runs still work, so rollback stays available.
-
-Needs repo secrets `PROD_SSH_HOST` (EC2 public IP or gray-cloud DNS —
-Cloudflare will not forward SSH on the orange `ring.neilsriv.tech`),
-`PROD_SSH_USER`, `PROD_SSH_KEY` (dedicated deploy key, not a laptop key).
-Optional repo variables: `PROD_SSH_PORT` (22), `PROD_APP_DIR`
-(`$HOME/ring`).
+Automatic after every successful **Publish ring-api** on `dev`. Manual /
+rollback: Actions → **Deploy ring-api** (optional SHA). Freeze auto with
+repo variable `DEPLOY_PAUSED=true` (manual dispatch still works).
 
 Or SSH in yourself:
 
@@ -259,12 +245,11 @@ cd ring
 # uv run ring deploy host <sha>            # same script
 ```
 
-That syncs git (compose/nginx), pulls `ring-api:<sha>`, runs
+That force-checkouts git (compose/nginx), pulls `ring-api:<sha>`, runs
 `uv run ring db upgrade --profile prod`, recreates Compose, and checks
-`GET /api/v1/version` (`image_build.sha`). Prod runs the image
-filesystem — pass a SHA that `publish_api.yml` actually tagged, not a
-docs-only `HEAD`. To roll back an image without reverting compose to a
-pre-cutover commit: `./dev_util/deploy_host.sh --skip-git <sha>`.
+`GET /api/v1/version` (`image_build.sha`). Pass a SHA that
+`publish_api.yml` actually tagged. Image-only restore:
+`./dev_util/deploy_host.sh --skip-git <sha>`.
 
 ### See what is live
 

--- a/docs/continuous-deploy.md
+++ b/docs/continuous-deploy.md
@@ -1,0 +1,221 @@
+# Continuous deploy
+
+**Every merge to `dev` can ship to production.** Frontend rebuilds on
+*any* push to `dev` (~1–2 minutes). Backend-touching merges also publish
+and roll out the API (~2–3 minutes). Docs/skills-only merges skip the
+API track entirely — they still redeploy an identical frontend bundle.
+
+This is the live prod path. Topology and Cloudflare/EC2 wiring live in
+[infrastructure.md](infrastructure.md). Agent-facing rules are summarized
+in [AGENTS.md](../AGENTS.md).
+
+---
+
+## Per-merge behavior
+
+| Merge touches | What runs | Time to live |
+|---------------|-----------|--------------|
+| `react/` only | Cloudflare Workers Builds → Worker deploy | ~1–2 min |
+| `ring/` (and related backend paths) | Publish ring-api → tests + migrations → EC2 swap | ~2–3 min |
+| both | both tracks in parallel | ~3 min |
+| docs / skills / non-backend only | nothing for API; frontend still rebuilds on any `dev` push | ~1–2 min |
+
+Backend path filter for publish (also inherited by auto-deploy):
+
+`ring/**`, `pyproject.toml`, `uv.lock`, `compose.core.yml`,
+`compose.prod.yml`, `.github/workflows/publish_api.yml`.
+
+---
+
+## Architecture (two independent tracks)
+
+```
+dev push
+ ├─ react/** (any push, actually) ──► Cloudflare Workers Builds ──► ring-frontend Worker
+ │                                      ring.neilsriv.tech/*  (routes)
+ │
+ └─ backend paths ──► Publish ring-api ──► ECR :latest + :<sha>
+                         │
+                         └─ (on success) Deploy ring-api
+                              ├─ pytest (target SHA)
+                              ├─ alembic upgrade head + schema drift check
+                              └─ SSH → deploy_host.sh --rollback-on-fail <sha>
+                                   └─ EC2: git checkout -f, prod.sh, migrate, compose up, /version gate
+```
+
+Frontend and API share `ring.neilsriv.tech` via Cloudflare Workers Routes:
+
+1. `ring.neilsriv.tech/api/*` → passthrough (nginx / API / WebSockets)
+2. `ring.neilsriv.tech/.well-known/*` → passthrough (Let's Encrypt ACME)
+3. `ring.neilsriv.tech/*` → `ring-frontend` Worker
+
+Never attach the custom domain directly to the Worker — that swallows
+`/api/*` and takes the API down.
+
+Prod API runs the **image filesystem** (no `./ring` bind-mount, no
+uvicorn `--reload`). The host git checkout only supplies compose, nginx,
+and `.env`. Migrations run *inside* the API container.
+
+---
+
+## Workflows and scripts
+
+| Piece | Path |
+|-------|------|
+| Publish images | [`.github/workflows/publish_api.yml`](../.github/workflows/publish_api.yml) |
+| Deploy (auto + manual) | [`.github/workflows/deploy_api.yml`](../.github/workflows/deploy_api.yml) |
+| Migration + schema drift gate | [`.github/workflows/check_migrations.yml`](../.github/workflows/check_migrations.yml) |
+| Host rollout | [`dev_util/deploy_host.sh`](../dev_util/deploy_host.sh) / `uv run ring deploy host` |
+| Image pull only | [`dev_util/prod.sh`](../dev_util/prod.sh) |
+| What is live | `uv run ring deploy status` |
+
+### Deploy job shape
+
+1. Resolve SHA (`workflow_run.head_sha`, or dispatch input, or `github.sha`)
+2. Fail fast if `public.ecr.aws/z2k1e8p1/ring-api:<sha>` is missing
+3. Run backend tests and `check_migrations` for that SHA
+4. SSH to EC2 and run `./dev_util/deploy_host.sh --rollback-on-fail <sha>`
+
+Concurrency group `prod-deploy` **queues** (does not cancel) so two
+deploys cannot race migrations.
+
+Auto-deploy uses `workflow_run` on **Publish ring-api** completing — not
+`push: dev`. A push trigger would race the image build. Failed publishes
+never deploy (`conclusion == 'success'`).
+
+`deploy_host.sh` force-checkouts tracked files (`git checkout -f -B`) so
+host-side drift like a rewritten `uv.lock` cannot abort the deploy.
+Untracked files (`.env`) are left alone.
+
+---
+
+## Secrets and variables
+
+| Name | Kind | Purpose |
+|------|------|---------|
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | secret | Publish to ECR Public |
+| `PROD_SSH_HOST` | secret | EC2 public IP or **gray-cloud** DNS — not orange `ring.neilsriv.tech` (Cloudflare will not forward SSH) |
+| `PROD_SSH_USER` | secret | Linux user on the box (`ubuntu` / `ec2-user`) |
+| `PROD_SSH_KEY` | secret | Dedicated deploy **private** key (ed25519). Not a laptop key. Set with `gh secret set PROD_SSH_KEY < ~/.ssh/ring-prod-deploy` |
+| `PROD_SSH_PORT` | variable | Optional; default `22` |
+| `PROD_APP_DIR` | variable | Optional; default `$HOME/ring` |
+| `DEPLOY_PAUSED` | variable | Set to `true` to freeze **automatic** deploys |
+
+### Freezing auto-deploy
+
+```text
+Settings → Secrets and variables → Actions → Variables
+DEPLOY_PAUSED = true
+```
+
+Merges still publish images; they do not roll out. Manual **Deploy
+ring-api** is deliberately *not* blocked, so rollback stays one click.
+Delete the variable (or set it to anything other than `true`) to resume.
+
+Longer term, OIDC + SSM `SendCommand` would remove the standing SSH key;
+SSH is the current path.
+
+---
+
+## Rollback
+
+```bash
+# Preferred: Actions → Deploy ring-api, sha = previous published image SHA
+# Or on the box:
+./dev_util/deploy_host.sh <previous-published-sha>
+# Image-only restore without changing compose checkout:
+./dev_util/deploy_host.sh --skip-git <previous-published-sha>
+```
+
+`--rollback-on-fail` captures live `image_build.sha` *before* mutating
+and restores that image if `/api/v1/version` does not match after swap.
+
+The SHA must exist as `ring-api:<sha>` in ECR (a Publish ring-api run).
+Docs-only `origin/dev` tips often have **no** image tag.
+
+---
+
+## Verify what is live
+
+```bash
+uv run ring deploy status
+curl -sS -A 'ring/1.0' https://ring.neilsriv.tech/version.json       # frontend
+curl -sS -A 'ring/1.0' https://ring.neilsriv.tech/api/v1/version     # API
+```
+
+Use a non-default User-Agent — Cloudflare rejects Python-urllib's default
+with 1010/403. In the app: **Settings → Build**.
+
+For the API, `image_build.sha` is the running code (baked into the image).
+`git` is unavailable in prod after the image-filesystem cutover.
+
+---
+
+## Laptop / break-glass builds
+
+CI publishes `ring-api`. Frontend prod is Cloudflare.
+
+```bash
+ring deploy prod -i ring-llm                  # still manual
+ring deploy prod -i ring-api -t "$(git rev-parse HEAD)"   # confirms first
+```
+
+`ring deploy prod` defaults to `ring-llm` and prompts before building
+`ring-api` / `ring-frontend`. Prefer CI unless ECR or Actions is down.
+
+---
+
+## Safety rules (required for auto-deploy)
+
+1. **Migrations must be additive / backwards-compatible.** They run
+   unattended against CockroachDB Cloud. Destructive changes are
+   two-step: deploy code that stops using the column, then a later
+   migration drops it.
+2. **CI proves the revision chain.** `check_migrations.yml` applies
+   every Alembic revision to an empty test CockroachDB and compares
+   table/column names to `ring/db/schema.sql` (pytest builds from that
+   dump). After adding a migration, run `ring db autogenerate-schema`
+   when the dump should change.
+3. **Backend-first PRs** ([`ring-split-pr`](../.cursor/skills/ring-split-pr/SKILL.md)).
+   The frontend track deploys within minutes of merge; OpenAPI-consuming
+   UI must land only after the API change is live.
+4. **Bundler / Vite config changes** need a `vite preview` browser check
+   — `pnpm run build` alone has shipped a blank page that crashed at
+   runtime.
+5. **Never build images on the EC2 `t2.micro`.** CI builds; the box only
+   pulls.
+6. **Vector index cluster setting** is out-of-band
+   (`feature.vector_index.enabled`) — set in test CI, `conftest.py`, and
+   `cloud-start.sh`. Migrations that create vector indexes assume it.
+
+`ring-llm` does **not** join CD (heavy / inactive).
+
+---
+
+## Optional leftovers (not required for CD)
+
+Prod SPA already comes from Cloudflare. These only tidy EC2:
+
+- Delete unused `www.ring.*` Workers Routes or add DNS
+- Remove leftover `frontend` service from `compose.prod.yml` (~300MB)
+- Remove nginx SPA `proxy_pass` to `ring-frontend`
+- Drop `ring-frontend` from `IMAGE_TAG_NAMES` if unused
+
+---
+
+## How we got here (phases)
+
+| Phase | Outcome | Status |
+|-------|---------|--------|
+| 1 | Cloudflare Workers Routes for prod SPA | Done |
+| 2 | CI SHA-tagged `ring-api` images on `dev` | Done (#303) |
+| 3 | Push-button `Deploy ring-api` + `deploy_host.sh` | Done (#333) |
+| 4 | Auto-deploy after successful publish | Done (#334) |
+| 5 | Optional EC2 frontend cleanup | Open |
+
+Incidents that shaped the design: attaching the domain to the Worker
+(swallowed `/api`); ECR cache needing OCI single-manifest export;
+image-only rollback while `./ring` was still bind-mounted; `--skip-git`
+compose sync silently corrupting the host checkout; Cockroach
+`/health?ready=1` going green before SQL auth worked; host `uv.lock`
+drift aborting plain `git checkout`.

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -163,22 +163,19 @@ Embedding generation → ring-llm microservice (not AWS Bedrock)
 
 ## Deployment
 
-Roadmap: [PR #301](https://github.com/neil-sriv/ring/pull/301) — frontend
-via Cloudflare Workers Routes, backend via CI-built SHA-tagged images.
-Frontend prod traffic already hits the Worker (`/*`); `/api/*` and
-`/.well-known/*` still pass through to this nginx.
+Prod deploys continuously from `dev`. Full path, secrets, rollback, and
+safety rules: [continuous-deploy.md](continuous-deploy.md).
 
 The two halves ship on **different triggers**, so their commits routinely
 differ:
 
 | | Trigger | Push → live |
 |---|---------|-------------|
-| Frontend | Automatic, every push to `dev` | ~1 minute |
-| API | Automatic, after **Publish ring-api** succeeds on `dev` | ~2–3 minutes |
+| Frontend | Automatic, every push to `dev` (Cloudflare Workers Builds) | ~1–2 minutes |
+| API | Automatic after **Publish ring-api** succeeds on `dev` | ~2–3 minutes |
 
-Both halves are automatic; see
-[continuous-deploy-plan.md](continuous-deploy-plan.md). Docs-only merges
-deploy nothing, because publishing is path-filtered to backend paths.
+Docs-only merges deploy nothing for the API (publish is path-filtered).
+Frontend still rebuilds on any `dev` push.
 
 ### Deploy the frontend (automatic)
 
@@ -242,8 +239,8 @@ will not forward SSH on the orange `ring.neilsriv.tech`),
 key). Optional vars: `PROD_SSH_PORT` (22), `PROD_APP_DIR` (`$HOME/ring`).
 
 Prod runs the API **image filesystem** (no `./ring` bind-mount, no
-uvicorn `--reload`). The one-shot host script still checkouts git so
-compose/nginx on disk match the deploy:
+uvicorn `--reload`). The host script force-checkouts git so compose/nginx
+on disk match the deploy:
 
 ```bash
 cd ring


### PR DESCRIPTION
## Summary

Stacks on [#334](https://github.com/neil-sriv/ring/pull/334). Turns the CD roadmap into the live operational doc and wires agents to it.

- Add [`docs/continuous-deploy.md`](docs/continuous-deploy.md) — per-merge behavior, workflow graph, secrets/`DEPLOY_PAUSED`, rollback, verify, safety rules, Phase 5 leftovers, short history
- Expand [`AGENTS.md`](AGENTS.md) with a **Continuous deploy (agents)** section (additive migrations, backend-first, no laptop `ring deploy prod` for day-to-day API, pause variable, Workers Routes pitfall) and add the migration CI gate to Quality gates
- Point README + `docs/infrastructure.md` at the new doc; drop stale “laptop fallback defaults to ring-api” wording
- Update workflow header comments to reference `continuous-deploy.md` instead of the old plan filename

Closes the doc gap left by [#301](https://github.com/neil-sriv/ring/pull/301) still being open — this is the canonical file on the Phase 4 stack rather than rewriting #301 in place.

## Test plan

- [ ] Skim `docs/continuous-deploy.md` for accuracy against live workflows
- [ ] Confirm AGENTS.md links resolve
- [ ] Merge after #334 (or merge #334 first, then retarget this to `dev`)

Made with [Cursor](https://cursor.com)