### PR TITLE
feat(infra): ship prod container logs to CloudWatch Logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Full topology, request flows, and Cloudflare/EC2 wiring:
 | S3 uploads | Bucket `rings3files` (`us-east-1`) | [ring/fastapp/config.py](ring/fastapp/config.py) `BUCKET_NAME`; upload in [ring/letters/crud/response.py](ring/letters/crud/response.py) |
 | CDN | `du32exnxihxuf.cloudfront.net` | [ring/s3/models/s3_model.py](ring/s3/models/s3_model.py) `qualified_s3_url` |
 | Email (SES) | `us-east-1`, sender `ring@neilsriv.tech` | [ring/email_util.py](ring/email_util.py) |
+| Logs (CloudWatch) | Log group `/ring/prod` (`us-east-1`) | `logging:` blocks in [compose.prod.yml](compose.prod.yml); viewing/IAM in [docs/infrastructure.md](docs/infrastructure.md) |
 | Container registry | ECR Public `public.ecr.aws/z2k1e8p1/` | [dev_util/docker.py](dev_util/docker.py), [dev_util/prod.sh](dev_util/prod.sh), [dev_util/deploy_host.sh](dev_util/deploy_host.sh) |
 | Frontend hosting | Cloudflare Workers Builds (`ring-frontend`), auto-deploys every push to `dev` | [react/wrangler.jsonc](react/wrangler.jsonc), [react/plugins/version-stamp.ts](react/plugins/version-stamp.ts) |
 

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,3 +1,18 @@
+# Ship container stdout/stderr to CloudWatch Logs (group /ring/prod) via the
+# Docker awslogs driver. The daemon ships logs itself: no extra container, no
+# extra RAM on the t2.micro. The EC2 instance role MUST allow
+# logs:CreateLogGroup/CreateLogStream/PutLogEvents/DescribeLogStreams *before*
+# this config deploys — the awslogs driver fails container creation when it
+# cannot reach CloudWatch, and deploy_host.sh rollback restores the image but
+# not this compose file. See docs/infrastructure.md ("Backend logs").
+x-awslogs-options: &awslogs-options
+  awslogs-region: us-east-1
+  awslogs-group: /ring/prod
+  awslogs-create-group: "true"
+  # Drop logs instead of blocking app stdout writes if CloudWatch is
+  # unreachable. Dual logging keeps `docker logs` on the host working.
+  mode: non-blocking
+
 services:
   api:
     image: prod-ring-api
@@ -10,6 +25,11 @@ services:
     platform: linux/amd64
     volumes:
       - $HOME/.postgresql/root.crt:/root/.postgresql/root.crt
+    logging:
+      driver: awslogs
+      options:
+        <<: *awslogs-options
+        awslogs-stream: api
 
   nginx:
     mem_limit: 300m
@@ -18,6 +38,11 @@ services:
       - ./prod.nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - ./etc/letsencrypt:/etc/letsencrypt:ro
       - ./certbot/www:/var/www/certbot
+    logging:
+      driver: awslogs
+      options:
+        <<: *awslogs-options
+        awslogs-stream: nginx
   certbot:
     container_name: certbot
     image: certbot/certbot:latest
@@ -27,6 +52,11 @@ services:
     volumes:
       - ./etc/letsencrypt:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot
+    logging:
+      driver: awslogs
+      options:
+        <<: *awslogs-options
+        awslogs-stream: certbot
 
   frontend:
     restart: unless-stopped
@@ -52,6 +82,11 @@ services:
     platform: linux/amd64
     networks:
       - default
+    logging:
+      driver: awslogs
+      options:
+        <<: *awslogs-options
+        awslogs-stream: frontend
 
 volumes:
   pgdata:

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -60,6 +60,7 @@ flowchart TB
 | CDN | Public URLs for uploaded media | CloudFront `du32exnxihxuf.cloudfront.net` → S3 origin |
 | Email | Invites, auth, letter notifications | SES (`us-east-1`), domain `neilsriv.tech`, sender `ring@neilsriv.tech` |
 | Container images | Prod Docker images | ECR Public `public.ecr.aws/z2k1e8p1/` |
