### PR TITLE
Focus search input when navigating to search via g+s

### DIFF
--- a/.github/workflows/check_migrations.yml
+++ b/.github/workflows/check_migrations.yml
@@ -71,11 +71,22 @@ jobs:
 
       # Cluster-level prerequisite, not something a migration can set for
       # itself. conftest.py does the same for pytest, cloud-start.sh for dev.
+      # Retried because the image entrypoint grants admin to COCKROACH_USER
+      # shortly after the user can authenticate, so the first attempts can
+      # fail with "only users with the MODIFYCLUSTERSETTING privilege ...".
       - name: Enable vector index
         run: |
-          docker exec ring-test-cockroach ./cockroach sql \
-            --url "$TEST_DB_URL" \
-            -e "SET CLUSTER SETTING feature.vector_index.enabled = true;"
+          for attempt in $(seq 1 30); do
+            if docker exec ring-test-cockroach ./cockroach sql \
+                --url "$TEST_DB_URL" \
+                -e "SET CLUSTER SETTING feature.vector_index.enabled = true;"; then
+              echo "Vector index enabled after ${attempt} attempt(s)"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Never got MODIFYCLUSTERSETTING privilege to enable vector index" >&2
+          exit 1
 
       # The test database starts empty, so this applies every revision from
       # scratch. A broken or unapplyable migration fails here, not in prod.

--- a/react/src/lib/globalKeyboardShortcuts.ts
+++ b/react/src/lib/globalKeyboardShortcuts.ts
@@ -15,12 +15,14 @@ interface GlobalShortcutState {
   paletteToggle: (() => void) | null
   helpOpen: (() => void) | null
   isHelpOpen: () => boolean
+  searchFocus: (() => void) | null
 }
 
 const state: GlobalShortcutState = {
   paletteToggle: null,
   helpOpen: null,
   isHelpOpen: () => false,
+  searchFocus: null,
 }
 
 export function registerKeyboardShortcutHandlers(handlers: {
@@ -31,6 +33,10 @@ export function registerKeyboardShortcutHandlers(handlers: {
   state.paletteToggle = handlers.togglePalette
   state.helpOpen = handlers.openHelp
   state.isHelpOpen = handlers.isHelpOpen
+}
+
+export function registerSearchFocusHandler(handler: (() => void) | null) {
+  state.searchFocus = handler
 }
 
 function shouldIgnoreShortcuts(event: KeyboardEvent) {
@@ -65,6 +71,11 @@ export function initGlobalKeyboardShortcuts(router: RegisteredRouter) {
       if (destination) {
         event.preventDefault()
         router.navigate({ to: destination })
+        if (destination === "/search") {
+          // Already on /search: the route doesn't remount, so its mount-time
+          // focus won't run again. Refocus the registered search input.
+          state.searchFocus?.()
+        }
       }
       return
     }

--- a/react/src/routes/_layout/search.tsx
+++ b/react/src/routes/_layout/search.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { Loader2, Search as SearchIcon } from "lucide-react"
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -15,6 +15,7 @@ import { useQuery } from "@tanstack/react-query"
 import type { SearchHit } from "../../client"
 import { performSearchSearchSearchGetOptions } from "../../client/@tanstack/react-query.gen"
 import { SearchResultRow } from "../../components/Common/SearchResultRow"
+import { registerSearchFocusHandler } from "../../lib/globalKeyboardShortcuts"
 
 export const Route = createFileRoute("/_layout/search")({
   component: Search,
@@ -24,6 +25,13 @@ function SearchContent() {
   const [searchQuery, setSearchQuery] = useState("")
   const [submittedQuery, setSubmittedQuery] = useState("")
   const [hasSubmittedSearch, setHasSubmittedSearch] = useState(false)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    searchInputRef.current?.focus()
+    registerSearchFocusHandler(() => searchInputRef.current?.focus())
+    return () => registerSearchFocusHandler(null)
+  }, [])
 
   const {
     data: searchResults,
@@ -67,6 +75,7 @@ function SearchContent() {
       <div className="flex py-8 px-4">
         <div className="relative w-full">
           <Input
+            ref={searchInputRef}
             type="text"
             placeholder="Search..."
             className="h-12 pr-12"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pressing `g` then `s` now lands you in the search input, ready to type — no extra click needed.

- The search page focuses its input on mount, so any navigation to `/search` (g+s, command palette, sidebar) starts with the cursor in the input.
- Pressing g+s while already on `/search` re-focuses the input via a `registerSearchFocusHandler` hook in `globalKeyboardShortcuts.ts`, since the route component doesn't remount in that case.

Focus is applied with a ref + effect rather than the `autoFocus` attribute to stay clear of Biome's `a11y/noAutofocus` rule.

## CI flake fix (rides along)

The first CI run failed in `Check migrations` at the "Enable vector index" step with `only users with the MODIFYCLUSTERSETTING privilege are allowed to set cluster setting 'feature.vector_index.enabled'` — unrelated to this change, and the identical error hit `neil/cursor/stale-send-deferral-fix` earlier today before passing on retry. The Cockroach image's entrypoint lets `COCKROACH_USER` authenticate (so the workflow's `SELECT 1` readiness probe passes) slightly before its admin grant lands, so the very next statement can lose the race. The step now retries the `SET CLUSTER SETTING` for up to 60s, mirroring the wait-loop pattern already used in the workflow.

## Testing

- `cd react && npx tsc --noEmit` — clean
- `cd react && pnpm run lint` — clean (unrelated auto-fixes reverted)
- `cd react && pnpm run build` — succeeds
- Manual browser test on the cloud VM: logged in, pressed g+s from the dashboard, typed immediately into the focused input; then blurred the input by clicking the page heading and pressed g+s again to confirm re-focus.
- Workflow YAML parses and the retry script passes `bash -n`.

<a href="https://cursor.com/agents/bc-05f29331-4add-4ee0-9b95-2411d4192e86/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgs_shortcut_focuses_search_input.mp4"><img src="https://cursor.com/artifacts/c/art-e7bbad57-31c2-47cf-8d0a-b5036b801562" alt="gs_shortcut_focuses_search_input.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05f29331-4add-4ee0-9b95-2411d4192e86?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05f29331-4add-4ee0-9b95-2411d4192e86&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

