### PR TITLE
Add admin reply tracker panel to loop page

### DIFF
--- a/react/src/components/Loops/LoopReplyTracker.tsx
+++ b/react/src/components/Loops/LoopReplyTracker.tsx
@@ -1,0 +1,168 @@
+import { Check, Clock } from "lucide-react"
+import type { PublicLetter, UserUnlinked } from "../../client"
+
+interface ParticipantReplyStatus {
+  participant: UserUnlinked
+  answeredCount: number
+  hasReplied: boolean
+}
+
+export function getParticipantReplyStatuses(
+  loop: PublicLetter,
+): ParticipantReplyStatus[] {
+  const answeredCounts = new Map<string, number>()
+  for (const question of loop.questions) {
+    const respondentIds = new Set(
+      question.responses.map((response) => response.participant.api_identifier),
+    )
+    for (const apiId of respondentIds) {
+      answeredCounts.set(apiId, (answeredCounts.get(apiId) ?? 0) + 1)
+    }
+  }
+
+  const responderIds = new Set(
+    loop.responders.map((responder) => responder.api_identifier),
+  )
+
+  // Roster is the letter's participants; also keep anyone who responded but
+  // is no longer listed as a participant so counts stay consistent.
+  const roster = new Map<string, UserUnlinked>()
+  for (const participant of loop.participants) {
+    roster.set(participant.api_identifier, participant)
+  }
+  for (const responder of loop.responders) {
+    if (!roster.has(responder.api_identifier)) {
+      roster.set(responder.api_identifier, responder)
+    }
+  }
+
+  return [...roster.values()]
+    .map((participant) => {
+      const answeredCount = answeredCounts.get(participant.api_identifier) ?? 0
+      return {
+        participant,
+        answeredCount,
+        hasReplied:
+          answeredCount > 0 || responderIds.has(participant.api_identifier),
+      }
+    })
+    .sort((a, b) => a.participant.name.localeCompare(b.participant.name))
+}
+
+function ReplyStatusChip({
+  status,
+  questionCount,
+}: {
+  status: ParticipantReplyStatus
+  questionCount: number
+}) {
+  const showAnsweredCount = status.hasReplied && questionCount > 0
+  const chipTitle = showAnsweredCount
+    ? `${status.participant.name} answered ${
+        status.answeredCount
+      } of ${questionCount} question${questionCount !== 1 ? "s" : ""}`
+    : status.hasReplied
+      ? `${status.participant.name} has replied`
+      : `${status.participant.name} hasn't replied yet`
+
+  return (
+    <li
+      title={chipTitle}
+      className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm ${
+        status.hasReplied
+          ? "border-green-600/30 bg-green-50 text-green-800 dark:border-green-400/30 dark:bg-green-950 dark:text-green-200"
+          : "border-border bg-muted text-muted-foreground"
+      }`}
+    >
+      {status.hasReplied ? (
+        <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      ) : (
+        <Clock className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      )}
+      <span className="font-medium">{status.participant.name}</span>
+      {showAnsweredCount && (
+        <span className="text-xs opacity-80">
+          {status.answeredCount}/{questionCount}
+        </span>
+      )}
+    </li>
+  )
+}
+
+export function LoopReplyTracker({ loop }: { loop: PublicLetter }) {
+  if (loop.status === "UPCOMING") {
+    return null
+  }
+
+  const statuses = getParticipantReplyStatuses(loop)
+  if (statuses.length === 0) {
+    return null
+  }
+
+  const replied = statuses.filter((status) => status.hasReplied)
+  const pending = statuses.filter((status) => !status.hasReplied)
+  const questionCount = loop.questions.length
+  const repliedRatio =
+    statuses.length > 0 ? replied.length / statuses.length : 0
+
+  return (
+    <div className="w-full rounded-xl border border-border/50 bg-background/80 p-6 shadow-md backdrop-blur-sm dark:border-border/30 dark:bg-background/60">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="text-lg font-semibold text-foreground">Replies</h3>
+        <p className="text-sm text-muted-foreground">
+          {replied.length} of {statuses.length} participant
+          {statuses.length !== 1 ? "s" : ""} replied
+        </p>
+      </div>
+
+      <div
+        className="mt-3 h-2 w-full overflow-hidden rounded-full bg-muted"
+        role="progressbar"
+        aria-label="Participants who replied"
+        aria-valuemin={0}
+        aria-valuemax={statuses.length}
+        aria-valuenow={replied.length}
+      >
+        <div
+          className="h-full rounded-full bg-green-600 transition-all duration-300 dark:bg-green-400"
+          style={{ width: `${Math.round(repliedRatio * 100)}%` }}
+        />
+      </div>
+
+      {replied.length > 0 && (
+        <div className="mt-4">
+          <p className="mb-2 text-sm font-medium text-muted-foreground">
+            Replied ({replied.length})
+          </p>
+          <ul className="flex flex-wrap gap-2">
+            {replied.map((status) => (
+              <ReplyStatusChip
+                key={status.participant.api_identifier}
+                status={status}
+                questionCount={questionCount}
+              />
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {pending.length > 0 && (
+        <div className="mt-4">
+          <p className="mb-2 text-sm font-medium text-muted-foreground">
+            {loop.status === "SENT" ? "Didn't reply" : "Waiting on"} (
+            {pending.length})
+          </p>
+          <ul className="flex flex-wrap gap-2">
+            {pending.map((status) => (
+              <ReplyStatusChip
+                key={status.participant.api_identifier}
+                status={status}
+                questionCount={questionCount}
+              />
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/react/src/routes/_layout/loops/$loopId.tsx
+++ b/react/src/routes/_layout/loops/$loopId.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../../client/@tanstack/react-query.gen"
 import DraftLoop from "../../../components/Loops/DraftLoop"
 import EditLetter from "../../../components/Loops/EditLoop"
+import { LoopReplyTracker } from "../../../components/Loops/LoopReplyTracker"
 import PublishedLoop from "../../../components/Loops/PublishedLoop"
 import AddQuestion from "../../../components/Question/AddQuestion"
 import GenerateQuestion from "../../../components/Question/GenerateQuestion"
@@ -51,6 +52,8 @@ function IssueContent() {
     readUserMePartiesMeGetQueryKey(),
   )
   const localDueDate = new Date(loop.send_at)
+  const isGroupAdmin =
+    group.admin.api_identifier === currentUser?.api_identifier
   const [editLoopOpen, setEditLoopOpen] = useState(false)
   const [addQuestionOpen, setAddQuestionOpen] = useState(false)
   const [generateQuestionOpen, setGenerateQuestionOpen] = useState(false)
@@ -71,15 +74,14 @@ function IssueContent() {
                     {group!.name}
                   </Link>
                 </h2>
-                {group.admin.api_identifier === currentUser?.api_identifier &&
-                  loop.status !== "SENT" && (
-                    <Button
-                      onClick={() => setEditLoopOpen(true)}
-                      className="absolute right-0 top-1/2 -translate-y-1/2"
-                    >
-                      Edit Loop
-                    </Button>
-                  )}
+                {isGroupAdmin && loop.status !== "SENT" && (
+                  <Button
+                    onClick={() => setEditLoopOpen(true)}
+                    className="absolute right-0 top-1/2 -translate-y-1/2"
+                  >
+                    Edit Loop
+                  </Button>
+                )}
               </div>
               {loop.title && (
                 <h2 className="text-lg font-semibold text-foreground sm:text-xl lg:text-2xl">
@@ -98,6 +100,8 @@ function IssueContent() {
               )}
             </div>
           </div>
+
+          {isGroupAdmin && <LoopReplyTracker loop={loop} />}
 
           {loop.status === "UPCOMING" && (
             <div className="flex w-full flex-wrap gap-4">
@@ -120,12 +124,7 @@ function IssueContent() {
             {loop.status === "SENT" ? (
               <PublishedLoop loop={loop} />
             ) : (
-              <DraftLoop
-                loop={loop}
-                isGroupAdmin={
-                  group.admin.api_identifier === currentUser?.api_identifier
-                }
-              />
+              <DraftLoop loop={loop} isGroupAdmin={isGroupAdmin} />
             )}
           </div>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Group admins now have an easy way to see who has already replied to an issue and who hasn't. A new **Replies** panel appears on the loop page (between the header and the questions), visible only to the group admin:

- Summary line ("3 of 5 participants replied") with a green progress bar
- **Replied** section: green chips per participant with a check icon and an answered-question count (e.g. "Alice Chen 2/7"; native tooltip spells it out)
- **Waiting on** section (labeled **Didn't reply** once the issue is published): gray chips with a clock icon
- Hidden for `UPCOMING` loops (responses aren't open yet) and for non-admin members

No backend changes: the panel is computed entirely from data already returned in `PublicLetter` (`participants`, `responders`, and per-question responses). Participants who replied but were later removed from the roster are still counted, keeping the numbers consistent with the existing `responder_count` shown on loop cards.

## Changes

- `react/src/components/Loops/LoopReplyTracker.tsx` — new component + `getParticipantReplyStatuses` helper
- `react/src/routes/_layout/loops/$loopId.tsx` — render the tracker for group admins; consolidate the repeated admin check into one `isGroupAdmin` variable

## Testing

- `pnpm run lint`, `npx tsc --noEmit`, `pnpm run build` all pass
- Manual browser test on the cloud VM with a 5-member group and partial responses:
  - Admin sees correct counts/chips on an in-progress loop ("Waiting on") and a published loop ("Didn't reply")
  - Page refresh reflects a newly submitted reply (participant moves to Replied)
  - Non-admin member sees no panel

![Admin view of in-progress loop with reply tracker](https://cursor.com/artifacts/c/art-2b4b67be-192a-4bcb-a053-08d83aa90ea0)

![Admin view of published loop with reply tracker](https://cursor.com/artifacts/c/art-a3d747cf-c467-472f-8600-a1f5de05cde6)

<a href="https://cursor.com/agents/bc-c2f368b7-d6b2-47ae-8f55-a74cc984b858/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Floop_reply_tracker_admin_and_member_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-8bc20468-beaa-43af-b71e-8e4ac17ec39e" alt="loop_reply_tracker_admin_and_member_walkthrough.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2f368b7-d6b2-47ae-8f55-a74cc984b858?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2f368b7-d6b2-47ae-8f55-a74cc984b858&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

