### PR TITLE
fix(deploy): unblock host checkout when uv.lock is dirty

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -108,6 +108,14 @@ jobs:
               APP_DIR="$HOME/ring"
             fi
             cd "$APP_DIR"
+            # Chicken-and-egg: the host runs whatever deploy_host.sh is already
+            # on disk. If that copy predates `git checkout -f` (#335) and tracked
+            # files are dirty (e.g. host-side uv rewriting uv.lock), checkout
+            # fails and the fixed script never lands. Discard local edits to
+            # tracked files first (.env stays untracked). Then run the script —
+            # after this bootstrap it will be the tip's version with -f.
+            git fetch --prune origin
+            git reset --hard HEAD
             ./dev_util/deploy_host.sh --rollback-on-fail "${{ needs.resolve.outputs.sha }}"
 
       # Append-only history for `ring deploy history` / rollback picks.

--- a/docs/continuous-deploy.md
+++ b/docs/continuous-deploy.md
@@ -85,7 +85,11 @@ Auto-deploy uses `workflow_run` on **Publish ring-api** completing — not
 never deploy (`conclusion == 'success'`).
 
 `deploy_host.sh` force-checkouts tracked files (`git checkout -f -B`) so
-host-side drift like a rewritten `uv.lock` cannot abort the deploy.
+host-side drift like a rewritten `uv.lock` cannot abort the deploy. The
+Actions SSH step also `git reset --hard HEAD` before invoking the script,
+so a host stuck on a pre-`-f` copy of `deploy_host.sh` can still pick up
+the fix (without that bootstrap, dirty tracked files block checkout
+forever).
 Untracked files (`.env`) are left alone.
 
 ---


### PR DESCRIPTION
## Summary
- Host still runs the **on-disk** `deploy_host.sh`. #335's `git checkout -f` is on `dev` but never landed on EC2 because dirty `uv.lock` blocks checkout — chicken-and-egg.
- Actions SSH step now `git fetch` + `git reset --hard HEAD` before calling the script (untracked `.env` preserved), then `deploy_host.sh` can check out the tip (with `-f`).

## Test plan
- [ ] Merge, then Actions → Deploy ring-api with SHA `47a6838d5d694a26587c015656f115b460e41878` (or empty = this ref once published)
- [ ] Or one-time on host: `cd ~/ring && git reset --hard HEAD`, then re-run Deploy
- [ ] Confirm Roll out gets past `Syncing git` / `uv.lock`
- [ ] `curl -sS https://ring.neilsriv.tech/api/v1/version` shows the target SHA


Made with [Cursor](https://cursor.com)