### PR TITLE
Mirror Cloudflare dashboard observability settings in wrangler config

### DIFF
--- a/react/wrangler.jsonc
+++ b/react/wrangler.jsonc
@@ -10,5 +10,24 @@
   "assets": {
     "directory": "./dist",
     "not_found_handling": "single-page-application"
+  },
+  // Mirrors the observability settings enabled in the Cloudflare dashboard so
+  // deploys from this config don't reset them. Assets-only Workers emit no
+  // invocation logs, so this stays inside the free tier until a `main` script
+  // is added. Docs: https://developers.cloudflare.com/workers/observability/
+  "observability": {
+    "enabled": false,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": true
+    },
+    "traces": {
+      "enabled": false,
+      "persist": true,
+      "head_sampling_rate": 1
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Observability (Workers Logs) was enabled for the `ring-frontend` Worker in the Cloudflare dashboard. On deploy, the wrangler config is the source of truth, so without this block the next Workers Builds deploy would silently reset the dashboard settings. The dashboard prompts you to copy this exact block into the config for that reason.

## What

Adds the dashboard-generated `observability` block to `react/wrangler.jsonc`, verbatim:

- `logs.enabled: true` with 100% head sampling, invocation logs, and dashboard persistence (the granular `logs` block takes precedence over the top-level `enabled: false`, which is the legacy combined switch).
- `traces.enabled: false` — tracing stays off.

## Cost

Effectively zero. This is an assets-only Worker (no `main` script): static asset requests never invoke Worker code and do not generate Workers Logs events, so nothing is billed. Even if a script is added later, the free allotment is 200k log events/day (Free) or 20M/month included (Paid, then $0.60/million).

## Validation

- `pnpm dlx wrangler@latest deploy --dry-run` with wrangler 4.124.0 parses the config cleanly with no unknown-field warnings and reads all 22 assets from `dist`.
- Frontend build and Biome lint pass; unrelated pre-existing lint drift picked up by `--apply-unsafe` was reverted to keep this change single-purpose.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbe47668-5b32-41b2-a031-37d596f292b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbe47668-5b32-41b2-a031-37d596f292b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

