### PR TITLE
feat(deploy): add ring deploy history for rollback SHAs

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -88,6 +88,9 @@ jobs:
     name: Roll out on EC2
     needs: [resolve, test, migrations]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
     steps:
       - name: SSH deploy_host.sh
         uses: appleboy/ssh-action@v1.2.2
@@ -106,3 +109,47 @@ jobs:
             fi
             cd "$APP_DIR"
             ./dev_util/deploy_host.sh --rollback-on-fail "${{ needs.resolve.outputs.sha }}"
+
+      # Append-only history for `ring deploy history` / rollback picks.
+      # Best-effort: a bookkeeping failure must not fail a successful host
+      # rollout (or hide it from history when conclusion != success).
+      - name: Record GitHub Deployment
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = '${{ needs.resolve.outputs.sha }}';
+            const event = '${{ github.event_name }}';
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+              environment: 'production-api',
+              auto_merge: false,
+              required_contexts: [],
+              description: `ring-api ${sha.slice(0, 7)} via ${event}`,
+              payload: {
+                event,
+                workflow: 'Deploy ring-api',
+                run_id: context.runId,
+              },
+            });
+            const id = deployment.data?.id;
+            if (!id) {
+              core.warning(
+                `createDeployment returned no id (status ${deployment.status}); ` +
+                  'skipping deployment status. Host rollout already succeeded.'
+              );
+              return;
+            }
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: id,
+              state: 'success',
+              environment: 'production-api',
+              environment_url: 'https://ring.neilsriv.tech',
+              description: 'deploy_host.sh completed',
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+            core.info(`Recorded production-api deployment ${sha}`);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,8 @@ prod deploy:
   building `ring-api` / `ring-frontend`. Host rollout is
   `deploy_host.sh` / Actions → **Deploy ring-api**.
 - **Incident freeze:** repo variable `DEPLOY_PAUSED=true` stops automatic