+| Logs | Container stdout/stderr | CloudWatch Logs group `/ring/prod` (`us-east-1`) via the Docker `awslogs` driver — see [Backend logs](#backend-logs--cloudwatch) |
 | DNS / TLS | `ring.neilsriv.tech` | DNS at registrar (not Route 53). TLS via Let's Encrypt + certbot on the EC2 host. |
 
 ---
@@ -284,6 +285,88 @@ running code). `git` is unavailable in prod after the cutover (no
 `./.git` mount). `docker.containers[].image_id` / `image_digest` come
 from a host-written snapshot (`.ring-runtime-version.json`, mounted
 read-only). The API does not talk to the Docker Engine.
+
+---
+
+## Backend logs — CloudWatch
+
+Prod containers ship stdout/stderr to **CloudWatch Logs** through the
+Docker `awslogs` log driver, configured in
+[compose.prod.yml](../compose.prod.yml) (and
+[llm/compose.prod.llm.yml](../llm/compose.prod.llm.yml) for the optional
+LLM service). The Docker daemon does the shipping using the EC2 instance
+role — no collector container, no extra RAM on the `t2.micro`. Local dev
+is untouched (default `json-file` driver).
+
+- **Log group:** `/ring/prod` (`us-east-1`), one stream per service:
+  `api`, `nginx`, `frontend`, `certbot`, `llm`.
+- The API emits plain-text loguru + uvicorn lines (request/response
+  logging in [ring/fastapp/fast.py](../ring/fastapp/fast.py); tokens and
+  emails are already redacted by
+  [ring/lib/request_logging.py](../ring/lib/request_logging.py)).
+- `mode: non-blocking` — if CloudWatch is slow or unreachable, log lines
+  are dropped instead of blocking the app's stdout writes.
+- Free tier is 5 GB/month ingest (then ~$0.50/GB in `us-east-1`); this
+  app will not get close unless something is looping.
+
+### Viewing logs
+
+```bash
+aws logs tail /ring/prod --follow                          # all services
+aws logs tail /ring/prod --follow --log-stream-names api   # backend only
+```
+
+Or in the console: CloudWatch → Log groups → `/ring/prod` → **Live
+Tail**, and **Logs Insights** for history, e.g.:
+
+```
+fields @timestamp, @logStream, @message
+| filter @message like /(?i)error/
+| sort @timestamp desc
+| limit 100
+```
+
+On the EC2 host, `docker logs ring-api` still works — Docker's dual
+logging keeps a local cache alongside the remote driver.
+
+### One-time setup (required BEFORE this config deploys)
+
+**Ordering matters.** The `awslogs` driver fails *container creation*
+when the daemon cannot talk to CloudWatch, and
+`deploy_host.sh --rollback-on-fail` restores the previous **image only**
+— the checked-out compose file keeps the logging config. Deploying this
+without IAM in place takes prod down until the policy is attached or the
+compose change is reverted. If needed, freeze automatic deploys with the
+`DEPLOY_PAUSED=true` repo variable while you set this up.
+
+1. Attach this to the EC2 instance role (the one that already talks to
+   S3/SES):
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "logs:CreateLogGroup",
+    "logs:CreateLogStream",
+    "logs:PutLogEvents",
+    "logs:DescribeLogStreams"
+  ],
+  "Resource": [
+    "arn:aws:logs:us-east-1:*:log-group:/ring/prod",
+    "arn:aws:logs:us-east-1:*:log-group:/ring/prod:*"
+  ]
+}
+```
+
+   `logs:CreateLogGroup` is not optional: `awslogs-create-group: "true"`
+   calls it on every container create, even when the group already
+   exists.
+
+2. Cap retention (driver-created groups default to never-expire):
+
+```bash
+aws logs put-retention-policy --log-group-name /ring/prod --retention-in-days 30
+```
 
 ---
 

--- a/llm/compose.prod.llm.yml
+++ b/llm/compose.prod.llm.yml
@@ -7,6 +7,16 @@ services:
     mem_limit: 300m
     platform: linux/amd64
     volumes: []
+    # Same CloudWatch shipping as compose.prod.yml (anchors do not cross
+    # files). Requires the same IAM policy on the EC2 instance role.
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: us-east-1
+        awslogs-group: /ring/prod
+        awslogs-create-group: "true"
+        awslogs-stream: llm
+        mode: non-blocking
 
 networks:
   ring-network:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the decision from the "Self-hosted logging options" conversation (2026-08-11): ship prod backend logs to CloudWatch Logs via the Docker `awslogs` driver — no collector container, no extra RAM on the t2.micro, and stdout is shipped by the Docker daemon using the EC2 instance role.

## Do this BEFORE merging

> [!WARNING]
> The `awslogs` driver fails **container creation** when the daemon cannot reach CloudWatch. `deploy_host.sh --rollback-on-fail` restores the previous image but **not** the compose file, so merging this before the IAM policy is attached takes prod down until IAM is fixed or the commit is reverted. If you need time, set the `DEPLOY_PAUSED=true` repo variable.

Attach this to the EC2 instance role (the one already used for S3/SES):

```json
{
  "Effect": "Allow",
  "Action": [
    "logs:CreateLogGroup",
    "logs:CreateLogStream",
    "logs:PutLogEvents",
    "logs:DescribeLogStreams"
  ],
  "Resource": [
    "arn:aws:logs:us-east-1:*:log-group:/ring/prod",
    "arn:aws:logs:us-east-1:*:log-group:/ring/prod:*"
  ]
}
```

`logs:CreateLogGroup` is required because `awslogs-create-group: "true"` calls it on every container create, even when the group already exists.

After first deploy, cap retention (driver-created groups never expire by default):

```bash
aws logs put-retention-policy --log-group-name /ring/prod --retention-in-days 30
```

## What changed

- `compose.prod.yml`: `logging:` blocks on `api`, `nginx`, `frontend`, `certbot` via a shared `x-awslogs-options` YAML anchor. One stream per service in log group `/ring/prod` (`us-east-1`). `mode: non-blocking` so a CloudWatch outage drops logs instead of blocking the app's stdout writes; dual logging keeps `docker logs` on the host working.
- `llm/compose.prod.llm.yml`: same block inline (stream `llm`) — YAML anchors don't cross files.
- `docs/infrastructure.md`: new "Backend logs — CloudWatch" section with viewing commands (`aws logs tail /ring/prod --follow`, Logs Insights example), the IAM policy, retention, and the deploy-ordering warning; plus a Logs row in the topology table.
- `AGENTS.md`: Logs row in the production services table.

Not touched, per the original plan: `ring/lib/logger.py` and any Python code — the API's existing stdout/stderr output (loguru + uvicorn, secrets already redacted by `ring/lib/request_logging.py`) is exactly what `awslogs` picks up. Local dev keeps the default `json-file` driver.

## Viewing logs once live

```bash
aws logs tail /ring/prod --follow                          # all services
aws logs tail /ring/prod --follow --log-stream-names api   # backend only
```

Or CloudWatch console → Log groups → `/ring/prod` → Live Tail / Logs Insights.

## Validation

- `docker compose -f compose.core.yml -f compose.prod.yml --profile prod --profile certbot config` renders all four services with the merged `awslogs` options (anchor + merge key resolve correctly).
- `docker compose -f llm/compose.llm.yml -f llm/compose.prod.llm.yml --profile prod config` renders the `llm` logging block.
- `docker compose -f compose.core.yml -f compose.dev.yml --profile dev config` contains zero `awslogs` references — dev is untouched.
- End-to-end shipping is only verifiable on the EC2 host after the IAM step, by design.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2aecb5f2-2862-4f23-94f0-dc3559a3fd9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2aecb5f2-2862-4f23-94f0-dc3559a3fd9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