-  EC2 rollouts; manual Deploy still works for rollback.
+  EC2 rollouts; manual Deploy still works for rollback. Pick a prior SHA
+  with `ring deploy history` (or `ring deploy status` for what's live).
 - **Never** build images on the EC2 host or attach `ring.neilsriv.tech`
   as a Cloudflare Worker custom domain (use Workers Routes with `/api/*`
   and `/.well-known/*` passthrough — see continuous-deploy.md).

--- a/dev_util/deploy.py
+++ b/dev_util/deploy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -244,6 +245,76 @@ def deploy_status(
         click.echo(
             f"  {format_component(component, behind_by_name[component.name], ref)}"
         )
+
+
+@dev_command("history", deploy)
+@click.option(
+    "--limit",
+    "-n",
+    type=int,
+    default=20,
+    show_default=True,
+    help="Max rows to show.",
+)
+@click.option(
+    "--resolve/--no-resolve",
+    default=False,
+    show_default=True,
+    help="Parse Actions logs for Deploy complete (<sha>) when no "
+    "GitHub Deployment records exist yet (slower).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON instead of a table.",
+)
+def deploy_history(
+    ctx: click.Context,
+    limit: int,
+    resolve: bool,
+    as_json: bool,
+    *args: list[Any],
+    **kwargs: dict[Any, Any],
+) -> None:
+    """List recent API deploys so you can pick a rollback SHA.
+
+    Prefers GitHub Deployments recorded by Deploy ring-api
+    (environment=production-api). Falls back to workflow runs; pass
+    --resolve to parse logs for the exact image SHA.
+    """
+    from dev_util.deploy_history import as_dicts, collect, format_record
+
+    try:
+        records = collect(limit, resolve_logs=resolve)
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            "gh CLI not found — install GitHub CLI to use deploy history."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or str(exc)).strip()
+        raise click.ClickException(detail or "gh command failed") from exc
+
+    if as_json:
+        click.echo(json.dumps({"deployments": as_dicts(records)}, indent=2))
+        return
+
+    if not records:
+        click.echo(
+            "No deploy history yet. Successful Deploy ring-api runs record "
+            "a GitHub Deployment (production-api); older runs need --resolve "
+            "to parse logs."
+        )
+        return
+
+    click.echo("API deploy history (newest first) — use sha with:")
+    click.echo(
+        "  Actions → Deploy ring-api, or ./dev_util/deploy_host.sh <sha>"
+    )
+    click.echo("")
+    for record in records:
+        click.echo(format_record(record))
 
 
 @dev_command("host", deploy)

--- a/dev_util/deploy_history.py
+++ b/dev_util/deploy_history.py
@@ -1,0 +1,216 @@
+"""Deploy history for `ring deploy history`.
+
+Successful **Deploy ring-api** runs record a GitHub Deployment with
+`environment=production-api` and `ref=<image sha>`. Older runs (before that
+recording existed) fall back to parsing Actions logs for
+`Deploy complete (<sha>)`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from typing import Any
+
+DEPLOY_WORKFLOW = "Deploy ring-api"
+PRODUCTION_ENV = "production-api"  # distinct from Cloudflare "production"
+COMPLETE_RE = re.compile(r"Deploy complete \(([0-9a-f]{7,40})\)")
+TARGET_RE = re.compile(r"Deploy target ([0-9a-f]{7,40})")
+RING_API_DESC_PREFIX = "ring-api "
+
+
+@dataclass
+class DeployRecord:
+    sha: str
+    short_sha: str
+    when: str
+    event: str
+    conclusion: str
+    source: str
+    url: str | None = None
+    run_id: int | None = None
+
+
+def _gh_json(args: list[str]) -> Any:
+    result = subprocess.run(
+        ["gh", *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout) if result.stdout.strip() else None
+
+
+def _short(sha: str) -> str:
+    return sha[:7] if len(sha) >= 7 else sha
+
+
+def deployments(limit: int) -> list[DeployRecord]:
+    """List GitHub Deployments recorded by Deploy ring-api."""
+    raw = _gh_json(
+        [
+            "api",
+            f"repos/{{owner}}/{{repo}}/deployments"
+            f"?environment={PRODUCTION_ENV}&per_page={limit}",
+        ]
+    )
+    if not isinstance(raw, list):
+        return []
+
+    records: list[DeployRecord] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        sha = item.get("sha") or item.get("ref")
+        if not isinstance(sha, str) or len(sha) < 7:
+            continue
+        desc = item.get("description") or ""
+        payload = (
+            item.get("payload")
+            if isinstance(item.get("payload"), dict)
+            else {}
+        )
+        workflow = (
+            payload.get("workflow") if isinstance(payload, dict) else None
+        )
+        # Ignore stale Cloudflare / unrelated production deployments.
+        if workflow != DEPLOY_WORKFLOW and not (
+            isinstance(desc, str) and desc.startswith(RING_API_DESC_PREFIX)
+        ):
+            continue
+        event = payload.get("event") if isinstance(payload, dict) else None
+        records.append(
+            DeployRecord(
+                sha=sha,
+                short_sha=_short(sha),
+                when=str(item.get("created_at") or ""),
+                event=str(event or item.get("task") or "deploy"),
+                conclusion="success",
+                source="github_deployment",
+                url=item.get("url")
+                if isinstance(item.get("url"), str)
+                else None,
+            )
+        )
+        if len(records) >= limit:
+            break
+    return records
+
+
+def _sha_from_run_logs(run_id: int) -> tuple[str, str] | None:
+    """Return (sha, source) from Actions logs, or None."""
+    result = subprocess.run(
+        ["gh", "run", "view", str(run_id), "--log"],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    text = (result.stdout or "") + (result.stderr or "")
+    complete = COMPLETE_RE.search(text)
+    if complete:
+        return complete.group(1), "workflow_log_complete"
+    target = TARGET_RE.search(text)
+    if target:
+        return target.group(1), "workflow_log_target"
+    return None
+
+
+def workflow_runs(limit: int, *, resolve_sha: bool) -> list[DeployRecord]:
+    """Fall back to Deploy ring-api workflow runs (and optionally their logs)."""
+    runs = _gh_json(
+        [
+            "run",
+            "list",
+            "--workflow",
+            DEPLOY_WORKFLOW,
+            "--limit",
+            str(limit),
+            "--json",
+            "databaseId,conclusion,event,headSha,createdAt,url,displayTitle",
+        ]
+    )
+    if not isinstance(runs, list):
+        return []
+
+    records: list[DeployRecord] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        run_id = run.get("databaseId")
+        conclusion = str(run.get("conclusion") or "unknown")
+        sha: str | None = None
+        source = "workflow_run_head"
+        if resolve_sha and isinstance(run_id, int):
+            parsed = _sha_from_run_logs(run_id)
+            if parsed:
+                sha, source = parsed
+        if not sha:
+            head = run.get("headSha")
+            sha = head if isinstance(head, str) else None
+        if not sha:
+            continue
+        # Keep successful jobs. Also keep host-complete rollouts whose later
+        # bookkeeping step failed (conclusion=failure but Deploy complete in
+        # logs) — those are real prod deploys.
+        if conclusion != "success" and source != "workflow_log_complete":
+            continue
+        records.append(
+            DeployRecord(
+                sha=sha,
+                short_sha=_short(sha),
+                when=str(run.get("createdAt") or ""),
+                event=str(run.get("event") or ""),
+                conclusion=conclusion,
+                source=source,
+                url=run.get("url")
+                if isinstance(run.get("url"), str)
+                else None,
+                run_id=run_id if isinstance(run_id, int) else None,
+            )
+        )
+    return records
+
+
+def collect(
+    limit: int = 20, *, resolve_logs: bool = False
+) -> list[DeployRecord]:
+    """Prefer GitHub Deployments; fill remaining slots from workflow runs."""
+    records = deployments(limit)
+    if len(records) >= limit:
+        return records[:limit]
+
+    seen = {r.sha for r in records}
+    for run in workflow_runs(limit, resolve_sha=resolve_logs or not records):
+        if run.sha in seen:
+            continue
+        records.append(run)
+        seen.add(run.sha)
+        if len(records) >= limit:
+            break
+    return records[:limit]
+
+
+def format_record(record: DeployRecord) -> str:
+    when = record.when.replace("T", " ").replace("Z", " UTC")
+    bits = [
+        record.short_sha,
+        record.conclusion.ljust(8),
+        record.event.ljust(16),
+        when,
+    ]
+    if record.source == "workflow_run_head":
+        bits.append(
+            "(headSha — may differ from deployed image; use --resolve)"
+        )
+    elif (
+        record.source == "workflow_log_complete"
+        and record.conclusion != "success"
+    ):
+        bits.append("(host ok; Actions job failed after rollout)")
+    return "  ".join(bits)
+
+
+def as_dicts(records: list[DeployRecord]) -> list[dict[str, Any]]:
+    return [asdict(r) for r in records]

--- a/docs/continuous-deploy.md
+++ b/docs/continuous-deploy.md
@@ -68,6 +68,7 @@ and `.env`. Migrations run *inside* the API container.
 | Host rollout | [`dev_util/deploy_host.sh`](../dev_util/deploy_host.sh) / `uv run ring deploy host` |
 | Image pull only | [`dev_util/prod.sh`](../dev_util/prod.sh) |
 | What is live | `uv run ring deploy status` |
+| Deploy history / rollback SHAs | `uv run ring deploy history` |
 
 ### Deploy job shape
 
@@ -119,8 +120,18 @@ SSH is the current path.
 
 ## Rollback
 
+Find a previous good SHA:
+
 ```bash
-# Preferred: Actions → Deploy ring-api, sha = previous published image SHA
+ring deploy history              # GitHub Deployments from successful rollouts
+ring deploy history --resolve    # also parse older Actions logs (slower)
+ring deploy status               # what is live right now
+```
+
+Then:
+
+```bash
+# Preferred: Actions → Deploy ring-api, sha = previous good image SHA
 # Or on the box:
 ./dev_util/deploy_host.sh <previous-published-sha>
 # Image-only restore without changing compose checkout:
@@ -131,7 +142,8 @@ SSH is the current path.
 and restores that image if `/api/v1/version` does not match after swap.
 
 The SHA must exist as `ring-api:<sha>` in ECR (a Publish ring-api run).
-Docs-only `origin/dev` tips often have **no** image tag.
+Docs-only `origin/dev` tips often have **no** image tag. **Deploy ring-api** runs also create a GitHub Deployment
+(`environment=production-api`) for `ring deploy history`.
 
 ---
 


### PR DESCRIPTION
## Summary

Stacks on [#336](https://github.com/neil-sriv/ring/pull/336) (CD docs) / [#334](https://github.com/neil-sriv/ring/pull/334) (Phase 4).

- `ring deploy history` lists recent API rollouts so you can pick a rollback SHA
- Successful **Deploy ring-api** runs record a GitHub Deployment (`environment=production-api`, distinct from stale Cloudflare `production` deployments)
- Until those records exist, history falls back to Deploy workflow runs and can `--resolve` SHAs from Actions logs (`Deploy complete (<sha>)`)

```bash
ring deploy history
ring deploy history --resolve -n 10
ring deploy history --json
```

## Test plan

- [x] `ring deploy history --resolve -n 3` shows the successful Phase 3 deploy (`dea0b2d`)
- [x] Stale Cloudflare `production` deployments are ignored
- [ ] After merge + next Deploy: history prefers `production-api` GitHub Deployments without `--resolve`

Made with [Cursor](https://cursor.com)